### PR TITLE
Add a demo endpoint for UX prototyping

### DIFF
--- a/api/src/main/scala/uk/ac/wellcome/platform/api/controllers/MainController.scala
+++ b/api/src/main/scala/uk/ac/wellcome/platform/api/controllers/MainController.scala
@@ -40,6 +40,23 @@ class MainController @Inject()(
 
   prefix(apiPrefix) {
 
+    // This is a demo endpoint for the UX team to use when prototyping
+    // item pages.
+    // TODO: Remove this endpoint.
+    get(s"/demoItem") {
+      request: Request =>
+        response.ok.json(Map(
+          "@context" -> "http://id.wellcomecollection.org/",
+          "id" -> "cbsx6cvr",
+          "type" -> "item",
+          "title" -> "The natural history of monkeys",
+          "date" -> "1546-04-07",
+          "authors" -> Array("William Jardine"),
+          "description" -> "230 page, color plates : frontispiece (portrait), add. color t.page ; (8vo)",
+          "topics" -> Array("monkeys", "animals")
+        ))
+    }
+
     get(s"/record") { request: CalmRequest =>
       val recordCollectionPair = for {
         recordOption <- calmService.findRecordByAltRefNo(request.altRefNo)

--- a/api/src/main/scala/uk/ac/wellcome/platform/api/controllers/MainController.scala
+++ b/api/src/main/scala/uk/ac/wellcome/platform/api/controllers/MainController.scala
@@ -53,7 +53,8 @@ class MainController @Inject()(
           "date" -> "1546-04-07",
           "authors" -> Array("William Jardine"),
           "description" -> "230 page, color plates : frontispiece (portrait), add. color t.page ; (8vo)",
-          "topics" -> Array("monkeys", "animals")
+          "topics" -> Array("monkeys", "animals"),
+          "media" -> Array("http://wellcomelibrary.org/content/59301/60865")
         ))
     }
 


### PR DESCRIPTION
This adds a `/demoItem` endpoint to the API, so the UX team can get some sample data for prototyping item pages. Based on [a book about monkeys](http://wellcomelibrary.org/item/b22031261#?c=0&m=6&s=0&cv=0&z=-1.2598%2C-0.089%2C3.5196%2C1.7808) that’s currently on the Wellcome Library front page.

The fields are plucked out of the air; I’ll need to check in with Chris next week about the state of the data model so we can start to move towards something that will resemble the final item API.

I’m not sure I’ve got the JSON-LD completely right – I’m hoping the details don’t matter at this stage, at least not until Jonathan’s back from holiday.

Reviewers:

- @alicefuzier – from a code perspective
- @jamesgorrie – is this the sort of endpoint/data you need?
- @ChristopherHilton – is this data sensible?