### PR TITLE
Adds an Identifiable trait to generate IDs

### DIFF
--- a/common/src/main/scala/uk/ac/wellcome/utils/IdentifierGenerator.scala
+++ b/common/src/main/scala/uk/ac/wellcome/utils/IdentifierGenerator.scala
@@ -1,0 +1,15 @@
+package uk.ac.wellcome.utils
+
+import scala.util.Random
+
+trait Identifiable {
+  val identifierLength = 8
+  val forbiddenLetters = List('o', 'i', 'l', '1')
+  val letterRange = ('1' to '9') ++ ('a' to 'z')
+  val letterSet = letterRange.filterNot(forbiddenLetters.contains)
+
+  def generate =
+    (1 to identifierLength)
+      .map(_ => letterSet(Random.nextInt(letterSet.length)))
+      .mkString
+}


### PR DESCRIPTION
Note: This does not generate unique IDs! The result of generating an ID
will need to be checked against existing IDs. This change simply
implements the ID generation rules:

- 8 characters
- Composed of digits and the Roman alphabet
- Case-insensitive
- No check digit
- No ambiguous characters

Some example IDs generated by this algorithm:

```
eppptsp9
xekcz4rb
svub7yhy
ybyj9p54
mthth6c2
9zz293n3
```

This gives us an ID space of around 850 billion (31^8) items ... do we think that's enough?

Resolves: https://github.com/wellcometrust/platform-api/issues/31