### PR TITLE
Add incremental updates to the Calm ~> DynamoDB adapter

### DIFF
--- a/calm_adapter/src/main/scala/uk/ac/wellcome/calm_adapter/models/OaiHarvestConfig.scala
+++ b/calm_adapter/src/main/scala/uk/ac/wellcome/calm_adapter/models/OaiHarvestConfig.scala
@@ -1,0 +1,3 @@
+package uk.ac.wellcome.platform.calm_adapter.models
+
+case class OaiHarvestConfig(oaiUrl: String, oaiDaysToFetch: Long)

--- a/calm_adapter/src/main/scala/uk/ac/wellcome/calm_adapter/modules/DynamoWarmupModule.scala
+++ b/calm_adapter/src/main/scala/uk/ac/wellcome/calm_adapter/modules/DynamoWarmupModule.scala
@@ -12,7 +12,7 @@ object DynamoWarmupModule extends TwitterModule {
   val writeCapacity =
     flag(
       name = "writeCapacity",
-      default = 600L,
+      default = 5L,
       help = "Dynamo write capacity"
     )
 

--- a/calm_adapter/src/main/scala/uk/ac/wellcome/calm_adapter/modules/OaiHarvestConfigModule.scala
+++ b/calm_adapter/src/main/scala/uk/ac/wellcome/calm_adapter/modules/OaiHarvestConfigModule.scala
@@ -5,7 +5,7 @@ import javax.inject.Singleton
 import com.google.inject.Provides
 import com.twitter.inject.TwitterModule
 
-case class OaiHarvestConfig(oaiUrl: String)
+case class OaiHarvestConfig(oaiUrl: String, oaiDaysToFetch: Long)
 
 object OaiHarvestConfigModule extends TwitterModule {
 
@@ -15,8 +15,15 @@ object OaiHarvestConfigModule extends TwitterModule {
     help = "Base URL for OAI request"
   )
 
+  private val oaiDaysToFetch = flag(
+    name = "oaiDaysToFetch",
+    default = 3L,
+    help = "How many days of records to fetch from the OAI"
+  )
+
   @Singleton
   @Provides
-  def providesOaiHarvestConfig(): OaiHarvestConfig = OaiHarvestConfig(oaiUrl())
+  def providesOaiHarvestConfig(): OaiHarvestConfig = OaiHarvestConfig(
+    oaiUrl(), oaiDaysToFetch())
 
 }

--- a/calm_adapter/src/main/scala/uk/ac/wellcome/calm_adapter/modules/OaiHarvestConfigModule.scala
+++ b/calm_adapter/src/main/scala/uk/ac/wellcome/calm_adapter/modules/OaiHarvestConfigModule.scala
@@ -5,7 +5,7 @@ import javax.inject.Singleton
 import com.google.inject.Provides
 import com.twitter.inject.TwitterModule
 
-case class OaiHarvestConfig(oaiUrl: String, oaiDaysToFetch: Long)
+import uk.ac.wellcome.platform.calm_adapter.models.OaiHarvestConfig
 
 object OaiHarvestConfigModule extends TwitterModule {
 

--- a/calm_adapter/src/main/scala/uk/ac/wellcome/calm_adapter/modules/OaiHarvestConfigModule.scala
+++ b/calm_adapter/src/main/scala/uk/ac/wellcome/calm_adapter/modules/OaiHarvestConfigModule.scala
@@ -18,7 +18,8 @@ object OaiHarvestConfigModule extends TwitterModule {
   private val oaiDaysToFetch = flag(
     name = "oaiDaysToFetch",
     default = 3L,
-    help = "How many days of records to fetch from the OAI"
+    help = ("How many days of records to fetch from the OAI. " ++
+            "Set to -1 to fetch all records.")
   )
 
   @Singleton

--- a/calm_adapter/src/main/scala/uk/ac/wellcome/calm_adapter/services/OaiParserService.scala
+++ b/calm_adapter/src/main/scala/uk/ac/wellcome/calm_adapter/services/OaiParserService.scala
@@ -87,7 +87,14 @@ class OaiParserService @Inject()(
     val formatter = DateTimeFormatter.ofPattern("dd/MM/yyyy")
 
     val today = LocalDate.now()
-    val afterDate = today.minusDays(oaiHarvestConfig.oaiDaysToFetch)
+    val afterDate = if (oaiHarvestConfig.oaiDaysToFetch == -1) {
+      LocalDate.MIN
+    } else {
+      today.minusDays(oaiHarvestConfig.oaiDaysToFetch)
+    }
+    if (afterDate != LocalDate.MIN) {
+      info(s"Only fetching records from after ${afterDate}")
+    }
 
     data
       .split("</record>")


### PR DESCRIPTION
This patch adds a new config flag `oaiDaysToFetch` (default&nbsp;3). Any records that occur more than $DAYS ago are discarded by the parser as uninteresting. To disable this behaviour and retrieve the entire set, set the parameter to –1.

This isn’t entirely ideal – we still grab the entire set from the OAI – but when fiddling with the `from` URL query parameters, I wasn’t able to get the data set I wanted, so doing the logic on our side is probably better for understanding and maintainability.

Additionally, the Dynamo warm-up limit now defaults to a safe number, so you can’t inadvertently create an expensive table while testing.

Resolves #92.