### PR TITLE
/s/UnifiedItem/Work

### DIFF
--- a/api/src/main/scala/uk/ac/wellcome/platform/api/models/Record.scala
+++ b/api/src/main/scala/uk/ac/wellcome/platform/api/models/Record.scala
@@ -2,7 +2,7 @@ package uk.ac.wellcome.platform.api.models
 
 import com.fasterxml.jackson.annotation.JsonProperty
 import com.sksamuel.elastic4s.searches.RichSearchHit
-import uk.ac.wellcome.models.{IdentifiedUnifiedItem, UnifiedItem}
+import uk.ac.wellcome.models.{IdentifiedWork, Work}
 import uk.ac.wellcome.utils.JsonUtil
 
 case class Record(
@@ -12,12 +12,12 @@ case class Record(
 )
 case object Record {
   def apply(hit: RichSearchHit): Record = {
-    val identifiedUnifiedItem =
-      JsonUtil.fromJson[IdentifiedUnifiedItem](hit.sourceAsString).get
+    val identifiedWork =
+      JsonUtil.fromJson[IdentifiedWork](hit.sourceAsString).get
 
     Record(
-      id = identifiedUnifiedItem.canonicalId,
-      label = identifiedUnifiedItem.unifiedItem.label
+      id = identifiedWork.canonicalId,
+      label = identifiedWork.work.label
     )
   }
 }

--- a/api/src/test/scala/uk/ac/wellcome/platform/api/ApiWorksTest.scala
+++ b/api/src/test/scala/uk/ac/wellcome/platform/api/ApiWorksTest.scala
@@ -5,15 +5,15 @@ import com.twitter.finagle.http.Status
 import com.twitter.finatra.http.EmbeddedHttpServer
 import com.twitter.inject.server.FeatureTest
 import uk.ac.wellcome.models.{
-  IdentifiedUnifiedItem,
+  IdentifiedWork,
   SourceIdentifier,
-  UnifiedItem
+  Work
 }
 import uk.ac.wellcome.test.utils.ElasticSearchLocal
 
 class ApiWorksTest extends FeatureTest with ElasticSearchLocal {
 
-  implicit val jsonMapper = IdentifiedUnifiedItem
+  implicit val jsonMapper = IdentifiedWork
   override val server =
     new EmbeddedHttpServer(
       new Server,
@@ -31,19 +31,19 @@ class ApiWorksTest extends FeatureTest with ElasticSearchLocal {
 
   test("it should return a list of works") {
 
-    val firstIdentifiedUnifiedItem =
-      identifiedUnifiedItemWith(canonicalId = "1234",
+    val firstIdentifiedWork =
+      identifiedWorkWith(canonicalId = "1234",
                                 label = "this is the first image label")
-    val secondIdentifiedUnifiedItem =
-      identifiedUnifiedItemWith(canonicalId = "4321",
+    val secondIdentifiedWork =
+      identifiedWorkWith(canonicalId = "4321",
                                 label = "this is the second image label")
-    val thirdIdentifiedUnifiedItem =
-      identifiedUnifiedItemWith(canonicalId = "9876",
+    val thirdIdentifiedWork =
+      identifiedWorkWith(canonicalId = "9876",
                                 label = "this is the third image label")
 
-    insertIntoElasticSearch(firstIdentifiedUnifiedItem)
-    insertIntoElasticSearch(secondIdentifiedUnifiedItem)
-    insertIntoElasticSearch(thirdIdentifiedUnifiedItem)
+    insertIntoElasticSearch(firstIdentifiedWork)
+    insertIntoElasticSearch(secondIdentifiedWork)
+    insertIntoElasticSearch(thirdIdentifiedWork)
 
     eventually {
       server.httpGet(
@@ -57,18 +57,18 @@ class ApiWorksTest extends FeatureTest with ElasticSearchLocal {
             |  "results": [
             |   {
             |     "type": "Work",
-            |     "id": "${firstIdentifiedUnifiedItem.canonicalId}",
-            |     "label": "${firstIdentifiedUnifiedItem.unifiedItem.label}"
+            |     "id": "${firstIdentifiedWork.canonicalId}",
+            |     "label": "${firstIdentifiedWork.work.label}"
             |   },
             |   {
             |     "type": "Work",
-            |     "id": "${secondIdentifiedUnifiedItem.canonicalId}",
-            |     "label": "${secondIdentifiedUnifiedItem.unifiedItem.label}"
+            |     "id": "${secondIdentifiedWork.canonicalId}",
+            |     "label": "${secondIdentifiedWork.work.label}"
             |   },
             |   {
             |     "type": "Work",
-            |     "id": "${thirdIdentifiedUnifiedItem.canonicalId}",
-            |     "label": "${thirdIdentifiedUnifiedItem.unifiedItem.label}"
+            |     "id": "${thirdIdentifiedWork.canonicalId}",
+            |     "label": "${thirdIdentifiedWork.work.label}"
             |   }
             |  ]
             |}
@@ -78,10 +78,10 @@ class ApiWorksTest extends FeatureTest with ElasticSearchLocal {
   }
 
   test("it should return a single work when requested with id") {
-    val identifiedUnifiedItem =
-      identifiedUnifiedItemWith(canonicalId = "1234",
+    val identifiedWork =
+      identifiedWorkWith(canonicalId = "1234",
                                 label = "this is the first image title")
-    insertIntoElasticSearch(identifiedUnifiedItem)
+    insertIntoElasticSearch(identifiedWork)
 
     eventually {
       server.httpGet(
@@ -108,14 +108,14 @@ class ApiWorksTest extends FeatureTest with ElasticSearchLocal {
   }
 
   private def insertIntoElasticSearch(
-    identifiedUnifiedItem: IdentifiedUnifiedItem): Any = {
+    identifiedWork: IdentifiedWork): Any = {
     elasticClient.execute(
-      indexInto(index / itemType).doc(identifiedUnifiedItem))
+      indexInto(index / itemType).doc(identifiedWork))
   }
 
-  private def identifiedUnifiedItemWith(canonicalId: String, label: String) = {
-    IdentifiedUnifiedItem(canonicalId = canonicalId,
-                          unifiedItem = UnifiedItem(
+  private def identifiedWorkWith(canonicalId: String, label: String) = {
+    IdentifiedWork(canonicalId = canonicalId,
+                          work = Work(
                             identifiers =
                               List(SourceIdentifier("Miro", "MiroID", "5678")),
                             label = label))

--- a/api/src/test/scala/uk/ac/wellcome/platform/api/services/ElasticSearchServiceTest.scala
+++ b/api/src/test/scala/uk/ac/wellcome/platform/api/services/ElasticSearchServiceTest.scala
@@ -3,9 +3,9 @@ package uk.ac.wellcome.platform.api.services
 import com.sksamuel.elastic4s.ElasticDsl._
 import org.scalatest.{AsyncFunSpec, Matchers}
 import uk.ac.wellcome.models.{
-  IdentifiedUnifiedItem,
+  IdentifiedWork,
   SourceIdentifier,
-  UnifiedItem
+  Work
 }
 import uk.ac.wellcome.platform.api.models.Record
 import uk.ac.wellcome.test.utils.ElasticSearchLocal
@@ -20,14 +20,14 @@ class ElasticSearchServiceTest
   val elasticService = new ElasticSearchService(index, itemType, elasticClient)
 
   it("should return the records in Elasticsearch") {
-    val firstIdentifiedUnifiedItem =
-      identifiedUnifiedItemWith(canonicalId = "1234",
+    val firstIdentifiedWork =
+      identifiedWorkWith(canonicalId = "1234",
                                 label = "this is the first item label")
-    val secondIdentifiedUnifiedItem =
-      identifiedUnifiedItemWith(canonicalId = "5678",
+    val secondIdentifiedWork =
+      identifiedWorkWith(canonicalId = "5678",
                                 label = "this is the second item label")
-    insertIntoElasticSearch(firstIdentifiedUnifiedItem,
-                            secondIdentifiedUnifiedItem)
+    insertIntoElasticSearch(firstIdentifiedWork,
+                            secondIdentifiedWork)
 
     val recordsFuture = elasticService.findRecords()
 
@@ -35,18 +35,18 @@ class ElasticSearchServiceTest
       records should have size 2
       records.head shouldBe Record(
         "Work",
-        firstIdentifiedUnifiedItem.canonicalId,
-        firstIdentifiedUnifiedItem.unifiedItem.label)
+        firstIdentifiedWork.canonicalId,
+        firstIdentifiedWork.work.label)
       records.tail.head shouldBe Record(
         "Work",
-        secondIdentifiedUnifiedItem.canonicalId,
-        secondIdentifiedUnifiedItem.unifiedItem.label)
+        secondIdentifiedWork.canonicalId,
+        secondIdentifiedWork.work.label)
     }
   }
 
   it("should find a record by id") {
     insertIntoElasticSearch(
-      identifiedUnifiedItemWith(canonicalId = "1234",
+      identifiedWorkWith(canonicalId = "1234",
                                 label = "this is the item label"))
 
     val recordsFuture = elasticService.findRecordById("1234")
@@ -58,11 +58,11 @@ class ElasticSearchServiceTest
   }
 
   private def insertIntoElasticSearch(
-    identifiedUnifiedItems: IdentifiedUnifiedItem*) = {
-    identifiedUnifiedItems.foreach { identifiedUnifiedItem =>
+    identifiedWorks: IdentifiedWork*) = {
+    identifiedWorks.foreach { identifiedWork =>
       elasticClient.execute(
         indexInto(index / itemType)
-          .doc(JsonUtil.toJson(identifiedUnifiedItem).get))
+          .doc(JsonUtil.toJson(identifiedWork).get))
     }
     eventually {
       elasticClient
@@ -70,13 +70,13 @@ class ElasticSearchServiceTest
           search(index).matchAll()
         }
         .await
-        .hits should have size identifiedUnifiedItems.size
+        .hits should have size identifiedWorks.size
     }
   }
 
-  private def identifiedUnifiedItemWith(canonicalId: String, label: String) = {
-    IdentifiedUnifiedItem(canonicalId,
-                          UnifiedItem(identifiers = List(
+  private def identifiedWorkWith(canonicalId: String, label: String) = {
+    IdentifiedWork(canonicalId,
+                          Work(identifiers = List(
                                         SourceIdentifier(source = "Calm",
                                                          sourceId = "AltRefNo",
                                                          value = "calmid")),

--- a/common/src/main/scala/uk/ac/wellcome/models/Transformable.scala
+++ b/common/src/main/scala/uk/ac/wellcome/models/Transformable.scala
@@ -4,7 +4,7 @@ import uk.ac.wellcome.utils.JsonUtil
 import scala.util.Try
 
 trait Transformable {
-  def transform: Try[UnifiedItem]
+  def transform: Try[Work]
 }
 
 case class MiroTransformableData(image_title: Option[String])
@@ -13,9 +13,9 @@ case class MiroTransformable(MiroID: String,
                              MiroCollection: String,
                              data: String)
     extends Transformable {
-  override def transform: Try[UnifiedItem] =
+  override def transform: Try[Work] =
     JsonUtil.fromJson[MiroTransformableData](data).map { miroData =>
-      UnifiedItem(identifiers =
+      Work(identifiers =
                     List(SourceIdentifier("Miro", "MiroID", MiroID)),
                   label = miroData.image_title.getOrElse("no label found"))
     }
@@ -24,8 +24,8 @@ case class MiroTransformable(MiroID: String,
 case class CalmDataTransformable(
   AccessStatus: Array[String]
 ) extends Transformable {
-  def transform: Try[UnifiedItem] = Try {
-    UnifiedItem(
+  def transform: Try[Work] = Try {
+    Work(
       identifiers = List(SourceIdentifier("source", "key", "value")),
       label = "calm data label",
       accessStatus = AccessStatus.headOption
@@ -42,7 +42,7 @@ case class CalmTransformable(
   data: String
 ) extends Transformable {
 
-  def transform: Try[UnifiedItem] =
+  def transform: Try[Work] =
     JsonUtil
       .fromJson[CalmDataTransformable](data)
       .flatMap(_.transform)

--- a/common/src/main/scala/uk/ac/wellcome/models/Work.scala
+++ b/common/src/main/scala/uk/ac/wellcome/models/Work.scala
@@ -9,14 +9,14 @@ case class Identifier(CanonicalID: String, MiroID: String)
 /** An identifier received from one of the original sources */
 case class SourceIdentifier(source: String, sourceId: String, value: String)
 
-case class IdentifiedUnifiedItem(canonicalId: String, unifiedItem: UnifiedItem)
+case class IdentifiedWork(canonicalId: String, work: Work)
 
 /** A representation of an item in our ontology, without a canonical identifier */
-case class UnifiedItem(identifiers: List[SourceIdentifier],
+case class Work(identifiers: List[SourceIdentifier],
                        label: String,
                        accessStatus: Option[String] = None)
 
-object IdentifiedUnifiedItem extends Indexable[IdentifiedUnifiedItem] {
-  override def json(t: IdentifiedUnifiedItem): String =
+object IdentifiedWork extends Indexable[IdentifiedWork] {
+  override def json(t: IdentifiedWork): String =
     JsonUtil.toJson(t).get
 }

--- a/common/src/test/scala/uk/ac/wellcome/models/MiroTransformableTest.scala
+++ b/common/src/test/scala/uk/ac/wellcome/models/MiroTransformableTest.scala
@@ -12,7 +12,7 @@ class MiroTransformableTest extends FunSpec with Matchers {
                         s"""{"image_title": "$imageTitle"}""")
 
     miroTransformable.transform.isSuccess shouldBe true
-    miroTransformable.transform.get shouldBe UnifiedItem(
+    miroTransformable.transform.get shouldBe Work(
       identifiers = List(SourceIdentifier("Miro", "MiroID", miroId)),
       label = imageTitle)
   }
@@ -27,7 +27,7 @@ class MiroTransformableTest extends FunSpec with Matchers {
         s"""{"image_title": "$imageTitle", "image_web_thumb_height": "84", "image_web_thumb_width": "56"}""")
 
     miroTransformable.transform.isSuccess shouldBe true
-    miroTransformable.transform.get shouldBe UnifiedItem(
+    miroTransformable.transform.get shouldBe Work(
       identifiers = List(SourceIdentifier("Miro", "MiroID", miroId)),
       label = imageTitle)
   }
@@ -38,7 +38,7 @@ class MiroTransformableTest extends FunSpec with Matchers {
       MiroTransformable(miroId, "Images-A", """{}""")
 
     miroTransformable.transform.isSuccess shouldBe true
-    miroTransformable.transform.get shouldBe UnifiedItem(
+    miroTransformable.transform.get shouldBe Work(
       identifiers = List(SourceIdentifier("Miro", "MiroID", miroId)), label = "no label found")
   }
 

--- a/id_minter/src/main/scala/uk/ac/wellcome/platform/idminter/modules/IdMinterModule.scala
+++ b/id_minter/src/main/scala/uk/ac/wellcome/platform/idminter/modules/IdMinterModule.scala
@@ -2,10 +2,10 @@ package uk.ac.wellcome.platform.idminter.modules
 
 import akka.actor.ActorSystem
 import com.twitter.inject.{Injector, TwitterModule}
-import uk.ac.wellcome.models.{IdentifiedUnifiedItem, UnifiedItem}
+import uk.ac.wellcome.models.{IdentifiedWork, Work}
 import uk.ac.wellcome.platform.idminter.steps.{
   IdentifierGenerator,
-  UnifiedItemExtractor
+  WorkExtractor
 }
 import uk.ac.wellcome.sns.SNSWriter
 import uk.ac.wellcome.sqs.SQSReader
@@ -31,17 +31,17 @@ object IdMinterModule extends TwitterModule with TryBackoff {
 
     sqsReader.retrieveAndDeleteMessages { message =>
       for {
-        unifiedItem <- UnifiedItemExtractor.toUnifiedItem(message)
-        canonicalId <- idGenerator.generateId(unifiedItem)
+        work <- WorkExtractor.toWork(message)
+        canonicalId <- idGenerator.generateId(work)
         _ <- snsWriter.writeMessage(
-          toIdentifiedUnifiedItemJson(unifiedItem, canonicalId),
+          toIdentifiedWorkJson(work, canonicalId),
           Some(snsSubject))
       } yield ()
     }
   }
 
-  private def toIdentifiedUnifiedItemJson(unifiedItem: UnifiedItem,
+  private def toIdentifiedWorkJson(work: Work,
                                           canonicalId: String) = {
-    JsonUtil.toJson(IdentifiedUnifiedItem(canonicalId, unifiedItem)).get
+    JsonUtil.toJson(IdentifiedWork(canonicalId, work)).get
   }
 }

--- a/id_minter/src/main/scala/uk/ac/wellcome/platform/idminter/steps/IdentifierGenerator.scala
+++ b/id_minter/src/main/scala/uk/ac/wellcome/platform/idminter/steps/IdentifierGenerator.scala
@@ -6,7 +6,7 @@ import com.gu.scanamo.Scanamo
 import com.gu.scanamo.syntax._
 import com.twitter.inject.{Logging, TwitterModuleFlags}
 import uk.ac.wellcome.models.aws.DynamoConfig
-import uk.ac.wellcome.models.{Identifier, SourceIdentifier, UnifiedItem}
+import uk.ac.wellcome.models.{Identifier, SourceIdentifier, Work}
 import uk.ac.wellcome.platform.idminter.utils.Identifiable
 import uk.ac.wellcome.utils.GlobalExecutionContext.context
 import scala.concurrent.blocking
@@ -20,13 +20,13 @@ class IdentifierGenerator @Inject()(dynamoDBClient: AmazonDynamoDB,
 
   private val identifiersTableName = dynamoConfig.table
 
-  def generateId(unifiedItem: UnifiedItem): Future[String] =
-    findMiroID(unifiedItem) match {
+  def generateId(work: Work): Future[String] =
+    findMiroID(work) match {
       case Some(identifier) => retrieveOrGenerateCanonicalId(identifier)
       case None =>
-        error(s"Item $unifiedItem did not contain a MiroID")
+        error(s"Item $work did not contain a MiroID")
         Future.failed(
-          new Exception(s"Item $unifiedItem did not contain a MiroID"))
+          new Exception(s"Item $work did not contain a MiroID"))
     }
 
   private def retrieveOrGenerateCanonicalId(identifier: SourceIdentifier) =
@@ -44,8 +44,8 @@ class IdentifierGenerator @Inject()(dynamoDBClient: AmazonDynamoDB,
           s"Error in parsing the object with MiroID ${identifier.value}")
     }
 
-  private def findMiroID(unifiedItem: UnifiedItem) = {
-    val maybeSourceIdentifier = unifiedItem.identifiers.find(identifier =>
+  private def findMiroID(work: Work) = {
+    val maybeSourceIdentifier = work.identifiers.find(identifier =>
       identifier.sourceId == "MiroID")
     info(s"SourceIdentifier: $maybeSourceIdentifier")
     maybeSourceIdentifier

--- a/id_minter/src/main/scala/uk/ac/wellcome/platform/idminter/steps/WorkExtractor.scala
+++ b/id_minter/src/main/scala/uk/ac/wellcome/platform/idminter/steps/WorkExtractor.scala
@@ -2,34 +2,34 @@ package uk.ac.wellcome.platform.idminter.steps
 
 import com.amazonaws.services.sqs.model.Message
 import com.twitter.inject.Logging
-import uk.ac.wellcome.models.UnifiedItem
+import uk.ac.wellcome.models.Work
 import uk.ac.wellcome.models.aws.SQSMessage
 import uk.ac.wellcome.utils.GlobalExecutionContext.context
 import uk.ac.wellcome.utils.JsonUtil
 
 import scala.concurrent.Future
 
-object UnifiedItemExtractor extends Logging {
+object WorkExtractor extends Logging {
 
-  def toUnifiedItem(message: Message): Future[UnifiedItem] =
+  def toWork(message: Message): Future[Work] =
     Future
       .fromTry {
-        tryExtractinUnifiedItem(message)
+        tryExtractinWork(message)
       }
-      .map { unifiedItem =>
-        info(s"Successfully extracted unified item $unifiedItem")
-        unifiedItem
+      .map { work =>
+        info(s"Successfully extracted unified item $work")
+        work
       } recover {
       case e: Throwable =>
         error("Failed extracting unified item from AWS message", e)
         throw e
     }
 
-  private def tryExtractinUnifiedItem(message: Message) = {
+  private def tryExtractinWork(message: Message) = {
     info(s"Parsing SQSMessage ${message.getBody}")
     JsonUtil.fromJson[SQSMessage](message.getBody).flatMap { sqsMessage =>
-      info(s"Extracting UnifiedItem from SQSMessage $sqsMessage")
-      JsonUtil.fromJson[UnifiedItem](sqsMessage.body)
+      info(s"Extracting Work from SQSMessage $sqsMessage")
+      JsonUtil.fromJson[Work](sqsMessage.body)
     }
   }
 }

--- a/id_minter/src/test/scala/uk/ac/wellcome/platform/idminter/IdMinterFeatureTest.scala
+++ b/id_minter/src/test/scala/uk/ac/wellcome/platform/idminter/IdMinterFeatureTest.scala
@@ -9,7 +9,7 @@ import org.scalatest.FunSpec
 import org.scalatest.concurrent.{Eventually, IntegrationPatience}
 import uk.ac.wellcome.finatra.modules._
 import uk.ac.wellcome.models.aws.SQSMessage
-import uk.ac.wellcome.models.{IdentifiedUnifiedItem, Identifier, SourceIdentifier, UnifiedItem}
+import uk.ac.wellcome.models.{IdentifiedWork, Identifier, SourceIdentifier, Work}
 import uk.ac.wellcome.platform.idminter.modules.IdMinterModule
 import uk.ac.wellcome.test.utils.{DynamoDBLocal, SNSLocal, SQSLocal}
 import uk.ac.wellcome.utils.JsonUtil
@@ -46,13 +46,13 @@ class IdMinterFeatureTest
   ))
 
   it("should read a unified item from the SQS queue, generate a canonical id, save it in dynamoDB and send a message to the SNS topic with the original unified item and the id") {
-    val unifiedItem =
-      UnifiedItem(identifiers =
+    val work =
+      Work(identifiers =
                     List(SourceIdentifier("Miro", "MiroID", "1234")),
                   label = "some label",
                   accessStatus = Option("super-secret"))
     val sqsMessage = SQSMessage(Some("subject"),
-                                JsonUtil.toJson(unifiedItem).get,
+                                JsonUtil.toJson(work).get,
                                 "topic",
                                 "messageType",
                                 "timestamp")
@@ -69,8 +69,8 @@ class IdMinterFeatureTest
       val messages = listMessagesReceivedFromSNS()
       messages should have size (1)
       JsonUtil
-        .fromJson[IdentifiedUnifiedItem](messages.head.message)
-        .get shouldBe IdentifiedUnifiedItem(id.CanonicalID, unifiedItem)
+        .fromJson[IdentifiedWork](messages.head.message)
+        .get shouldBe IdentifiedWork(id.CanonicalID, work)
       messages.head.subject should be("identified-item")
     }
   }
@@ -112,12 +112,12 @@ class IdMinterFeatureTest
   }
 
   private def generateSqsMessage(MiroID: String) = {
-    val unifiedItem = UnifiedItem(
+    val work = Work(
       identifiers = List(SourceIdentifier("Miro", "MiroID", MiroID)),
       label = "some label",
       accessStatus = Option("super-secret"))
     SQSMessage(Some("subject"),
-               JsonUtil.toJson(unifiedItem).get,
+               JsonUtil.toJson(work).get,
                "topic",
                "messageType",
                "timestamp")

--- a/id_minter/src/test/scala/uk/ac/wellcome/platform/idminter/steps/IdentifierGeneratorTest.scala
+++ b/id_minter/src/test/scala/uk/ac/wellcome/platform/idminter/steps/IdentifierGeneratorTest.scala
@@ -5,7 +5,7 @@ import com.gu.scanamo.syntax._
 import org.scalatest.concurrent.{IntegrationPatience, ScalaFutures}
 import org.scalatest.{BeforeAndAfterEach, FunSpec, Matchers}
 import uk.ac.wellcome.models.aws.DynamoConfig
-import uk.ac.wellcome.models.{Identifier, SourceIdentifier, UnifiedItem}
+import uk.ac.wellcome.models.{Identifier, SourceIdentifier, Work}
 import uk.ac.wellcome.test.utils.DynamoDBLocal
 
 class IdentifierGeneratorTest
@@ -27,10 +27,10 @@ class IdentifierGeneratorTest
     Scanamo.put(dynamoDbClient)(identifiersTableName)(
       Identifier("5678", "1234"))
 
-    val unifiedItem =
-      UnifiedItem(
+    val work =
+      Work(
         identifiers = List(SourceIdentifier("Miro", "MiroID", "1234")), label = "some label")
-    val futureId = identifierGenerator.generateId(unifiedItem)
+    val futureId = identifierGenerator.generateId(work)
 
     whenReady(futureId) { id =>
       id shouldBe "5678"
@@ -38,10 +38,10 @@ class IdentifierGeneratorTest
   }
 
   it("should generate an id and save it in the database if a record doesn't already exist") {
-    val unifiedItem =
-      UnifiedItem(
+    val work =
+      Work(
         identifiers = List(SourceIdentifier("Miro", "MiroID", "1234")), label = "some label")
-    val futureId = identifierGenerator.generateId(unifiedItem)
+    val futureId = identifierGenerator.generateId(work)
 
     whenReady(futureId) { id =>
       id should not be (empty)
@@ -52,13 +52,13 @@ class IdentifierGeneratorTest
   }
 
   it("should reject an item with no miroId in the list of Identifiers") {
-    val unifiedItem =
-      UnifiedItem(
+    val work =
+      Work(
         identifiers = List(SourceIdentifier("NotMiro", "NotMiroID", "1234")), label = "some label")
-    val futureId = identifierGenerator.generateId(unifiedItem)
+    val futureId = identifierGenerator.generateId(work)
 
     whenReady(futureId.failed) { exception =>
-      exception.getMessage shouldBe s"Item $unifiedItem did not contain a MiroID"
+      exception.getMessage shouldBe s"Item $work did not contain a MiroID"
     }
   }
 
@@ -69,10 +69,10 @@ class IdentifierGeneratorTest
     Scanamo.put(dynamoDbClient)(identifiersTableName)(
       Identifier("8765", miroId))
 
-    val unifiedItem =
-      UnifiedItem(
+    val work =
+      Work(
         identifiers = List(SourceIdentifier("Miro", "MiroID", miroId)), label = "some label")
-    val futureId = identifierGenerator.generateId(unifiedItem)
+    val futureId = identifierGenerator.generateId(work)
 
     whenReady(futureId.failed) { exception =>
       exception.getMessage shouldBe s"Found more than one record with MiroID $miroId"

--- a/id_minter/src/test/scala/uk/ac/wellcome/platform/idminter/steps/WorkExtractorTest.scala
+++ b/id_minter/src/test/scala/uk/ac/wellcome/platform/idminter/steps/WorkExtractorTest.scala
@@ -5,32 +5,32 @@ import com.fasterxml.jackson.core.JsonParseException
 import org.scalatest.concurrent.{IntegrationPatience, ScalaFutures}
 import org.scalatest.{FunSpec, Matchers}
 import uk.ac.wellcome.models.aws.SQSMessage
-import uk.ac.wellcome.models.{SourceIdentifier, UnifiedItem}
+import uk.ac.wellcome.models.{SourceIdentifier, Work}
 import uk.ac.wellcome.utils.JsonUtil
 
-class UnifiedItemExtractorTest
+class WorkExtractorTest
     extends FunSpec
     with Matchers
     with ScalaFutures
     with IntegrationPatience {
 
   it("extracts the unified item included in the SQS message") {
-    val unifiedItem =
-      UnifiedItem(identifiers =
+    val work =
+      Work(identifiers =
                     List(SourceIdentifier("Miro", "MiroId", "1234")),
                   label = "this is the item label",
                   accessStatus = Option("super-secret"))
     val sqsMessage = SQSMessage(Some("subject"),
-                                JsonUtil.toJson(unifiedItem).get,
+                                JsonUtil.toJson(work).get,
                                 "topic",
                                 "messageType",
                                 "timestamp")
     val message = new Message().withBody(JsonUtil.toJson(sqsMessage).get)
 
-    val eventualUnifiedItem = UnifiedItemExtractor.toUnifiedItem(message)
+    val eventualWork = WorkExtractor.toWork(message)
 
-    whenReady(eventualUnifiedItem) { extractedUnifiedItem =>
-      extractedUnifiedItem should be(unifiedItem)
+    whenReady(eventualWork) { extractedWork =>
+      extractedWork should be(work)
     }
 
   }
@@ -43,9 +43,9 @@ class UnifiedItemExtractorTest
                                 "timestamp")
     val message = new Message().withBody(JsonUtil.toJson(sqsMessage).get)
 
-    val eventualUnifiedItem = UnifiedItemExtractor.toUnifiedItem(message)
+    val eventualWork = WorkExtractor.toWork(message)
 
-    whenReady(eventualUnifiedItem.failed) { e =>
+    whenReady(eventualWork.failed) { e =>
       e shouldBe a[JsonParseException]
     }
   }

--- a/ingestor/src/main/scala/uk/ac/wellcome/platform/ingestor/modules/SQSWorker.scala
+++ b/ingestor/src/main/scala/uk/ac/wellcome/platform/ingestor/modules/SQSWorker.scala
@@ -4,7 +4,7 @@ import akka.actor.ActorSystem
 import com.amazonaws.services.sqs.model.{Message => AwsSQSMessage}
 import com.twitter.inject.{Injector, TwitterModule}
 import uk.ac.wellcome.models.aws.SQSMessage
-import uk.ac.wellcome.platform.ingestor.services.IdentifiedUnifiedItemIndexer
+import uk.ac.wellcome.platform.ingestor.services.IdentifiedWorkIndexer
 import uk.ac.wellcome.sqs.SQSReader
 import uk.ac.wellcome.utils.{JsonUtil, TryBackoff}
 
@@ -19,17 +19,17 @@ object SQSWorker extends TwitterModule with TryBackoff {
 
     val system = injector.instance[ActorSystem]
     val sqsReader = injector.instance[SQSReader]
-    val indexer = injector.instance[IdentifiedUnifiedItemIndexer]
+    val indexer = injector.instance[IdentifiedWorkIndexer]
 
     run(() => processMessages(sqsReader, indexer), system)
   }
 
   private def processMessages(
     sqsReader: SQSReader,
-    indexer: IdentifiedUnifiedItemIndexer): Unit = {
+    indexer: IdentifiedWorkIndexer): Unit = {
     sqsReader.retrieveAndDeleteMessages { message =>
       extractMessage(message).map { sqsMessage =>
-        indexer.indexIdentifiedUnifiedItem(sqsMessage.body)
+        indexer.indexIdentifiedWork(sqsMessage.body)
       }
     }
   }

--- a/ingestor/src/main/scala/uk/ac/wellcome/platform/ingestor/services/IdentifiedWorkIndexer.scala
+++ b/ingestor/src/main/scala/uk/ac/wellcome/platform/ingestor/services/IdentifiedWorkIndexer.scala
@@ -7,24 +7,24 @@ import com.sksamuel.elastic4s.ElasticDsl._
 import com.sksamuel.elastic4s.indexes.RichIndexResponse
 import com.twitter.inject.Logging
 import com.twitter.inject.annotations.Flag
-import uk.ac.wellcome.models.IdentifiedUnifiedItem
+import uk.ac.wellcome.models.IdentifiedWork
 import uk.ac.wellcome.utils.GlobalExecutionContext.context
 import uk.ac.wellcome.utils.JsonUtil
 
 import scala.concurrent.Future
 
 @Singleton
-class IdentifiedUnifiedItemIndexer @Inject()(
+class IdentifiedWorkIndexer @Inject()(
   @Flag("es.index") esIndex: String,
   @Flag("es.type") esType: String,
   elasticClient: ElasticClient
 ) extends Logging {
 
-  def indexIdentifiedUnifiedItem(document: String): Future[RichIndexResponse] = {
-    implicit val jsonMapper = IdentifiedUnifiedItem
+  def indexIdentifiedWork(document: String): Future[RichIndexResponse] = {
+    implicit val jsonMapper = IdentifiedWork
 
     Future
-      .fromTry(JsonUtil.fromJson[IdentifiedUnifiedItem](document))
+      .fromTry(JsonUtil.fromJson[IdentifiedWork](document))
       .flatMap(item => {
         info(s"Indexing item $item")
         elasticClient.execute {

--- a/ingestor/src/test/scala/uk/ac/wellcome/platform/ingestor/IngestorFeatureTest.scala
+++ b/ingestor/src/test/scala/uk/ac/wellcome/platform/ingestor/IngestorFeatureTest.scala
@@ -7,7 +7,7 @@ import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.{FunSpec, Matchers}
 import uk.ac.wellcome.finatra.modules._
 import uk.ac.wellcome.models.aws.SQSMessage
-import uk.ac.wellcome.models.{IdentifiedUnifiedItem, SourceIdentifier, UnifiedItem}
+import uk.ac.wellcome.models.{IdentifiedWork, SourceIdentifier, Work}
 import uk.ac.wellcome.platform.ingestor.modules.SQSWorker
 import uk.ac.wellcome.test.utils.{ElasticSearchLocal, SQSLocal}
 import uk.ac.wellcome.utils.GlobalExecutionContext.context
@@ -50,11 +50,11 @@ class IngestorFeatureTest
   )
 
   it("should read an identified unified item from the SQS queue and ingest it into Elasticsearch") {
-    val identifiedUnifiedItem = JsonUtil
+    val identifiedWork = JsonUtil
       .toJson(
-        IdentifiedUnifiedItem(
+        IdentifiedWork(
           canonicalId = "1234",
-          unifiedItem = UnifiedItem(
+          work = Work(
             identifiers = List(SourceIdentifier("Miro", "MiroID", "5678")), label = "some label")))
       .get
 
@@ -63,7 +63,7 @@ class IngestorFeatureTest
       JsonUtil
         .toJson(
           SQSMessage(Some("identified-item"),
-                     identifiedUnifiedItem,
+                     identifiedWork,
                      "ingester",
                      "messageType",
                      "timestamp"))
@@ -74,7 +74,7 @@ class IngestorFeatureTest
       val hitsFuture = elasticClient.execute(search(s"$indexName/$itemType").matchAll()).map(_.hits)
       whenReady(hitsFuture) { hits =>
         hits should have size 1
-        hits.head.sourceAsString shouldBe identifiedUnifiedItem
+        hits.head.sourceAsString shouldBe identifiedWork
       }
     }
   }

--- a/ingestor/src/test/scala/uk/ac/wellcome/platform/ingestor/services/IdentifiedWorkIndexerTest.scala
+++ b/ingestor/src/test/scala/uk/ac/wellcome/platform/ingestor/services/IdentifiedWorkIndexerTest.scala
@@ -4,14 +4,14 @@ import com.fasterxml.jackson.core.JsonParseException
 import com.sksamuel.elastic4s.ElasticDsl._
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.{FunSpec, Matchers}
-import uk.ac.wellcome.models.{IdentifiedUnifiedItem, SourceIdentifier, UnifiedItem}
+import uk.ac.wellcome.models.{IdentifiedWork, SourceIdentifier, Work}
 import uk.ac.wellcome.test.utils.ElasticSearchLocal
 import uk.ac.wellcome.utils.GlobalExecutionContext.context
 import uk.ac.wellcome.utils.JsonUtil
 
 import scala.concurrent.Future
 
-class IdentifiedUnifiedItemIndexerTest
+class IdentifiedWorkIndexerTest
     extends FunSpec
     with ScalaFutures
     with Matchers
@@ -19,25 +19,25 @@ class IdentifiedUnifiedItemIndexerTest
 
   val itemType = "item"
 
-  val identifiedUnifiedItemIndexer =
-    new IdentifiedUnifiedItemIndexer(index, itemType, elasticClient)
+  val identifiedWorkIndexer =
+    new IdentifiedWorkIndexer(index, itemType, elasticClient)
 
-  def identifiedUnifiedItemJson(canonicalId: String, sourceId: String, label: String): String = {
+  def identifiedWorkJson(canonicalId: String, sourceId: String, label: String): String = {
     JsonUtil.toJson(
-        IdentifiedUnifiedItem(
+        IdentifiedWork(
           canonicalId = canonicalId,
-          unifiedItem = UnifiedItem(
+          work = Work(
             identifiers = List(SourceIdentifier("Miro", "MiroID", sourceId)), label = label)))
       .get
   }
 
   it("should insert an identified unified item into Elasticsearch") {
 
-    val identifiedUnifiedItemString =
-      identifiedUnifiedItemJson("5678", "1234", "some label")
+    val identifiedWorkString =
+      identifiedWorkJson("5678", "1234", "some label")
 
-    val future = identifiedUnifiedItemIndexer.indexIdentifiedUnifiedItem(
-      identifiedUnifiedItemString)
+    val future = identifiedWorkIndexer.indexIdentifiedWork(
+      identifiedWorkString)
 
     whenReady(future) { _ =>
       eventually {
@@ -46,19 +46,19 @@ class IdentifiedUnifiedItemIndexerTest
           .map { _.hits }
           .await
         hits should have size 1
-        hits.head.sourceAsString shouldBe identifiedUnifiedItemString
+        hits.head.sourceAsString shouldBe identifiedWorkString
       }
     }
 
   }
 
   it("should add only one record when multiple records with same id are ingested") {
-    val identifiedUnifiedItemString =
-      identifiedUnifiedItemJson("5678", "1234", "some label")
+    val identifiedWorkString =
+      identifiedWorkJson("5678", "1234", "some label")
 
     val future = Future.sequence(
-      (1 to 2).map(_ => identifiedUnifiedItemIndexer.indexIdentifiedUnifiedItem(
-        identifiedUnifiedItemString))
+      (1 to 2).map(_ => identifiedWorkIndexer.indexIdentifiedWork(
+        identifiedWorkString))
     )
 
     whenReady(future) { _ =>
@@ -68,14 +68,14 @@ class IdentifiedUnifiedItemIndexerTest
           .map { _.hits }
           .await
         hits should have size 1
-        hits.head.sourceAsString shouldBe identifiedUnifiedItemString
+        hits.head.sourceAsString shouldBe identifiedWorkString
       }
     }
 
   }
 
   it("should return a failed future if the input string is not an identified unified item") {
-    val future = identifiedUnifiedItemIndexer.indexIdentifiedUnifiedItem("a document")
+    val future = identifiedWorkIndexer.indexIdentifiedWork("a document")
 
     whenReady(future.failed) { exception =>
       exception shouldBe a[JsonParseException]

--- a/transformer/src/test/scala/uk/ac/wellcome/transformer/CalmTransformerFeatureTest.scala
+++ b/transformer/src/test/scala/uk/ac/wellcome/transformer/CalmTransformerFeatureTest.scala
@@ -3,7 +3,7 @@ package uk.ac.wellcome.transformer
 import com.gu.scanamo.Scanamo
 import com.twitter.finatra.http.EmbeddedHttpServer
 import org.scalatest.FunSpec
-import uk.ac.wellcome.models.{CalmTransformable, SourceIdentifier, UnifiedItem}
+import uk.ac.wellcome.models.{CalmTransformable, SourceIdentifier, Work}
 import uk.ac.wellcome.test.utils.MessageInfo
 import uk.ac.wellcome.transformer.utils.TransformerFeatureTest
 import uk.ac.wellcome.utils.JsonUtil
@@ -58,7 +58,7 @@ class CalmTransformerFeatureTest extends FunSpec with TransformerFeatureTest {
     //currently for calm data we only output hardcoded sample values
     snsMessage.message shouldBe JsonUtil
       .toJson(
-        UnifiedItem(
+        Work(
           identifiers = List(SourceIdentifier("source", "key", "value")),
           label = "calm data label",
           accessStatus = AccessStatus

--- a/transformer/src/test/scala/uk/ac/wellcome/transformer/MiroTransformerFeatureTest.scala
+++ b/transformer/src/test/scala/uk/ac/wellcome/transformer/MiroTransformerFeatureTest.scala
@@ -3,7 +3,7 @@ package uk.ac.wellcome.transformer
 import com.gu.scanamo.Scanamo
 import com.twitter.finatra.http.EmbeddedHttpServer
 import org.scalatest.FunSpec
-import uk.ac.wellcome.models.{MiroTransformable, SourceIdentifier, UnifiedItem}
+import uk.ac.wellcome.models.{MiroTransformable, SourceIdentifier, Work}
 import uk.ac.wellcome.test.utils.MessageInfo
 import uk.ac.wellcome.transformer.utils.TransformerFeatureTest
 import uk.ac.wellcome.utils.JsonUtil
@@ -52,7 +52,7 @@ class MiroTransformerFeatureTest extends FunSpec with TransformerFeatureTest {
                                        imageTitle: String) = {
     snsMessage.message shouldBe JsonUtil
       .toJson(
-        UnifiedItem(identifiers =
+        Work(identifiers =
                       List(SourceIdentifier("Miro", "MiroID", miroId)),
                     label = imageTitle))
       .get


### PR DESCRIPTION
This renames all our references to "UnifiedItem" to "Work". Essentially just the result of running

```console
$ sed -ie 's/UnifiedItem/Work/g' **/*.scala
```

over the codebase, and renaming a small number of files.

The change is for developers working on the API – this means that our internal class names match the types we're sending in JSON-LD.

This addresses the first part of #234 – I’ll put the Jackson and Elasticsearch changes in a separate patch.