### PR TITLE
Tidy up the Circle build/test scripts

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -20,14 +20,14 @@ dependencies:
     - "project/target/streams"
   # Compile all sources
   override:
-    - ./circle/deps.sh
+    - ./run_circle.sh compile
 
 test:
   override:
-    - ./circle/test.sh
+    - ./run_circle.sh test
 
 deployment:
   production:
     branch: master
     commands:
-      - ./circle/deploy.sh
+      - ./run_circle.sh deploy

--- a/circle/deploy.sh
+++ b/circle/deploy.sh
@@ -1,9 +1,0 @@
-#!/bin/bash
-
-set -x
-set -o errexit
-
-for project in api
-do
-    sbt "project $project" -DconfigBucket=$CONFIG_BUCKET -Denv=$BUILD_ENV ecr:push
-done

--- a/circle/deps.sh
+++ b/circle/deps.sh
@@ -1,9 +1,0 @@
-#!/bin/bash
-
-set -x
-set -o errexit
-
-for project in common api
-do
-    sbt "project $project" compile
-done

--- a/circle/test.sh
+++ b/circle/test.sh
@@ -1,9 +1,0 @@
-#!/bin/bash
-
-set -x
-set -o errexit
-
-for project in common api
-do
-    sbt "project $project" test
-done

--- a/run_circle.sh
+++ b/run_circle.sh
@@ -17,9 +17,9 @@ set -o errexit
 set -o nounset
 
 
-
 # Read command-line arguments
-if (( $# == 1 )); then
+if (( $# == 1 ))
+then
     TASK="$1"
 else
     echo "Usage: run_circle.sh <TASK>"
@@ -27,17 +27,63 @@ else
 fi
 
 
-if [[ "$TASK" == "compile" || "$TASK" == "test" ]]; then
-    for project in $PROJECTS; do
-        sbt "project $project" "$TASK"
-    done
-elif [[ "$TASK" == "deploy" ]]; then
-    for project in $PROJECTS; do
-        # There isn't a deploy step for the common lib
-        if [[ "$project" == "common" ]]; then continue; fi
-        sbt "project $project" -DconfigBucket=$CONFIG_BUCKET -Denv=$BUILD_ENV ecr:push
-    done
-else
-    echo "Unrecognised task '$TASK'"
-    exit 1
+# Check if we want to build this project, based on the files that have
+# changed between this branch and the current master
+
+# Get the name of the currently checked-out branch
+current_branch=$(git rev-parse --abbrev-ref HEAD)
+
+if [[ $current_branch != "master" ]]
+then
+    git fetch origin
+
+    # Get a list of files that changed between master and the current branch
+    # TODO: Err, does this handle added files?
+    changed_files=$(git diff --name-only master "$current_branch")
 fi
+
+
+for project in $PROJECTS
+do
+    # Always build everything on master
+    if [[ $current_branch == "master" ]]
+    then
+        run_task=true
+    else
+        # Build everything if common-lib has changed, otherwise only build
+        # projects with changed files.
+        run_task=false
+        for file in $changed_files
+        do
+            # TODO: What's the name for the common-lib directory?
+            if [[ "$file" == "common-lib/"* ]] || [[ "$file" == "$project"/* ]]
+            then
+                run_task=true
+                break
+            fi
+        done
+    fi
+
+    if [[ "$run_task" != "true" ]]
+    then
+        continue
+    fi
+
+    # At this point we know we want to run this project: run the task!
+    if [[ "$TASK" == "compile" || "$TASK" == "test" ]]
+    then
+        sbt "project $project" "$TASK"
+    elif [[ "$TASK" == "deploy" ]]
+    then
+        # There isn't a deploy step for the common lib
+        if [[ "$project" == "common" ]]
+        then
+            continue
+        fi
+        sbt "project $project" -DconfigBucket=$CONFIG_BUCKET -Denv=$BUILD_ENV ecr:push
+    else
+        echo "Unrecognised task '$TASK'"
+        exit 1
+    fi
+
+done

--- a/run_circle.sh
+++ b/run_circle.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+# This script runs our build process for Circle.  This is made somewhat
+# complicated because we have a multi-project setup.
+#
+# The script is invoked with a single command-line argument: one of
+# 'compile', 'test', or 'deploy', which runs the corresponding task for
+# each of the projects in the repo.
+
+
+# List of projects that sbt knows how to build
+PROJECTS="common api"
+
+
+# Some bash debugging options: tracing, and exit as soon as a build step fails
+set -x
+set -o errexit
+set -o nounset
+
+
+
+# Read command-line arguments
+if (( $# == 1 )); then
+    TASK="$1"
+else
+    echo "Usage: run_circle.sh <TASK>"
+    exit 1
+fi
+
+
+if [[ "$TASK" == "compile" || "$TASK" == "test" ]]; then
+    for project in $PROJECTS; do
+        sbt "project $project" "$TASK"
+    done
+elif [[ "$TASK" == "deploy" ]]; then
+    for project in $PROJECTS; do
+        # There isn't a deploy step for the common lib
+        if [[ "$project" == "common" ]]; then continue; fi
+        sbt "project $project" -DconfigBucket=$CONFIG_BUCKET -Denv=$BUILD_ENV ecr:push
+    done
+else
+    echo "Unrecognised task '$TASK'"
+    exit 1
+fi


### PR DESCRIPTION
Changes:

* Consolidate the Circle scripts into a single file that takes an argument “compile”, “test” or “deploy”.
* Only build projects based on whether their files have changed in the current branch.

I’ll want to squash the Git bits before we merge, because I think there’s a non-trivial chance we’ll want to revert to the “just build everything” behaviour later.

Resolves #63.