### PR TITLE
Ensure the Calm adapter tries to shut down the right service

### DIFF
--- a/calm_adapter/src/main/scala/uk/ac/wellcome/calm_adapter/modules/CalmAdapterWorker.scala
+++ b/calm_adapter/src/main/scala/uk/ac/wellcome/calm_adapter/modules/CalmAdapterWorker.scala
@@ -58,7 +58,7 @@ object CalmAdapterWorker extends TwitterModule {
       .toJson(
         ECSServiceScheduleRequest(
           "services_cluster",
-          "calm-adapter",
+          "calm_adapter",
           0
         )
       )


### PR DESCRIPTION
## What is this PR trying to achieve?

Get the Calm adapter to shut down correctly. We renamed the service, and now it breaks the Lambda which tries to shut it down. I don't think it's worth making this configurable because the service name should rarely change.

## Who is this change for?

Internal.

## Have the following been considered/are they needed?

- [x] Tests – not required
- [x] Docs – not required
- [x] Spoken to the right people – no external dependencies
