### PR TITLE
Fixing test run on CI

### DIFF
--- a/id_minter/src/main/scala/uk/ac/wellcome/platform/idminter/steps/IdentifierGenerator.scala
+++ b/id_minter/src/main/scala/uk/ac/wellcome/platform/idminter/steps/IdentifierGenerator.scala
@@ -24,7 +24,8 @@ class IdentifierGenerator @Inject()(dynamoDBClient: AmazonDynamoDB,
     findMiroID(unifiedItem) match {
       case Some(identifier) => retrieveOrGenerateCanonicalId(identifier)
       case None =>
-        logAndThrowError(s"Item $unifiedItem did not contain a MiroID")
+        error(s"Item $unifiedItem did not contain a MiroID")
+        Future.failed(new Exception(s"Item $unifiedItem did not contain a MiroID"))
     }
 
   private def retrieveOrGenerateCanonicalId(identifier: SourceIdentifier) =

--- a/project/Common.scala
+++ b/project/Common.scala
@@ -21,7 +21,7 @@ object Common {
       "-feature",
       "-language:postfixOps"
     ),
-    testOptions += Tests.Argument(TestFrameworks.JUnit, "-q", "-v")
+    parallelExecution in Test := false
   ) ++ Search.settings ++ Swagger.settings ++ Finatra.settings
 }
 

--- a/run_circle.sh
+++ b/run_circle.sh
@@ -75,7 +75,9 @@ do
         sbt "project $project" "$TASK"
     elif [[ "$TASK" == "test" ]]
     then
-        sbt "project $project" "dockerComposeTest"
+        sbt "project $project" "dockerComposeUp"
+        sbt "project $project" "test"
+        sbt "project $project" "dockerComposeStop"
     elif [[ "$TASK" == "deploy" ]]
     then
         # There isn't a deploy step for the common lib


### PR DESCRIPTION
dockerComposeTest does not seem to be running all tests for some reason, so switching to starting the docker containers, running the tests and stopping the containers explicitly. Also realized that one test in the idMinter was failing, so fixed that. Disabled parallel test execution as multiple tests cannot interfere with the docker containers at the same time without affecting each others results

## What is this PR trying to achieve?
Fix our build as not all tests are currently executed

## Who is this change for?
Us, to have more reliable builds

## Have the following been considered/are they needed?

- [ ] Tests?
- [ ] Docs?
- [ ] Spoken to the right people?
