### PR TITLE
Move the Travis config out into a script

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,20 +5,7 @@ sudo: required
 dist: trusty
 
 install:
-  # This is needed for elasticsearch docker container to start: see https://github.com/travis-ci/travis-ci/issues/6534
-  - sudo sysctl -w vm.max_map_count=262144
-
-  # Install Docker on Travis.  Merely exposing Docker through the Travis
-  # settings is insufficient, because the docker-compose tests we use are
-  # unable to see it in that case.
-  - curl -sSL "https://get.docker.com/gpg" | sudo -E apt-key add -
-  - echo "deb https://apt.dockerproject.org/repo ubuntu-trusty main" | sudo tee -a /etc/apt/sources.list
-  - sudo apt-get update
-  - sudo apt-get -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" --assume-yes install docker-engine
-  - docker version
-
-  # Install the AWS tools so we can log in to ECR
-  - pip install --upgrade --user awscli
+  - ./.travis/install.sh
 
 cache:
   directories:
@@ -43,32 +30,7 @@ matrix:
     - env: PROJECT=id_minter
 
 script:
-  # https://graysonkoonce.com/getting-the-current-branch-name-during-a-pull-request-in-travis-ci/
-  - export BRANCH=$(if [ "$TRAVIS_PULL_REQUEST" == "false" ]; then echo $TRAVIS_BRANCH; else echo $TRAVIS_PULL_REQUEST_BRANCH; fi)
-  - echo "TRAVIS_BRANCH=$TRAVIS_BRANCH, PR=$PR, BRANCH=$BRANCH"
-
-  # Run the commands for the test.  Chaining them together means we don't
-  # have to pay the cost of starting the JVM three times.
-  # http://www.scala-sbt.org/0.12.2/docs/Howto/runningcommands.html
-  - sbt "project $PROJECT" ";dockerComposeUp;test;dockerComposeStop"
-
-  - >
-    export AWS_DEFAULT_REGION=eu-west-1;
-    if [[ "$BRANCH" == "master" ]];
-    then
-      if [[ "$PROJECT" != "common" ]]; then
-        sbt "project $PROJECT" stage;
-        export NAME="0.0.1-$(git rev-parse HEAD)_prod";
-        $(aws ecr get-login);
-        docker build --build-arg project=$PROJECT --build-arg config_bucket=$CONFIG_BUCKET --build-arg build_env=prod --tag=$AWS_ECR_REPO/uk.ac.wellcome/$PROJECT:$NAME .;
-        docker push $AWS_ECR_REPO/uk.ac.wellcome/$PROJECT:$NAME;
-        echo "New container image is $NAME"
-      else
-        echo "Not an application (common); skipping deploy";
-      fi;
-    else
-      echo "Not on master; skipping deploy...";
-    fi
+  - ./.travis/run.sh
 
 env:
   global:

--- a/.travis/install.sh
+++ b/.travis/install.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+
+set -o errexit
+set -o nounset
+set -o verbose
+
+# This is needed for the Elasticsearch docker container to start.
+# See https://github.com/travis-ci/travis-ci/issues/6534
+sudo sysctl -w vm.max_map_count=262144
+
+# Install Docker on Travis.  Merely exposing Docker through the Travis
+# settings is insufficient, because the docker-compose tests we use are
+# unable to see it in that case.
+curl -sSL "https://get.docker.com/gpg" | sudo -E apt-key add -
+echo "deb https://apt.dockerproject.org/repo ubuntu-trusty main" | sudo tee -a /etc/apt/sources.list
+sudo apt-get update
+sudo apt-get -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" --assume-yes install docker-engine
+docker version
+
+# Install the AWS tools so we can log in to ECR
+pip install --upgrade --user awscli

--- a/.travis/run.sh
+++ b/.travis/run.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+
+set -o errexit
+set -o nounset
+set -o verbose
+
+# https://graysonkoonce.com/getting-the-current-branch-name-during-a-pull-request-in-travis-ci/
+if [[ "$TRAVIS_PULL_REQUEST" == "false" ]]
+then
+  export BRANCH="$TRAVIS_PULL_REQUEST"
+else
+  export BRANCH="$TRAVIS_PULL_REQUEST_BRANCH"
+fi
+
+echo "TRAVIS_BRANCH=$TRAVIS_BRANCH, PR=$TRAVIS_PULL_REQUEST, BRANCH=$BRANCH"
+
+# Run the commands for the test.  Chaining them together means we don't
+# have to pay the cost of starting the JVM three times.
+# http://www.scala-sbt.org/0.12.2/docs/Howto/runningcommands.html
+sbt "project $PROJECT" ";dockerComposeUp;test;dockerComposeStop"
+
+# If we're on master, build a Docker image and push it to ECR
+export AWS_DEFAULT_REGION=eu-west-1;
+if [[ "$BRANCH" == "master" ]];
+then
+  if [[ "$PROJECT" != "common" ]]; then
+    sbt "project $PROJECT" stage;
+    export NAME="0.0.1-$(git rev-parse HEAD)_prod";
+    $(aws ecr get-login);
+    docker build --build-arg project=$PROJECT --build-arg config_bucket=$CONFIG_BUCKET --build-arg build_env=prod --tag=$AWS_ECR_REPO/uk.ac.wellcome/$PROJECT:$NAME .;
+    docker push $AWS_ECR_REPO/uk.ac.wellcome/$PROJECT:$NAME;
+    echo "New container image is $NAME"
+  else
+    echo "Not an application (common); skipping deploy";
+  fi;
+else
+  echo "Not on master; skipping deploy...";
+fi
+
+exit 0


### PR DESCRIPTION
Resolves #210. This is just a straight transplant, not very interesting so I just went ahead and did it. This clears the path to push on with #202, #203, #208.

## What is this PR trying to achieve?

Make it easier to run the build process outside Travis, make it easier to work with the build scripts.

## Who is this change for?

Developers.

## Have the following been considered/are they needed?

- [x] Tests – not required
- [x] Docs – ditto
- [x] Spoken to the right people – ditto