### PR TITLE
Refactoring SQSLocal and SNSLocal

### DIFF
--- a/common/src/test/scala/uk/ac/wellcome/sns/SNSWriterTest.scala
+++ b/common/src/test/scala/uk/ac/wellcome/sns/SNSWriterTest.scala
@@ -12,7 +12,7 @@ class SNSWriterTest
     with SNSLocal
     with IntegrationPatience {
 
-  override def topicName: String = "test-topic-name"
+  val topicArn = createTopicAndReturnArn("test-topic-name")
   val snsConfig = SNSConfig("eu-west-1", topicArn)
 
   it("should send a message with subject to the SNS client and return a publish attempt with the id of the request") {

--- a/common/src/test/scala/uk/ac/wellcome/sqs/SQSReaderTest.scala
+++ b/common/src/test/scala/uk/ac/wellcome/sqs/SQSReaderTest.scala
@@ -1,11 +1,12 @@
 package uk.ac.wellcome.sqs
 
 import com.amazonaws.services.sqs.model.Message
-import org.scalatest.concurrent.{Eventually, IntegrationPatience, ScalaFutures}
+import org.scalatest.concurrent.{IntegrationPatience, ScalaFutures}
 import org.scalatest.{FunSpec, Matchers}
 import uk.ac.wellcome.models.aws.SQSConfig
 import uk.ac.wellcome.test.utils.SQSLocal
 
+import scala.collection.JavaConversions._
 import scala.concurrent.duration._
 
 class SQSReaderTest
@@ -15,7 +16,10 @@ class SQSReaderTest
     with IntegrationPatience
     with SQSLocal {
 
-  override def queueName: String = "test_queue"
+  val queueUrl = createQueueAndReturnUrl("test_queue")
+
+  // Setting 1 second timeout for tests, so that test don't have to wait too long to test message deletion
+  sqsClient.setQueueAttributes(queueUrl, Map("VisibilityTimeout" -> "1"))
 
   it("should get messages from the SQS queue, limited by the maximum number of messages and return them") {
     val sqsConfig =

--- a/common/src/test/scala/uk/ac/wellcome/test/utils/SNSLocal.scala
+++ b/common/src/test/scala/uk/ac/wellcome/test/utils/SNSLocal.scala
@@ -11,7 +11,6 @@ import org.scalatest.{BeforeAndAfterEach, Suite}
 
 trait SNSLocal extends BeforeAndAfterEach with Logging {this: Suite =>
 
-  def topicName: String
   private val localSNSEndpointUrl = "http://localhost:9292"
 
   val amazonSNS: AmazonSNS = AmazonSNSClientBuilder
@@ -22,7 +21,9 @@ trait SNSLocal extends BeforeAndAfterEach with Logging {this: Suite =>
       new EndpointConfiguration(localSNSEndpointUrl, "local"))
     .build()
 
-  val topicArn = amazonSNS.createTopic(topicName).getTopicArn
+  def createTopicAndReturnArn(topicName: String) = {
+    amazonSNS.createTopic(topicName).getTopicArn
+  }
 
   override def beforeEach(): Unit = {
     super.beforeEach()

--- a/id_minter/src/test/scala/uk/ac/wellcome/platform/idminter/IdMinterIntegrationTest.scala
+++ b/id_minter/src/test/scala/uk/ac/wellcome/platform/idminter/IdMinterIntegrationTest.scala
@@ -26,16 +26,16 @@ class IdMinterIntegrationTest
     with Eventually
     with IntegrationPatience {
 
-  override def topicName: String = "test_ingestor"
-  override def queueName: String = "test_id_minter"
+  val ingestorTopicArn = createTopicAndReturnArn("test_ingestor")
+  val idMinterQueue = createQueueAndReturnUrl("test_id_minter")
 
   override val injector =
     TestInjector(
       flags = Map(
         "aws.region" -> "local",
-        "aws.sqs.queue.url" -> queueUrl,
+        "aws.sqs.queue.url" -> idMinterQueue,
         "aws.sqs.waitTime" -> "1",
-        "aws.sns.topic.arn" -> topicArn,
+        "aws.sns.topic.arn" -> ingestorTopicArn,
         "aws.dynamo.tableName" -> identifiersTableName
       ),
       modules = Seq(AkkaModule,
@@ -59,7 +59,7 @@ class IdMinterIntegrationTest
                                 "messageType",
                                 "timestamp")
 
-    sqsClient.sendMessage(queueUrl, JsonUtil.toJson(sqsMessage).get)
+    sqsClient.sendMessage(idMinterQueue, JsonUtil.toJson(sqsMessage).get)
 
     IdMinterModule.singletonStartup(injector)
 
@@ -83,7 +83,7 @@ class IdMinterIntegrationTest
     val firstMiroId = "1234"
     val sqsMessage = generateSqsMessage(firstMiroId)
 
-    sqsClient.sendMessage(queueUrl, JsonUtil.toJson(sqsMessage).get)
+    sqsClient.sendMessage(idMinterQueue, JsonUtil.toJson(sqsMessage).get)
 
     IdMinterModule.singletonStartup(injector)
 
@@ -94,7 +94,7 @@ class IdMinterIntegrationTest
 
     val secondMiroId = "5678"
     val secondSqsMessage = generateSqsMessage(secondMiroId)
-    sqsClient.sendMessage(queueUrl, JsonUtil.toJson(secondSqsMessage).get)
+    sqsClient.sendMessage(idMinterQueue, JsonUtil.toJson(secondSqsMessage).get)
 
     eventually {
       Scanamo.queryIndex[Identifier](dynamoDbClient)("Identifiers", "MiroID")(
@@ -104,14 +104,14 @@ class IdMinterIntegrationTest
   }
 
   test("it should keep polling if something fails processing a message") {
-    sqsClient.sendMessage(queueUrl, "not a json string")
+    sqsClient.sendMessage(idMinterQueue, "not a json string")
 
     IdMinterModule.singletonStartup(injector)
 
     val miroId = "1234"
     val sqsMessage = generateSqsMessage(miroId)
 
-    sqsClient.sendMessage(queueUrl, JsonUtil.toJson(sqsMessage).get)
+    sqsClient.sendMessage(idMinterQueue, JsonUtil.toJson(sqsMessage).get)
     eventually {
       Scanamo.queryIndex[Identifier](dynamoDbClient)("Identifiers", "MiroID")(
         'MiroID -> miroId) should have size (1)

--- a/ingestor/src/test/scala/uk/ac/wellcome/platform/ingestor/IngestorIntegrationTest.scala
+++ b/ingestor/src/test/scala/uk/ac/wellcome/platform/ingestor/IngestorIntegrationTest.scala
@@ -18,14 +18,14 @@ class IngestorIntegrationTest
     with Matchers
     with ElasticSearchLocal {
 
-  override def queueName: String = "test_es_ingestor_queue"
+  val ingestorQueueUrl = createQueueAndReturnUrl("test_es_ingestor_queue")
   val index = "records"
   val itemType = "item"
   override def injector: Injector = {
     TestInjector(
       flags = Map(
         "aws.region" -> "eu-west-1",
-        "aws.sqs.queue.url" -> queueUrl,
+        "aws.sqs.queue.url" -> ingestorQueueUrl,
         "aws.sqs.waitTime" -> "1",
         "es.host" -> "localhost",
         "es.port" -> "9300",
@@ -56,7 +56,7 @@ class IngestorIntegrationTest
       .get
 
     sqsClient.sendMessage(
-      queueUrl,
+      ingestorQueueUrl,
       JsonUtil
         .toJson(
           SQSMessage(Some("identified-item"),

--- a/transformer/src/test/scala/uk/ac/wellcome/transformer/CalmTransformerIntegrationTest.scala
+++ b/transformer/src/test/scala/uk/ac/wellcome/transformer/CalmTransformerIntegrationTest.scala
@@ -26,7 +26,7 @@ class CalmTransformerIntegrationTest extends TransformerIntegrationTest {
         "aws.dynamo.streams.appName" -> "test-transformer-calm",
         "aws.dynamo.streams.arn" -> calmDataStreamArn,
         "aws.dynamo.tableName" -> calmDataTableName,
-        "aws.sns.topic.arn" -> topicArn
+        "aws.sns.topic.arn" -> idMinterTopicArn
       ),
       modules = Seq(
         StreamsRecordProcessorFactoryModule,

--- a/transformer/src/test/scala/uk/ac/wellcome/transformer/MiroTransformerIntegrationTest.scala
+++ b/transformer/src/test/scala/uk/ac/wellcome/transformer/MiroTransformerIntegrationTest.scala
@@ -26,7 +26,7 @@ class MiroTransformerIntegrationTest extends TransformerIntegrationTest {
         "aws.dynamo.streams.appName" -> "test-transformer-miro",
         "aws.dynamo.streams.arn" -> miroDataStreamArn,
         "aws.dynamo.tableName" -> miroDataTableName,
-        "aws.sns.topic.arn" -> topicArn
+        "aws.sns.topic.arn" -> idMinterTopicArn
       ),
       modules = Seq(
         StreamsRecordProcessorFactoryModule,

--- a/transformer/src/test/scala/uk/ac/wellcome/transformer/utils/TransformerIntegrationTest.scala
+++ b/transformer/src/test/scala/uk/ac/wellcome/transformer/utils/TransformerIntegrationTest.scala
@@ -18,7 +18,7 @@ trait TransformerIntegrationTest
     with Eventually
     with IntegrationPatience {
 
-  override def topicName: String = "test_id_minter"
+  val idMinterTopicArn = createTopicAndReturnArn("test_id_minter")
 
   object LocalKinesisModule extends TwitterModule {
 


### PR DESCRIPTION
## What is this PR trying to achieve?
Make SQSLocal and SNSLocal usages more readable and more flexible as they can now create as many queues and topics as needed by tests
## Who is this change for?
Developers who like readable code
## Have the following been considered/are they needed?

- [x] Tests?
- [x] Docs?
- [x] Spoken to the right people?
