### PR TITLE
[WIP] Define CI configuration with a Jenkinsfile

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,0 +1,30 @@
+stage("Checkout") {
+  node {
+    git 'https://github.com/wellcometrust/platform-api'
+    stash name: 'sources', excludes: 'target'
+  }
+}
+
+node {
+  stage("Compile") {
+    def projects = ["common", "api", "calm_adapter", "transformer", "ingestor"]
+    def stepsForParallel = [:]
+
+    for (int i = 0; i < projects.size(); i++) {
+      def s = projects.get(i)
+      def compileStep = "${s}"
+      stepsForParallel[compileStep] = transformIntoCompileStep(s)
+    }
+
+    parallel stepsForParallel
+  }
+}
+
+def transformIntoCompileStep(String project) {
+  return {
+    node {
+      unstash 'sources'
+      sh "/usr/bin/sbt ${project}/compile"
+    }
+  }
+}


### PR DESCRIPTION
It seems like it’s possible to define Jenkins configuration in code, point your Jenkins instance at the repo, and it just automagically works out what jobs it should run. Seems like it might be worth trying.

@alicefuzier @kenoir Thoughts on doing it this way?

Current pipeline just has the compile steps in it:

![screen shot 2017-04-05 at 17 24 51](https://cloud.githubusercontent.com/assets/301220/24716430/ec6dec6c-1a26-11e7-915b-4c3058364656.png)