### PR TITLE
Added list of identifiers to UnifiedItem

### DIFF
--- a/api/src/main/scala/uk/ac/wellcome/platform/api/models/Record.scala
+++ b/api/src/main/scala/uk/ac/wellcome/platform/api/models/Record.scala
@@ -5,11 +5,7 @@ import com.sksamuel.elastic4s.searches.RichSearchHit
 
 case class Record(
   @JsonProperty("type") ontologyType: String = "Work",
-  id: String,
-  title: String
-//  materialType: String,
-//  date: Option[String],
-//  acquisition: Option[String]
+  id: String
 )
 case object Record {
   def apply(hit: RichSearchHit): Record = {
@@ -17,11 +13,7 @@ case object Record {
       hit.sourceAsMap.filter(o => o._2 != null)
 
     Record(
-      id = data("AltRefNo").toString,
-      title = data("Title").toString
-//      materialType=data("Material").toString,
-//      date=data.get("Date").map(_.toString),
-//      acquisition=data.get("Acquisition").map(_.toString)
+      id = data("id").toString
     )
   }
 }

--- a/api/src/test/scala/uk/ac/wellcome/platform/api/services/CalmServiceTest.scala
+++ b/api/src/test/scala/uk/ac/wellcome/platform/api/services/CalmServiceTest.scala
@@ -1,0 +1,31 @@
+package uk.ac.wellcome.platform.api.services
+
+import com.sksamuel.elastic4s.ElasticDsl.indexInto
+import com.sksamuel.elastic4s.testkit.ElasticSugar
+import org.scalatest.{AsyncFunSpec, Matchers}
+import uk.ac.wellcome.finatra.services.ElasticsearchService
+import uk.ac.wellcome.models.{Identifier, UnifiedItem}
+import uk.ac.wellcome.platform.api.models.Record
+
+class CalmServiceTest extends AsyncFunSpec with ElasticSugar with Matchers{
+
+  val elasticSearchService = new ElasticsearchService(client)
+  val calmService = new CalmService(elasticSearchService)
+
+  it("should find records") {
+    ensureIndexExists("records")
+    insertIntoElasticSearch(UnifiedItem("id", List(Identifier("Calm", "AltRefNo", "calmid")), None))
+
+    val recordsFuture = calmService.findRecords()
+
+    recordsFuture map {records=>
+      records should have size 1
+      records.head shouldBe Record("Work", "id")
+    }
+  }
+
+  private def insertIntoElasticSearch(unifiedItem: UnifiedItem) = {
+    client.execute(indexInto("records" / "item").doc(UnifiedItem.json(unifiedItem)))
+    blockUntilCount(1,"records")
+  }
+}

--- a/common/src/main/scala/uk/ac/wellcome/models/CalmDynamoRecord.scala
+++ b/common/src/main/scala/uk/ac/wellcome/models/CalmDynamoRecord.scala
@@ -12,7 +12,8 @@ case class DirtyCalmRecord(
 ) extends Transformable {
   def transform: Try[UnifiedItem] = Try {
     UnifiedItem(
-      "Foo",
+      "id",
+      List(Identifier("source", "key", "value")),
       accessStatus = AccessStatus
     )
   }

--- a/common/src/main/scala/uk/ac/wellcome/models/UnifiedItem.scala
+++ b/common/src/main/scala/uk/ac/wellcome/models/UnifiedItem.scala
@@ -3,8 +3,11 @@ package uk.ac.wellcome.models
 import com.sksamuel.elastic4s._
 import uk.ac.wellcome.utils.JsonUtil
 
+case class Identifier(source: String, sourceId: String, value: String)
+
 case class UnifiedItem(
-  source: String,
+  id: String,
+  identifiers: List[Identifier],
   accessStatus: Option[String]
 )
 object UnifiedItem extends Indexable[UnifiedItem] {

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -35,6 +35,7 @@ object Dependencies {
 
   val esDependencies: Seq[ModuleID] = Seq(
     "com.sksamuel.elastic4s" %% "elastic4s-core" % versions.elastic4s,
+    "com.sksamuel.elastic4s" %% "elastic4s-testkit" % versions.elastic4s % "test",
     "com.sksamuel.elastic4s" %% "elastic4s-xpack-security" % versions.elastic4s
   )
 

--- a/transformer/src/main/scala/uk/ac/wellcome/transformer/actors/PublishableMessageRecordActor.scala
+++ b/transformer/src/main/scala/uk/ac/wellcome/transformer/actors/PublishableMessageRecordActor.scala
@@ -34,7 +34,7 @@ class PublishableMessageRecordActor @Inject()(
       JsonUtil.toJson(unifiedItem) match {
         case Success(stringifiedJson) => {
           val message = SNSMessage(
-            Some(unifiedItem.source),
+            Some("Foo"),
             stringifiedJson,
             snsConfig.topicArn,
             snsClient


### PR DESCRIPTION
Created first integration test for CalmService with embedded ElasticSearch. Removed source from UnifiedItem and added a list of Identifiers to it. Modified Record accordingly