### PR TITLE
Fix an interpolated expression

### DIFF
--- a/common/src/main/scala/uk/ac/wellcome/finatra/modules/ElasticClientModule.scala
+++ b/common/src/main/scala/uk/ac/wellcome/finatra/modules/ElasticClientModule.scala
@@ -60,7 +60,7 @@ object ElasticClientModule extends TwitterModule {
         (defaults, config) =>
           defaults
             .put("xpack.security.transport.ssl.enabled", config.ssl)
-            .put("request.headers.X-Found-Cluster", s"${cluster.name}")
+            .put("request.headers.X-Found-Cluster", s"${clusterName}")
             .put("xpack.security.user", config.user))
       .build()
 

--- a/common/src/main/scala/uk/ac/wellcome/finatra/modules/ElasticClientModule.scala
+++ b/common/src/main/scala/uk/ac/wellcome/finatra/modules/ElasticClientModule.scala
@@ -60,7 +60,7 @@ object ElasticClientModule extends TwitterModule {
         (defaults, config) =>
           defaults
             .put("xpack.security.transport.ssl.enabled", config.ssl)
-            .put("request.headers.X-Found-Cluster", "${cluster.name}")
+            .put("request.headers.X-Found-Cluster", s"${cluster.name}")
             .put("xpack.security.user", config.user))
       .build()
 


### PR DESCRIPTION
I was seeing a build warning about this:

```
[common] [warn] /var/jenkins_home/workspace/common-compile@2/common/src/main/scala/uk/ac/wellcome/finatra/modules/ElasticClientModule.scala:63: possible missing interpolator: detected an interpolated expression
[common] [warn]             .put("request.headers.X-Found-Cluster", "${cluster.name}")
```