### PR TITLE
log entrypoint for SQSReader as debug

### DIFF
--- a/common/src/main/scala/uk/ac/wellcome/sqs/SQSReader.scala
+++ b/common/src/main/scala/uk/ac/wellcome/sqs/SQSReader.scala
@@ -14,10 +14,10 @@ class SQSReader @Inject()(sqsClient: AmazonSQS, sqsConfig: SQSConfig)
     extends Logging {
 
   def retrieveMessages(): Future[List[Message]] = Future {
-    info(s"Looking for new messages at ${sqsConfig.queueUrl}")
+    debug(s"Looking for new messages at ${sqsConfig.queueUrl}")
     receiveMessages()
   } map { messages =>
-    info(s"Received messages $messages")
+    info(s"Received messages $messages from queue ${sqsConfig.queueUrl}")
     messages
   } recover {
     case exception: Throwable =>


### PR DESCRIPTION
## What is this PR trying to achieve?
Logging in id_minter is very spammy as it checks for log every 100 milliseconds. Since we added extra logging when we receive or fail to read messages, the logging at the beginning is redundant

## Who is this change for?
For us to be able to read logs more easily

