### PR TITLE
Fix the downsizing of the Calm adapter

### DIFF
--- a/calm_adapter/src/main/scala/uk/ac/wellcome/calm_adapter/modules/CalmAdapterWorker.scala
+++ b/calm_adapter/src/main/scala/uk/ac/wellcome/calm_adapter/modules/CalmAdapterWorker.scala
@@ -76,8 +76,8 @@ object CalmAdapterWorker extends TwitterModule {
     val messageBody = JsonUtil
       .toJson(
         ECSServiceScheduleRequest(
-          "service_cluster",
-          "calm_adapter",
+          "services_cluster",
+          "calm-adapter",
           0
         )
       )


### PR DESCRIPTION
Right now it's running itself repeatedly, because the name of the service and cluster is wrong – when it posts a new service schedule, we can't act upon it, and it just runs again.

This fix means it should shut down properly at the end of a run.

Related to #146.