### PR TITLE
Add logging in case the wrapping future fails

### DIFF
--- a/id_minter/src/main/scala/uk/ac/wellcome/platform/idminter/steps/IdentifierGenerator.scala
+++ b/id_minter/src/main/scala/uk/ac/wellcome/platform/idminter/steps/IdentifierGenerator.scala
@@ -25,6 +25,10 @@ class IdentifierGenerator @Inject()(dynamoDBClient: AmazonDynamoDB,
       case None =>
         logAndThrowError(s"Item $unifiedItem did not contain a MiroID")
     }
+  } recover {
+    case e: Throwable =>
+      error(s"Failed generating id for $unifiedItem", e)
+      throw e
   }
 
   private def retrieveOrGenerateCanonicalId(identifier: SourceIdentifier) = {


### PR DESCRIPTION
Wrapping future fails when id_minter doesn't have permissions to access the dynamo db, but the information is lost because we don't log
