### PR TITLE
Make demo item media URL https

### DIFF
--- a/api/src/main/scala/uk/ac/wellcome/platform/api/controllers/MainController.scala
+++ b/api/src/main/scala/uk/ac/wellcome/platform/api/controllers/MainController.scala
@@ -48,7 +48,7 @@ class MainController @Inject()(
           "authors" -> Array("William Jardine"),
           "description" -> "230 page, color plates : frontispiece (portrait), add. color t.page ; (8vo)",
           "topics" -> Array("monkeys", "animals"),
-          "media" -> Array("http://wellcomelibrary.org/content/59301/60865")
+          "media" -> Array("https://wellcomelibrary.org/content/59301/60865")
         ))
     }
 


### PR DESCRIPTION
## What is this PR trying to achieve?
Making the URL for the demo item media HTTPS so we can use it over HTTPs on the client.

## Who is this change for?
@alexwlchan @alicefuzier