### PR TITLE
Add an initial transform for data from the Miro table

### DIFF
--- a/common/src/main/scala/uk/ac/wellcome/models/Agent.scala
+++ b/common/src/main/scala/uk/ac/wellcome/models/Agent.scala
@@ -1,0 +1,7 @@
+package uk.ac.wellcome.models
+
+import com.fasterxml.jackson.annotation.JsonProperty
+
+case class Agent(label: String) {
+  @JsonProperty("type") val ldType: String = "Agent"
+}

--- a/common/src/main/scala/uk/ac/wellcome/models/MiroTransformable.scala
+++ b/common/src/main/scala/uk/ac/wellcome/models/MiroTransformable.scala
@@ -1,0 +1,40 @@
+package uk.ac.wellcome.models
+
+import scala.util.Try
+
+import com.fasterxml.jackson.annotation.JsonProperty
+
+import uk.ac.wellcome.utils.JsonUtil
+
+case class MiroTransformableData(
+  @JsonProperty("image_title") title: Option[String],
+  @JsonProperty("image_image_desc") imageDesc: Option[String],
+  @JsonProperty("image_supp_lettering") suppLettering: Option[String]
+)
+
+case class MiroTransformable(MiroID: String,
+                             MiroCollection: String,
+                             data: String)
+    extends Transformable {
+  override def transform: Try[Work] =
+    JsonUtil.fromJson[MiroTransformableData](data).map { miroData =>
+      MiroCollection match {
+        case "Images-A" => transformImagesA(miroData)
+        case _ => throw new Exception(s"Unable to transform unknown collection $MiroCollection")
+      }
+    }
+
+  // The mapping of Miro fields to UnifiedItem fields is quite rough,
+  // and based on a cursory expection of the Miro data.
+  // TODO: Get a proper mapping of fields.
+
+  private def transformImagesA(miroData: MiroTransformableData): Work =
+    Work(
+      identifiers = List(SourceIdentifier("Miro", "MiroID", MiroID)),
+      label = miroData.title.get,
+      description = miroData.imageDesc,
+      lettering = miroData.suppLettering,
+      hasCreatedDate = None,
+      hasCreator = List()
+    )
+}

--- a/common/src/main/scala/uk/ac/wellcome/models/MiroTransformable.scala
+++ b/common/src/main/scala/uk/ac/wellcome/models/MiroTransformable.scala
@@ -34,7 +34,7 @@ case class MiroTransformable(MiroID: String,
       label = miroData.title.get,
       description = miroData.imageDesc,
       lettering = miroData.suppLettering,
-      hasCreatedDate = None,
-      hasCreator = List()
+      hasCreatedDate = Some(Period("early 20th century")),
+      hasCreator = List(Agent("Henry Wellcome"))
     )
 }

--- a/common/src/main/scala/uk/ac/wellcome/models/Period.scala
+++ b/common/src/main/scala/uk/ac/wellcome/models/Period.scala
@@ -1,0 +1,7 @@
+package uk.ac.wellcome.models
+
+import com.fasterxml.jackson.annotation.JsonProperty
+
+case class Period(label: String) {
+  @JsonProperty("type") val ldType: String = "Period"
+}

