### PR TITLE
Add a shutdown procedure for the Calm adapter

### DIFF
--- a/calm_adapter/src/main/scala/uk/ac/wellcome/calm_adapter/Server.scala
+++ b/calm_adapter/src/main/scala/uk/ac/wellcome/calm_adapter/Server.scala
@@ -28,14 +28,4 @@ class Server extends HttpServer {
       .filter[TraceIdMDCFilter[Request, Response]]
       .add[ManagementController]
   }
-
-  def shutdown(): Unit = {
-    super.close()
-
-    // We wait a few seconds before calling System.exit(), o/w the shutdown
-    // hooks don't run properly.  In particular, this means DynamoWarmupModule
-    // doesn't have time to reset our write capacity.
-    val timer = new Timer()
-    timer.schedule(new TimerTask() { def run = System.exit(0) }, 5000L)
-  }
 }

--- a/calm_adapter/src/main/scala/uk/ac/wellcome/calm_adapter/Server.scala
+++ b/calm_adapter/src/main/scala/uk/ac/wellcome/calm_adapter/Server.scala
@@ -1,5 +1,7 @@
 package uk.ac.wellcome.platform.calm_adapter
 
+import java.util.{Timer, TimerTask}
+
 import com.twitter.finagle.http.{Request, Response}
 import com.twitter.finatra.http.HttpServer
 import com.twitter.finatra.http.filters.{
@@ -25,5 +27,15 @@ class Server extends HttpServer {
       .filter[LoggingMDCFilter[Request, Response]]
       .filter[TraceIdMDCFilter[Request, Response]]
       .add[ManagementController]
+  }
+
+  def shutdown(): Unit = {
+    super.close()
+
+    // We wait a few seconds before calling System.exit(), o/w the shutdown
+    // hooks don't run properly.  In particular, this means DynamoWarmupModule
+    // doesn't have time to reset our write capacity.
+    val timer = new Timer()
+    timer.schedule(new TimerTask() { def run = System.exit(0) }, 5000L)
   }
 }

--- a/calm_adapter/src/main/scala/uk/ac/wellcome/calm_adapter/actors/DynamoRecordWriterActor.scala
+++ b/calm_adapter/src/main/scala/uk/ac/wellcome/calm_adapter/actors/DynamoRecordWriterActor.scala
@@ -58,6 +58,6 @@ class DynamoRecordWriterActor @Inject()(
 
   override def postStop(): Unit = {
     info("Dynamo actor finished, shutting down")
-    ServerMain.shutdown()
+    ServerMain.close()
   }
 }

--- a/calm_adapter/src/main/scala/uk/ac/wellcome/calm_adapter/actors/OaiParserActor.scala
+++ b/calm_adapter/src/main/scala/uk/ac/wellcome/calm_adapter/actors/OaiParserActor.scala
@@ -2,7 +2,7 @@ package uk.ac.wellcome.platform.calm_adapter.actors
 
 import javax.inject.Inject
 
-import akka.actor.Actor
+import akka.actor.{Actor, PoisonPill}
 import com.google.inject.name.Named
 import com.twitter.inject.Logging
 
@@ -19,6 +19,16 @@ import uk.ac.wellcome.platform.calm_adapter.services._
 // The OAI intersperses unescaped HTML with the XML, so we can't use
 // an XML parser.  Instead this class is implemented as a combination
 // of regexes and stream parsers.
+
+/**
+ * Tells the dynamoRecordWriterActor that the oaiParserActor is done.
+ *
+ * We don't send an Akka PoisonPill because that immediately drops any
+ * messages that arrive after it on the queue.  This is just a signal not
+ * to expect anything else to arrive.
+ */
+case class PoisonPillWrapper()
+
 
 @Named("OaiParserActor")
 class OaiParserActor @Inject()(
@@ -38,5 +48,9 @@ class OaiParserActor @Inject()(
       parseRecords(response)
     }
     case unknown => error(s"Received unknown OAI response ${unknown}")
+  }
+
+  override def postStop(): Unit = {
+    actorRegister.send("dynamoRecordWriterActor", PoisonPillWrapper())
   }
 }

--- a/calm_adapter/src/main/scala/uk/ac/wellcome/calm_adapter/modules/DynamoWarmupModule.scala
+++ b/calm_adapter/src/main/scala/uk/ac/wellcome/calm_adapter/modules/DynamoWarmupModule.scala
@@ -23,6 +23,11 @@ object DynamoWarmupModule extends TwitterModule {
   ) =
     try {
 
+      if (dynamoConfig.table == "") {
+        error("DynamoDB table name must not be empty")
+        System.exit(1)
+      }
+
       (new DynamoUpdateWriteCapacityCapable {
         val client = dynamoClient
       }).updateWriteCapacity(dynamoConfig.table, capacity)

--- a/common/src/main/scala/uk/ac/wellcome/finatra/modules/SNSClientModule.scala
+++ b/common/src/main/scala/uk/ac/wellcome/finatra/modules/SNSClientModule.scala
@@ -1,0 +1,24 @@
+package uk.ac.wellcome.platform.finatra.modules
+
+import javax.inject.Singleton
+
+import com.google.inject.Provides
+import com.twitter.inject.TwitterModule
+
+import com.amazonaws.services.sns._
+
+/** Sent to request a change in the desired count of an ECS service. */
+case class ECSServiceScheduleRequest(
+  cluster: String, service: String, desired_count: Long)
+
+object SNSClientModule extends TwitterModule {
+  override val modules = Seq(SNSConfigModule)
+
+  @Singleton
+  @Provides
+  def providesSNSClient(snsConfig: SNSConfig): AmazonSNS =
+    AmazonSNSClientBuilder
+      .standard()
+      .withRegion(snsConfig.region)
+      .build()
+}

--- a/common/src/main/scala/uk/ac/wellcome/finatra/modules/SNSConfigModule.scala
+++ b/common/src/main/scala/uk/ac/wellcome/finatra/modules/SNSConfigModule.scala
@@ -1,0 +1,18 @@
+package uk.ac.wellcome.platform.finatra.modules
+
+import javax.inject.Singleton
+
+import com.google.inject.Provides
+import com.twitter.inject.TwitterModule
+
+
+case class SNSConfig(region: String, topicArn: String)
+
+object SNSConfigModule extends TwitterModule {
+  private val region = flag[String]("aws.region", "eu-west-1", "AWS region")
+  private val topicArn = flag[String]("aws.sns.topic.arn", "", "ARN of the SNS topic")
+
+  @Singleton
+  @Provides
+  def providesSNSConfig(): SNSConfig = SNSConfig(region(), topicArn())
+}


### PR DESCRIPTION
* When the OAI harvest actor gets its final response, it tears down itself and sends a teardown message to the OAI parser actor.
* When the OAI parser actor gets the teardown message, it tears down itself and sends a teardown message to the Dynamo actor.
* When the Dynamo actor gets the teardown message, it waits 60 seconds for any outstanding tasks to finish, then tears down the entire application.

I’ve tested with locally, with a small subset of OAI records – this does cause the warmup actor to clamp down the capacity.