### PR TITLE
Info logs by default

### DIFF
--- a/api/src/main/resources/logback.xml
+++ b/api/src/main/resources/logback.xml
@@ -8,7 +8,7 @@
     </encoder>
   </appender>
 
-  <root level="debug">
+  <root level="info">
     <appender-ref ref="STDOUT" />
   </root>
 </configuration>

--- a/ingestor/src/main/resources/logback.xml
+++ b/ingestor/src/main/resources/logback.xml
@@ -8,7 +8,7 @@
     </encoder>
   </appender>
 
-  <root level="debug">
+  <root level="info">
     <appender-ref ref="STDOUT" />
   </root>
 </configuration>

--- a/transformer/src/main/resources/logback.xml
+++ b/transformer/src/main/resources/logback.xml
@@ -8,7 +8,7 @@
     </encoder>
   </appender>
 
-  <root level="debug">
+  <root level="info">
     <appender-ref ref="STDOUT" />
   </root>
 </configuration>


### PR DESCRIPTION
Debug logs in Cloudwatch are a pain to wade through and arguably add minimal to no value.

On the rare occasions they might be useful, we can turn them back on, but I think we should have a default policy of INFO logs and above.