### PR TITLE
Fix Elasticsearch connection for ingestor and api

### DIFF
--- a/common/src/main/scala/uk/ac/wellcome/finatra/modules/ElasticClientModule.scala
+++ b/common/src/main/scala/uk/ac/wellcome/finatra/modules/ElasticClientModule.scala
@@ -60,7 +60,7 @@ object ElasticClientModule extends TwitterModule {
         (defaults, config) =>
           defaults
             .put("xpack.security.transport.ssl.enabled", config.ssl)
-            .put("request.headers.X-Found-Cluster", s"${clusterName}")
+            .put("request.headers.X-Found-Cluster", clusterName())
             .put("xpack.security.user", config.user))
       .build()
 


### PR DESCRIPTION
The Api and the ingestor are not able to connect to Elasticsearch because the value of the request.headers.X-Found-Cluster config variable that we pass in is not correct. At the moment the value we pass in is -es.name='ab2541dab2e4aaa825d7d721c29f464a' which is the printout of the finatra flag we use for it. It can either be an interpolatiom expression as ```"${cluster.name}"``` or the actual cluster name. Putting the cluster name as the interpolation expression is confusing 

## What is this PR trying to achieve?
Get our apps to connect to elasticsearch
## Who is this change for?
Everyone
## Have the following been considered/are they needed?

- [x] Tests?
- [x] Docs?
- [x] Spoken to the right people?
