### PR TITLE
Quickfix for Transformer in order to parse CALM data

### DIFF
--- a/common/src/main/scala/uk/ac/wellcome/models/CalmDynamoRecord.scala
+++ b/common/src/main/scala/uk/ac/wellcome/models/CalmDynamoRecord.scala
@@ -8,13 +8,13 @@ trait Transformable {
 }
 
 case class DirtyCalmRecord(
-  AccessStatus: Option[String]
+  AccessStatus: Array[String]
 ) extends Transformable {
   def transform: Try[UnifiedItem] = Try {
     UnifiedItem(
       "id",
       List(Identifier("source", "key", "value")),
-      accessStatus = AccessStatus
+      accessStatus = AccessStatus.headOption
     )
   }
 }


### PR DESCRIPTION
All calm records will deserialize as Arrays!

This is a temporary solution in order to demonstrate the pipeline so
folks can see it working.