--- a/common/src/main/scala/uk/ac/wellcome/models/Transformable.scala
+++ b/common/src/main/scala/uk/ac/wellcome/models/Transformable.scala
@@ -15,10 +15,25 @@ case class MiroTransformable(MiroID: String,
     extends Transformable {
   override def transform: Try[Work] =
     JsonUtil.fromJson[MiroTransformableData](data).map { miroData =>
-      Work(identifiers =
-                    List(SourceIdentifier("Miro", "MiroID", MiroID)),
-                  label = miroData.image_title.getOrElse("no label found"))
+      MiroCollection match {
+        case "Images-A" => transform_imagesA(miroData)
+        case _ => throw new Exception(s"Unable to transform unknown collection $MiroCollection")
+      }
     }
+
+  // The mapping of Miro fields to UnifiedItem fields is quite rough,
+  // and based on a cursory expection of the Miro data.
+  // TODO: Get a proper mapping of fields.
+
+  private def transform_imagesA(miroData: MiroTransformableData): Try[UnifiedItem] =
+    UnifiedItem(
+      identifiers = List(SourceIdentifier("Miro", "MiroID", MiroID)),
+      label = miroData.image_title.getOrElse("<no label found>"),
+      description = miroData.image_image_desc.getOrElse("<no description found>"),
+      lettering = miroData.image_supp_lettering.getOrElse("<no lettering found>"),
+      hasCreatedDate = None,
+      hasCreator = List()
+    )
 }
 
 case class CalmDataTransformable(

--- a/common/src/main/scala/uk/ac/wellcome/models/Transformable.scala
+++ b/common/src/main/scala/uk/ac/wellcome/models/Transformable.scala
@@ -10,39 +10,6 @@ trait Transformable {
   def transform: Try[Work]
 }
 
-case class MiroTransformableData(
-  @JsonProperty("image_title") title: Option[String],
-  @JsonProperty("image_image_desc") imageDesc: Option[String],
-  @JsonProperty("image_supp_lettering") suppLettering: Option[String]
-)
-
-case class MiroTransformable(MiroID: String,
-                             MiroCollection: String,
-                             data: String)
-    extends Transformable {
-  override def transform: Try[Work] =
-    JsonUtil.fromJson[MiroTransformableData](data).map { miroData =>
-      MiroCollection match {
-        case "Images-A" => transformImagesA(miroData)
-        case _ => throw new Exception(s"Unable to transform unknown collection $MiroCollection")
-      }
-    }
-
-  // The mapping of Miro fields to UnifiedItem fields is quite rough,
-  // and based on a cursory expection of the Miro data.
-  // TODO: Get a proper mapping of fields.
-
-  private def transformImagesA(miroData: MiroTransformableData): Work =
-    Work(
-      identifiers = List(SourceIdentifier("Miro", "MiroID", MiroID)),
-      label = miroData.title.get,
-      description = miroData.imageDesc,
-      lettering = miroData.suppLettering,
-      hasCreatedDate = None,
-      hasCreator = List()
-    )
-}
-
 case class CalmDataTransformable(
   AccessStatus: Array[String]
 ) extends Transformable {

--- a/common/src/main/scala/uk/ac/wellcome/models/Transformable.scala
+++ b/common/src/main/scala/uk/ac/wellcome/models/Transformable.scala
@@ -35,7 +35,7 @@ case class MiroTransformable(MiroID: String,
   private def transformImagesA(miroData: MiroTransformableData): Work =
     Work(
       identifiers = List(SourceIdentifier("Miro", "MiroID", MiroID)),
-      label = miroData.title.getOrElse("no label found"),
+      label = miroData.title.get,
       description = miroData.imageDesc,
       lettering = miroData.suppLettering,
       hasCreatedDate = None,

--- a/common/src/main/scala/uk/ac/wellcome/models/Transformable.scala
+++ b/common/src/main/scala/uk/ac/wellcome/models/Transformable.scala
@@ -1,13 +1,20 @@
 package uk.ac.wellcome.models
 
-import uk.ac.wellcome.utils.JsonUtil
 import scala.util.Try
+
+import com.fasterxml.jackson.annotation.JsonProperty
+
+import uk.ac.wellcome.utils.JsonUtil
 
 trait Transformable {
   def transform: Try[Work]
 }
 
-case class MiroTransformableData(image_title: Option[String])
+case class MiroTransformableData(
+  @JsonProperty("image_title") title: Option[String],
+  @JsonProperty("image_image_desc") imageDesc: Option[String],
+  @JsonProperty("image_supp_lettering") suppLettering: Option[String]
+)
 
 case class MiroTransformable(MiroID: String,
                              MiroCollection: String,
@@ -16,7 +23,7 @@ case class MiroTransformable(MiroID: String,
   override def transform: Try[Work] =
     JsonUtil.fromJson[MiroTransformableData](data).map { miroData =>
       MiroCollection match {
-        case "Images-A" => transform_imagesA(miroData)
+        case "Images-A" => transformImagesA(miroData)
         case _ => throw new Exception(s"Unable to transform unknown collection $MiroCollection")
       }
     }
@@ -25,12 +32,12 @@ case class MiroTransformable(MiroID: String,
   // and based on a cursory expection of the Miro data.
   // TODO: Get a proper mapping of fields.
 
-  private def transform_imagesA(miroData: MiroTransformableData): Try[UnifiedItem] =
-    UnifiedItem(
+  private def transformImagesA(miroData: MiroTransformableData): Work =
+    Work(
       identifiers = List(SourceIdentifier("Miro", "MiroID", MiroID)),
-      label = miroData.image_title.getOrElse("<no label found>"),
-      description = miroData.image_image_desc.getOrElse("<no description found>"),
-      lettering = miroData.image_supp_lettering.getOrElse("<no lettering found>"),
+      label = miroData.title.getOrElse("no label found"),
+      description = miroData.imageDesc,
+      lettering = miroData.suppLettering,
       hasCreatedDate = None,
       hasCreator = List()
     )

--- a/common/src/main/scala/uk/ac/wellcome/models/Work.scala
+++ b/common/src/main/scala/uk/ac/wellcome/models/Work.scala
@@ -12,10 +12,18 @@ case class SourceIdentifier(source: String, sourceId: String, value: String)
 
 case class IdentifiedWork(canonicalId: String, work: Work)
 
-/** A representation of an item in our ontology, without a canonical identifier */
+/** A representation of a work in our ontology, without a
+ *  canonical identifier.
+ */
 case class Work(
   identifiers: List[SourceIdentifier],
   label: String,
+  description: Option[String] = None,
+  lettering: Option[String] = None,
+  hasCreatedDate: Option[String] = None,
+  hasCreator: List[String] = List(),
+
+  // TODO: Remove this field?
   accessStatus: Option[String] = None
 ) {
   @JsonProperty("type") val ldType: String = "Work"

--- a/common/src/main/scala/uk/ac/wellcome/models/Work.scala
+++ b/common/src/main/scala/uk/ac/wellcome/models/Work.scala
@@ -20,8 +20,8 @@ case class Work(
   label: String,
   description: Option[String] = None,
   lettering: Option[String] = None,
-  hasCreatedDate: Option[String] = None,
-  hasCreator: List[String] = List(),
+  hasCreatedDate: Option[Period] = None,
+  hasCreator: List[Agent] = List(),
 
   // TODO: Remove this field?
   accessStatus: Option[String] = None

--- a/common/src/test/scala/uk/ac/wellcome/models/MiroTransformableTest.scala
+++ b/common/src/test/scala/uk/ac/wellcome/models/MiroTransformableTest.scala
@@ -38,7 +38,9 @@ class MiroTransformableTest extends FunSpec with Matchers {
       data = """{"image_title": "A picture of a parrot"}""",
       expectedWork = Work(
         identifiers = List(SourceIdentifier("Miro", "MiroID", "M0000001")),
-        label = "A picture of a parrot"
+        label = "A picture of a parrot",
+        hasCreatedDate = Some(Period("early 20th century")),
+        hasCreator = List(Agent("Henry Wellcome"))
       )
     )
   }
@@ -50,7 +52,9 @@ class MiroTransformableTest extends FunSpec with Matchers {
       data = s"""{"image_title": "A cartoon of a cat", "foo": "bar", "baz": "bat"}""",
       expectedWork = Work(
         identifiers = List(SourceIdentifier("Miro", "MiroID", "M0000002")),
-        label = "A cartoon of a cat"
+        label = "A cartoon of a cat",
+        hasCreatedDate = Some(Period("early 20th century")),
+        hasCreator = List(Agent("Henry Wellcome"))
       )
     )
   }

--- a/common/src/test/scala/uk/ac/wellcome/models/MiroTransformableTest.scala
+++ b/common/src/test/scala/uk/ac/wellcome/models/MiroTransformableTest.scala
@@ -3,50 +3,79 @@ package uk.ac.wellcome.models
 import org.scalatest.{FunSpec, Matchers}
 
 class MiroTransformableTest extends FunSpec with Matchers {
-  it("should be able to transform itself into a unified item") {
-    val miroId = "123"
-    val imageTitle = "some image title"
-    val miroTransformable =
-      MiroTransformable(miroId,
-                        "Images-A",
-                        s"""{"image_title": "$imageTitle"}""")
+
+  /** Given all the required data for the transform step, and the expected
+   *  final result, assert the transform behaves correctly.
+   */
+  def assertTransformIsSuccessful(miroID: String, miroCollection: String, data: String, expectedWork: Work) {
+    val miroTransformable = MiroTransformable(
+      MiroID = miroID,
+      MiroCollection = miroCollection,
+      data = data
+    )
 
     miroTransformable.transform.isSuccess shouldBe true
-    miroTransformable.transform.get shouldBe Work(
-      identifiers = List(SourceIdentifier("Miro", "MiroID", miroId)),
-      label = imageTitle)
+    miroTransformable.transform.get shouldBe expectedWork
   }
 
-  it("should be able to transform itself into a unified item if the data fields contains more fields") {
-    val miroId = "123"
-    val imageTitle = "some image title"
-    val miroTransformable =
-      MiroTransformable(
-        miroId,
-        "Images-A",
-        s"""{"image_title": "$imageTitle", "image_web_thumb_height": "84", "image_web_thumb_width": "56"}""")
-
-    miroTransformable.transform.isSuccess shouldBe true
-    miroTransformable.transform.get shouldBe Work(
-      identifiers = List(SourceIdentifier("Miro", "MiroID", miroId)),
-      label = imageTitle)
-  }
-
-  it("should be able to transform itself into a unified item if the data field is empty") {
-    val miroId = "123"
-    val miroTransformable =
-      MiroTransformable(miroId, "Images-A", """{}""")
-
-    miroTransformable.transform.isSuccess shouldBe true
-    miroTransformable.transform.get shouldBe Work(
-      identifiers = List(SourceIdentifier("Miro", "MiroID", miroId)), label = "no label found")
-  }
-
-  it("should fail transforming itself if the data field is not valid json") {
-    val miroId = "123"
-    val miroTransformable =
-      MiroTransformable(miroId, "Images-A", """not a json string""")
+  /** Given all the required data for the transform step, assert that the
+   *  transform fails.
+   */
+  def assertTransformIsFailure(miroID: String, miroCollection: String, data: String) {
+    val miroTransformable = MiroTransformable(
+      MiroID = miroID,
+      MiroCollection = miroCollection,
+      data = data
+    )
 
     miroTransformable.transform.isSuccess shouldBe false
+  }
+
+  it("should be able to transform itself into a unified item") {
+    assertTransformIsSuccessful(
+      miroID = "M0000001",
+      miroCollection = "Images-A",
+      data = """{"image_title": "A picture of a parrot"}""",
+      expectedWork = Work(
+        identifiers = List(SourceIdentifier("Miro", "MiroID", "M0000001")),
+        label = "A picture of a parrot"
+      )
+    )
+  }
+
+  it("should be able to cope with unrecognised fields in the JSON data") {
+    assertTransformIsSuccessful(
+      miroID = "M0000002",
+      miroCollection = "Images-A",
+      data = s"""{"image_title": "A cartoon of a cat", "foo": "bar", "baz": "bat"}""",
+      expectedWork = Work(
+        identifiers = List(SourceIdentifier("Miro", "MiroID", "M0000002")),
+        label = "A cartoon of a cat"
+      )
+    )
+  }
+
+  it("should fail the transform if the JSON is missing the image title") {
+    assertTransformIsFailure(
+      miroID = "M0000003",
+      miroCollection = "Images-A",
+      data = """{"not_image_title": 123}"""
+    )
+  }
+
+  it("should fail the transform if the data field is not valid JSON") {
+    assertTransformIsFailure(
+      miroID = "M0000004",
+      miroCollection = "Images-A",
+      data = """Not a valid JSON string, nope."""
+    )
+  }
+
+  it("should fail the transform if the Miro collection isn't Images-A") {
+    assertTransformIsFailure(
+      miroID = "M0000005",
+      miroCollection = "Images-Z",
+      data = """{"image_title": "A drawing of a dog"}"""
+    )
   }
 }

--- a/id_minter/src/test/scala/uk/ac/wellcome/platform/idminter/steps/WorkExtractorTest.scala
+++ b/id_minter/src/test/scala/uk/ac/wellcome/platform/idminter/steps/WorkExtractorTest.scala
@@ -14,12 +14,17 @@ class WorkExtractorTest
     with ScalaFutures
     with IntegrationPatience {
 
-  it("extracts the unified item included in the SQS message") {
-    val work =
-      Work(identifiers =
-                    List(SourceIdentifier("Miro", "MiroId", "1234")),
-                  label = "this is the item label",
-                  accessStatus = Option("super-secret"))
+  it("extracts the work included in the SQS message") {
+
+    val miroID = "M0000001"
+    val label = "A note about a narwhal"
+    val accessStatus = Option("open access")
+
+    val work = Work(
+      identifiers = List(SourceIdentifier("Miro", "MiroId", miroID)),
+      label = label,
+      accessStatus = accessStatus
+    )
     val sqsMessage = SQSMessage(Some("subject"),
                                 JsonUtil.toJson(work).get,
                                 "topic",
@@ -29,10 +34,12 @@ class WorkExtractorTest
 
     val eventualWork = WorkExtractor.toWork(message)
 
-    whenReady(eventualWork) { extractedWork =>
-      extractedWork should be(work)
-    }
 
+    whenReady(eventualWork) { extractedWork =>
+      extractedWork.identifiers.head.value shouldBe miroID
+      extractedWork.label shouldBe label
+      extractedWork.accessStatus shouldBe accessStatus
+    }
   }
 
   it("should return a failed future if it fails parsing the message it receives") {

--- a/transformer/src/test/scala/uk/ac/wellcome/transformer/receive/RecordReceiverTest.scala
+++ b/transformer/src/test/scala/uk/ac/wellcome/transformer/receive/RecordReceiverTest.scala
@@ -67,7 +67,7 @@ class RecordReceiverTest
     val future = recordReceiver.receiveRecord(new RecordAdapter(calmRecord))
 
     whenReady(future.failed) { x =>
-      x.getMessage should startWith("Unable to transform into unified item")
+      x.getMessage should startWith("Unable to transform into Work")
     }
   }
 
@@ -116,7 +116,7 @@ class RecordReceiverTest
     when(transformableParser.extractTransformable(recordMap)).thenReturn(Try {
       new Transformable {
         override def transform: Try[Work] = Try {
-          throw new RuntimeException("Unable to transform into unified item")
+          throw new RuntimeException("Unable to transform into Work")
         }
       }
     })


### PR DESCRIPTION
## What is this PR trying to achieve?

Start to transform Miro data to match the schema defined in #129.

## Who is this change for?

End-users of the API.

## Have the following been considered/are they needed?

- [x] Tests?
- [x] Docs?
- [x] Spoken to the right people?
