### PR TITLE
Update the JSON-LD context

### DIFF
--- a/api/src/main/resources/context.json
+++ b/api/src/main/resources/context.json
@@ -1,8 +1,26 @@
-{
-  "@context": {
-    "@base": "http://id.wellcomecollection.org/",
-    "@vocab": "http://wellcomecollection.org/ontologies/works/",
-    "id": "@id",
-    "type": "@type"
+[
+  {
+    "@context": {
+      "@base": "http://id.wellcomecollection.org/",
+      "@vocab": "http://wellcomecollection.org/ontologies/works/",
+      "id": "@id",
+      "type": "@type",
+      "hasCreator": {
+        "@container": "@list"
+      }
+    }
+  },
+  {
+    "@context": {
+      "wa": "http://wellcomecollection.org/ontologies/api/",
+      "ResultList": "wa:ResultList",
+      "pageSize": "wa:pageSize",
+      "totalPages": "wa:totalPages",
+      "totalResults": "wa:totalResults",
+      "results": {
+        "@type": "wa:results",
+        "@container": "@list"
+      }
+    }
   }
-}
+]

--- a/api/src/main/scala/uk/ac/wellcome/platform/api/utils/ApiRequestUtils.scala
+++ b/api/src/main/scala/uk/ac/wellcome/platform/api/utils/ApiRequestUtils.scala
@@ -11,9 +11,21 @@ object ApiRequestUtils {
       case _ => "http"
     }
 
-    val hostHeader = request.host match {
-      case Some(host) => host
-      case _ => throw new BadRequestException("Host header not set")
+    // Most users will access our API through a DNS record that comes through
+    // https://api.wellcomecollection.org.  I can't find a way to detect
+    // the DNS name through the request headers, so just hard-code it if we
+    // detect the request came through ELB.
+    //
+    // Specifically, we look for a header that is added to all ELB requests:
+    // http://docs.aws.amazon.com/elasticloadbalancing/latest/application/load-balancer-request-tracing.html
+    val hostHeader: String = request.headerMap.get("X-Amzn-Trace-Id") match {
+      case Some(_) => "api.wellcomecollection.org"
+      case None => {
+        request.host match {
+          case Some(host) => host
+          case _ => throw new BadRequestException("Host header not set")
+        }
+      }
     }
 
     scheme + "://" + hostHeader


### PR DESCRIPTION
## What is this PR trying to achieve?

Update `context.json` to the latest mapping, per #132. Fixes the `@context` value on API responses. See https://api.wellcomecollection.org/catalogue/v0/works/2bp9dawj for an example.

Resolves #132.

## Who is this change for?

Users of the API.

## Have the following been considered/are they needed?

- [x] Tests? Not required.
- [x] Docs? Not required.
- [x] Spoken to the right people?