### PR TITLE
Ingestor should not create a new item if one already exists in elastic search with the same id

### DIFF
--- a/ingestor/src/main/scala/uk/ac/wellcome/platform/ingestor/services/IdentifiedUnifiedItemIndexer.scala
+++ b/ingestor/src/main/scala/uk/ac/wellcome/platform/ingestor/services/IdentifiedUnifiedItemIndexer.scala
@@ -28,7 +28,7 @@ class IdentifiedUnifiedItemIndexer @Inject()(
       .flatMap(item => {
         info(s"Indexing item $item")
         elasticClient.execute {
-          indexInto(esIndex / esType).doc(item)
+          indexInto(esIndex / esType).id(item.canonicalId).doc(item)
         }
       })
       .recover {

--- a/ingestor/src/test/scala/uk/ac/wellcome/platform/ingestor/services/IdentifiedUnifiedItemIndexerTest.scala
+++ b/ingestor/src/test/scala/uk/ac/wellcome/platform/ingestor/services/IdentifiedUnifiedItemIndexerTest.scala
@@ -9,24 +9,32 @@ import uk.ac.wellcome.test.utils.ElasticSearchLocal
 import uk.ac.wellcome.utils.GlobalExecutionContext.context
 import uk.ac.wellcome.utils.JsonUtil
 
+import scala.concurrent.Future
+
 class IdentifiedUnifiedItemIndexerTest
     extends FunSpec
     with ScalaFutures
     with Matchers
     with ElasticSearchLocal {
 
-  it("should insert an identified unified item into Elasticsearch") {
-    val index = "records"
-    val itemType = "item"
-    val identifiedUnifiedItemIndexer =
-      new IdentifiedUnifiedItemIndexer(index, itemType, elasticClient)
-    val identifiedUnifiedItemString = JsonUtil
-      .toJson(
+  val itemType = "item"
+
+  val identifiedUnifiedItemIndexer =
+    new IdentifiedUnifiedItemIndexer(index, itemType, elasticClient)
+
+  def identifiedUnifiedItemJson(canonicalId: String, sourceId: String, label: String): String = {
+    JsonUtil.toJson(
         IdentifiedUnifiedItem(
-          canonicalId = "5678",
+          canonicalId = canonicalId,
           unifiedItem = UnifiedItem(
-            identifiers = List(SourceIdentifier("Miro", "MiroID", "1234")), label = "some label")))
+            identifiers = List(SourceIdentifier("Miro", "MiroID", sourceId)), label = label)))
       .get
+  }
+
+  it("should insert an identified unified item into Elasticsearch") {
+
+    val identifiedUnifiedItemString =
+      identifiedUnifiedItemJson("5678", "1234", "some label")
 
     val future = identifiedUnifiedItemIndexer.indexIdentifiedUnifiedItem(
       identifiedUnifiedItemString)
@@ -44,9 +52,29 @@ class IdentifiedUnifiedItemIndexerTest
 
   }
 
+  it("should add only one record when multiple records with same id are ingested") {
+    val identifiedUnifiedItemString =
+      identifiedUnifiedItemJson("5678", "1234", "some label")
+
+    val future = Future.sequence(
+      (1 to 2).map(_ => identifiedUnifiedItemIndexer.indexIdentifiedUnifiedItem(
+        identifiedUnifiedItemString))
+    )
+
+    whenReady(future) { _ =>
+      eventually {
+        val hits = elasticClient
+          .execute(search(s"$index/$itemType").matchAll().limit(100))
+          .map { _.hits }
+          .await
+        hits should have size 1
+        hits.head.sourceAsString shouldBe identifiedUnifiedItemString
+      }
+    }
+
+  }
+
   it("should return a failed future if the input string is not an identified unified item") {
-    val identifiedUnifiedItemIndexer =
-      new IdentifiedUnifiedItemIndexer("records", "item", elasticClient)
     val future = identifiedUnifiedItemIndexer.indexIdentifiedUnifiedItem("a document")
 
     whenReady(future.failed) { exception =>


### PR DESCRIPTION
## What is this PR trying to achieve?
Make the ingestor not create a new item if it receives an item for an id that already exists inelasticsearch
## Who is this change for?
Everyone
## Have the following been considered/are they needed?

- [x] Tests?
- [x] Docs?
- [x] Spoken to the right people?
