### PR TITLE
Move out some Elasticsearch-based code into a common lib

### DIFF
--- a/api/src/main/scala/uk/ac/wellcome/platformapi/Server.scala
+++ b/api/src/main/scala/uk/ac/wellcome/platformapi/Server.scala
@@ -5,9 +5,9 @@ import com.twitter.finatra.http.HttpServer
 import com.twitter.finatra.http.filters.{CommonFilters, LoggingMDCFilter, TraceIdMDCFilter}
 import com.twitter.finatra.http.routing.HttpRouter
 
+import uk.ac.wellcome.finatra.exceptions._
+import uk.ac.wellcome.finatra.modules._
 import uk.ac.wellcome.platform.api.controllers._
-import uk.ac.wellcome.platform.api.modules._
-import uk.ac.wellcome.platform.api.exceptions._
 
 object ServerMain extends Server
 

--- a/api/src/main/scala/uk/ac/wellcome/platformapi/controllers/ManagementController.scala
+++ b/api/src/main/scala/uk/ac/wellcome/platformapi/controllers/ManagementController.scala
@@ -2,7 +2,8 @@ package uk.ac.wellcome.platform.api.controllers
 
 import com.twitter.finagle.http.Request
 import com.twitter.finatra.http.Controller
-import uk.ac.wellcome.platform.api.services._
+
+import uk.ac.wellcome.finatra.services.ElasticsearchService
 
 import javax.inject.{Inject, Singleton}
 import com.sksamuel.elastic4s.ElasticDsl._

--- a/api/src/main/scala/uk/ac/wellcome/platformapi/services/CalmService.scala
+++ b/api/src/main/scala/uk/ac/wellcome/platformapi/services/CalmService.scala
@@ -6,6 +6,7 @@ import com.sksamuel.elastic4s.ElasticDsl._
 import scala.concurrent.Future
 import scala.concurrent.ExecutionContext.Implicits.global
 
+import uk.ac.wellcome.finatra.services.ElasticsearchService
 import uk.ac.wellcome.platform.api.models._
 
 

--- a/build.sbt
+++ b/build.sbt
@@ -7,7 +7,10 @@ import com.typesafe.sbt.packager.linux.LinuxPlugin
 lazy val common = (project in file("common-lib")).
   settings(SbtGit.useJGit).
   settings(Common.settings: _*).
-  settings(GitVersioning.buildSettings: _*)
+  settings(Search.settings: _*).
+  settings(Finatra.settings: _*).
+  settings(GitVersioning.buildSettings: _*).
+  settings(libraryDependencies ++= Dependencies.commonDependencies)
 
 lazy val api = (project in file("api")).
   dependsOn(common).

--- a/common-lib/src/main/scala/uk/ac/wellcome/finatra/exceptions/ElasticsearchExceptionMapper.scala
+++ b/common-lib/src/main/scala/uk/ac/wellcome/finatra/exceptions/ElasticsearchExceptionMapper.scala
@@ -1,4 +1,4 @@
-package uk.ac.wellcome.platform.api.exceptions
+package uk.ac.wellcome.finatra.exceptions
 
 import org.elasticsearch.ElasticsearchException
 import com.twitter.finagle.http.{Request, Response}

--- a/common-lib/src/main/scala/uk/ac/wellcome/finatra/modules/ElasticClientModule.scala
+++ b/common-lib/src/main/scala/uk/ac/wellcome/finatra/modules/ElasticClientModule.scala
@@ -1,4 +1,4 @@
-package uk.ac.wellcome.platform.api.modules
+package uk.ac.wellcome.finatra.modules
 
 import javax.inject.Singleton
 

--- a/common-lib/src/main/scala/uk/ac/wellcome/finatra/services/ElasticsearchService.scala
+++ b/common-lib/src/main/scala/uk/ac/wellcome/finatra/services/ElasticsearchService.scala
@@ -1,8 +1,9 @@
-package uk.ac.wellcome.platform.api.services
+package uk.ac.wellcome.finatra.services
 
 import javax.inject.{Inject, Singleton}
-import uk.ac.wellcome.platform.api.modules.ElasticClientModule
 import com.sksamuel.elastic4s.ElasticClient
+
+import uk.ac.wellcome.finatra.modules.ElasticClientModule
 
 
 @Singleton

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -13,6 +13,11 @@ object Dependencies {
     val elastic4s = "5.1.5"
   }
 
+  val esDependencies: Seq[ModuleID] = Seq(
+    "com.sksamuel.elastic4s" %% "elastic4s-core" % versions.elastic4s,
+    "com.sksamuel.elastic4s" %% "elastic4s-xpack-security" % versions.elastic4s
+  )
+
   val commonDependencies: Seq[ModuleID] = Seq(
     "com.twitter" %% "finatra-http" % versions.finatra,
     "com.twitter" %% "finatra-httpclient" % versions.finatra,
@@ -36,13 +41,8 @@ object Dependencies {
     "org.mockito" % "mockito-core" % versions.mockito % "test",
     "org.scalatest" %% "scalatest" % versions.scalatest % "test",
     "com.novocode" % "junit-interface" % versions.junitInterface % "test"
-  )
+  ) ++ esDependencies
 
-  val esDependencies: Seq[ModuleID] = Seq(
-    "com.sksamuel.elastic4s" %% "elastic4s-core" % versions.elastic4s,
-    "com.sksamuel.elastic4s" %% "elastic4s-xpack-security" % versions.elastic4s
-  )
-
-  val apiDependencies: Seq[ModuleID] = commonDependencies ++ esDependencies
+  val apiDependencies: Seq[ModuleID] = commonDependencies
 
 }


### PR DESCRIPTION
This is the first half of our work from yesterday, to start building a common library. I’ve tidied it up and squashed into a single commit, so we can merge.

Once this is merged, we’ll need to rebase the transformer code, and I need to tidy that up and remove all the unused imports.