### PR TITLE
Switch back to building universal/stage

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,2 +1,2 @@
 */target/*
-!*/target/docker
+!*/target/universal

--- a/.travis.yml
+++ b/.travis.yml
@@ -57,7 +57,7 @@ script:
     if [[ "$BRANCH" == "master" ]];
     then
       if [[ "$PROJECT" != "common" ]]; then
-        sbt "project $PROJECT" docker:stage;
+        sbt "project $PROJECT" stage;
         export NAME="0.0.1-$(git rev-parse HEAD)_prod";
         $(aws ecr get-login);
         docker build --build-arg project=$PROJECT --build-arg config_bucket=$CONFIG_BUCKET --build-arg build_env=prod --tag=$AWS_ECR_REPO/uk.ac.wellcome/$PROJECT:$NAME .;

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ ARG project
 
 RUN apk update && apk add python3 && pip3 install awscli && rm -rf /var/cache/apk
 
-ADD $project/target/docker/stage/opt /opt
+ADD $project/target/universal/stage /opt/docker
 RUN chown -R daemon:daemon /opt/docker
 USER daemon
 


### PR DESCRIPTION
We were seeing issues with builds because we were copying
docker/stage into the Docker image, but rebuilding universal/stage.
The Travis cache was providing a stale binary, hence the never-
changing Docker images.

In 0614ea6, we switched to building docker/stage, but this also
builds a Dockerfile that we don't need.  This patch reverts us back
to using universal/stage, and makes sure that directory is visible
to the Docker build context.
