### PR TITLE
Add service prefix to transformer

### DIFF
--- a/transformer/src/main/scala/uk/ac/wellcome/transformer/Server.scala
+++ b/transformer/src/main/scala/uk/ac/wellcome/transformer/Server.scala
@@ -18,6 +18,10 @@ class Server extends HttpServer {
   override val name = "uk.ac.wellcome.platform.transformer Transformer"
   override val modules = Seq(KinesisWorker)
 
+  private final val servicePrefix = flag(name = "service.prefix",
+                                         default = "/transformer",
+                                         help = "API path prefix")
+
   override def configureHttp(router: HttpRouter) {
     router
       .filter[CommonFilters]

--- a/transformer/src/main/scala/uk/ac/wellcome/transformer/controllers/ManagementController.scala
+++ b/transformer/src/main/scala/uk/ac/wellcome/transformer/controllers/ManagementController.scala
@@ -7,9 +7,16 @@ import scala.concurrent.ExecutionContext.Implicits.global
 import com.twitter.finagle.http.Request
 import com.twitter.finatra.http.Controller
 
+import com.twitter.inject.annotations.Flag
+
 @Singleton
-class ManagementController @Inject()() extends Controller {
-  get("/management/healthcheck") { request: Request =>
-    response.ok.json(Map("message" -> "ok"))
+class ManagementController @Inject()(
+  @Flag("service.prefix") servicePrefix: String
+) extends Controller {
+
+  prefix(servicePrefix) {
+    get("/management/healthcheck") { request: Request =>
+      response.ok.json(Map("message" -> "ok"))
+    }
   }
 }


### PR DESCRIPTION
In order to route HTTP requests to this service correctly via an ALB this app needs to receive requests directed to `/transformer`