### PR TITLE
Future refactoring

### DIFF
--- a/common/src/main/scala/uk/ac/wellcome/sns/SNSWriter.scala
+++ b/common/src/main/scala/uk/ac/wellcome/sns/SNSWriter.scala
@@ -6,6 +6,8 @@ import com.google.inject.Inject
 import com.twitter.inject.Logging
 import uk.ac.wellcome.models.aws.SNSConfig
 import uk.ac.wellcome.utils.GlobalExecutionContext.context
+import scala.concurrent.blocking
+
 
 import scala.concurrent.Future
 
@@ -18,11 +20,11 @@ class SNSWriter @Inject()(snsClient: AmazonSNS, snsConfig: SNSConfig)
   def writeMessage(message: String,
                    subject: Option[String]): Future[PublishAttempt] =
     Future {
-
-      info(
-        s"about to publish message $message on the SNS topic ${snsConfig.topicArn}")
-      snsClient.publish(toPublishRequest(message, subject))
-
+      blocking {
+        info(
+          s"about to publish message $message on the SNS topic ${snsConfig.topicArn}")
+        snsClient.publish(toPublishRequest(message, subject))
+      }
     }.map { publishResult =>
         info(s"Published message ${publishResult.getMessageId}")
         PublishAttempt(publishResult.getMessageId)

--- a/common/src/main/scala/uk/ac/wellcome/sqs/SQSReader.scala
+++ b/common/src/main/scala/uk/ac/wellcome/sqs/SQSReader.scala
@@ -6,6 +6,7 @@ import com.google.inject.Inject
 import com.twitter.inject.Logging
 import uk.ac.wellcome.models.aws.SQSConfig
 import uk.ac.wellcome.utils.GlobalExecutionContext.context
+import scala.concurrent.blocking
 
 import scala.collection.JavaConversions._
 import scala.concurrent.Future
@@ -15,8 +16,10 @@ class SQSReader @Inject()(sqsClient: AmazonSQS, sqsConfig: SQSConfig)
 
   def retrieveMessages(): Future[List[Message]] =
     Future {
-      debug(s"Looking for new messages at ${sqsConfig.queueUrl}")
-      receiveMessages()
+      blocking {
+        debug(s"Looking for new messages at ${sqsConfig.queueUrl}")
+        receiveMessages()
+      }
     } map { messages =>
       info(s"Received messages $messages from queue ${sqsConfig.queueUrl}")
       messages

--- a/id_minter/src/main/scala/uk/ac/wellcome/platform/idminter/steps/IdentifierGenerator.scala
+++ b/id_minter/src/main/scala/uk/ac/wellcome/platform/idminter/steps/IdentifierGenerator.scala
@@ -51,8 +51,8 @@ class IdentifierGenerator @Inject()(dynamoDBClient: AmazonDynamoDB,
   }
 
   private def findMiroIdInDynamo(miroId: String) = Future {
-    info(s"About to search for MiroID $miroId in $identifiersTableName")
     blocking {
+      info(s"About to search for MiroID $miroId in $identifiersTableName")
       Scanamo.queryIndex[Identifier](dynamoDBClient)(identifiersTableName,
         "MiroID")('MiroID -> miroId)
     }
@@ -64,8 +64,8 @@ class IdentifierGenerator @Inject()(dynamoDBClient: AmazonDynamoDB,
 
   private def generateAndSaveCanonicalId(miroId: String) = {
     val canonicalId = Identifiable.generate
-    info(s"putting new canonicalId $canonicalId for MiroID $miroId")
     blocking {
+      info(s"putting new canonicalId $canonicalId for MiroID $miroId")
       Scanamo.put(dynamoDBClient)(identifiersTableName)(
         Identifier(canonicalId, miroId))
       canonicalId

--- a/id_minter/src/main/scala/uk/ac/wellcome/platform/idminter/steps/UnifiedItemExtractor.scala
+++ b/id_minter/src/main/scala/uk/ac/wellcome/platform/idminter/steps/UnifiedItemExtractor.scala
@@ -13,13 +13,13 @@ import scala.util.{Failure, Success}
 object UnifiedItemExtractor extends Logging {
 
   def toUnifiedItem(message: Message): Future[UnifiedItem] =
-    Future {
+    Future.fromTry {
       tryExtractinUnifiedItem(message)
-    }.map {
-      case Success(unifiedItem) =>
-        info(s"Successfully extracted unified item $unifiedItem")
-        unifiedItem
-      case Failure(e) =>
+    }.map { unifiedItem =>
+      info(s"Successfully extracted unified item $unifiedItem")
+      unifiedItem
+    } recover {
+      case e: Throwable =>
         error("Failed extracting unified item from AWS message", e)
         throw e
     }

--- a/transformer/src/main/scala/uk/ac/wellcome/transformer/receive/RecordReceiver.scala
+++ b/transformer/src/main/scala/uk/ac/wellcome/transformer/receive/RecordReceiver.scala
@@ -30,7 +30,7 @@ class RecordReceiver @Inject()(snsWriter: SNSWriter) extends Logging {
       case Success(unifiedItem) => publishMessage(unifiedItem)
       case Failure(e) =>
         error("Failed extracting unified item from record", e)
-        throw e
+        Future.failed(e)
     }
   }
 

--- a/transformer/src/main/scala/uk/ac/wellcome/transformer/receive/RecordReceiver.scala
+++ b/transformer/src/main/scala/uk/ac/wellcome/transformer/receive/RecordReceiver.scala
@@ -52,7 +52,7 @@ class RecordReceiver @Inject()(snsWriter: SNSWriter) extends Logging {
           s"Unable to parse record ${record.value} received $dynamoReadError")
     }.recover {
       case e: Throwable =>
-        error("Error extracting transforable case class", e)
+        error("Error extracting transformable case class", e)
         throw e
     }
   }

--- a/transformer/src/test/scala/uk/ac/wellcome/transformer/receive/RecordReceiverTest.scala
+++ b/transformer/src/test/scala/uk/ac/wellcome/transformer/receive/RecordReceiverTest.scala
@@ -84,7 +84,7 @@ class RecordReceiverTest
   private def mockFailPublishMessage = {
     val mockSNS = mock[SNSWriter]
     when(mockSNS.writeMessage(anyString(), any[Option[String]]))
-      .thenThrow(new RuntimeException("Failed publishing message"))
+      .thenReturn(Future.failed(new RuntimeException("Failed publishing message")))
     mockSNS
   }
 


### PR DESCRIPTION
## What is this PR trying to achieve?
Futures should be used to wrap IO bound operations, not CPU only operations. Also, blocking operations should be wrapped in a blocking construct so that the ExecutionContext can deal with them.
## Who is this change for?
Hopefully make transformer and any other app using futures more performant and more stable
