### PR TITLE
ID minter only generates IDs that start with letters

### DIFF
--- a/id_minter/src/main/scala/uk/ac/wellcome/platform/idminter/utils/Identifiable.scala
+++ b/id_minter/src/main/scala/uk/ac/wellcome/platform/idminter/utils/Identifiable.scala
@@ -16,9 +16,12 @@ object Identifiable {
   def generate = {
     (1 to identifierLength)
       .map(x => x match {
-        // In certain contexts, IDs are used as a string.  This can cause
-        // problems if the first character is a digit, so we have a rule
-        // that the first character must be a letter.
+        // One of the serialization formats of RDF is XML, so for
+        // compatibility, our identifiers have to comply with XML rules.
+        // XML identifiers cannot start with numbers, so we apply the same
+        // rule to the identifiers we generate.
+        //
+        // See: http://stackoverflow.com/a/1077111/1558022
         case 1 => firstCharacterSet(Random.nextInt(firstCharacterSet.length))
         case _ => allowedCharacterSet(Random.nextInt(allowedCharacterSet.length))
       })

--- a/id_minter/src/main/scala/uk/ac/wellcome/platform/idminter/utils/Identifiable.scala
+++ b/id_minter/src/main/scala/uk/ac/wellcome/platform/idminter/utils/Identifiable.scala
@@ -4,12 +4,24 @@ import scala.util.Random
 
 object Identifiable {
   private val identifierLength = 8
-  private val forbiddenLetters = List('o', 'i', 'l', '1')
-  private val letterRange = ('1' to '9') ++ ('a' to 'z')
-  private val letterSet = letterRange.filterNot(forbiddenLetters.contains)
 
-  def generate =
+  private val forbiddenLetters = List('o', 'i', 'l', '1')
+  private val numberRange = ('1' to '9')
+  private val letterRange = ('a' to 'z')
+
+  private val characterSet = numberRange ++ letterRange
+  private val allowedCharacterSet = (characterSet).filterNot(forbiddenLetters.contains)
+  private val firstCharacterSet = allowedCharacterSet.filterNot(numberRange.contains)
+
+  def generate = {
     (1 to identifierLength)
-      .map(_ => letterSet(Random.nextInt(letterSet.length)))
+      .map(x => x match {
+        // In certain contexts, IDs are used as a string.  This can cause
+        // problems if the first character is a digit, so we have a rule
+        // that the first character must be a letter.
+        case 1 => firstCharacterSet(Random.nextInt(firstCharacterSet.length))
+        case _ => allowedCharacterSet(Random.nextInt(allowedCharacterSet.length))
+      })
       .mkString
+  }
 }

--- a/id_minter/src/test/scala/uk/ac/wellcome/platform/idminter/utils/IdentifiableTest.scala
+++ b/id_minter/src/test/scala/uk/ac/wellcome/platform/idminter/utils/IdentifiableTest.scala
@@ -16,14 +16,9 @@ class IdentifiableTest extends FunSpec with PropertyChecks with Matchers {
     }
   }
 
-  // We have a rule that identifiers can't start with a number, as this
-  // makes them awkward to use as a string in certain contexts.
   it("should never generate an identifier that starts with a number") {
     forAll(minSuccessful(100)) { (_: Int) =>
-      {
-        val id = Identifiable.generate
-        assert(!id.head.isDigit)
-      }
+      Identifiable.generate should not (startWith regex "[0-9]")
     }
   }
 

--- a/id_minter/src/test/scala/uk/ac/wellcome/platform/idminter/utils/IdentifiableTest.scala
+++ b/id_minter/src/test/scala/uk/ac/wellcome/platform/idminter/utils/IdentifiableTest.scala
@@ -16,4 +16,15 @@ class IdentifiableTest extends FunSpec with PropertyChecks with Matchers {
     }
   }
 
+  // We have a rule that identifiers can't start with a number, as this
+  // makes them awkward to use as a string in certain contexts.
+  it("should never generate an identifier that starts with a number") {
+    forAll(minSuccessful(100)) { (_: Int) =>
+      {
+        val id = Identifiable.generate
+        assert(!id.head.isDigit)
+      }
+    }
+  }
+
 }


### PR DESCRIPTION
## What is this PR trying to achieve?

Addresses the first half of #225 – new IDs won't start with a number.

Once this is merged, we'll need to flush the existing tables, as have some existing identifiers that begin with numbers.

## Who is this change for?

End-users who may be using identifiers as strings, for whom a leading numeral is potentially problematic.

## Have the following been considered/are they needed?

- [x] Tests? See unit test in patch
- [x] Docs? Not required.
- [x] Spoken to the right people?