### PR TITLE
Use custom docker image for fake-sns

### DIFF
--- a/common/src/test/scala/uk/ac/wellcome/test/utils/SNSLocal.scala
+++ b/common/src/test/scala/uk/ac/wellcome/test/utils/SNSLocal.scala
@@ -19,14 +19,12 @@ trait SNSLocal extends Suite with BeforeAndAfterEach {
 
   private val topicName = "es_ingest"
 
-  //we use this implementation of SNS running in a docker container https://github.com/elruwen/fake_sns
-  //Topic arns are always built in this way by this implementatiom
-  val ingestTopicArn = s"arn:aws:sns:us-east-1:123456789012:$topicName"
+  //we use this implementation of SNS running in a docker container https://github.com/elruwen/fake_sns/tree/feature-fixed-account-id
+  val ingestTopicArn = amazonSNS.createTopic(topicName).getTopicArn
 
   override def beforeEach(): Unit = {
     super.beforeEach()
-    new DefaultHttpClient().execute(new HttpDelete(localSNSEndpointUrl))
-    amazonSNS.createTopic(topicName)
+    new DefaultHttpClient().execute(new HttpDelete(s"$localSNSEndpointUrl/messages"))
   }
 
   def listMessagesReceivedFromSNS(): List[MessageInfo] = {

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,7 @@ dynamodb:
   ports:
     - "45678:8000"
 sns:
-  image: ruwen/fake_sns
+  image: alicefuzier/fake-sns
   ports:
     - "9292:9292"
 sqs:


### PR DESCRIPTION
The docker image we are currently using for SNS integration tests is built on debian and it's quite slow. I've pushed another one built on alpine to docker hub so let's use that one