### PR TITLE
Remove the demo endpoint

### DIFF
--- a/api/src/main/scala/uk/ac/wellcome/platform/api/controllers/WorksController.scala
+++ b/api/src/main/scala/uk/ac/wellcome/platform/api/controllers/WorksController.scala
@@ -29,24 +29,6 @@ class WorksController @Inject()(@Flag("api.prefix") apiPrefix: String,
   override val hostName = apiHost
 
   prefix(apiPrefix) {
-    // This is a demo endpoint for the UX team to use when prototyping
-    // item pages.
-    // TODO: Remove this endpoint.
-    get(s"/demoItem") { request: Request =>
-      response.ok.json(
-        Map(
-          "@context" -> "http://id.wellcomecollection.org/",
-          "id" -> "cbsx6cvr",
-          "type" -> "item",
-          "title" -> "The natural history of monkeys",
-          "date" -> "1546-04-07",
-          "authors" -> Array("William Jardine"),
-          "description" -> "230 page, color plates : frontispiece (portrait), add. color t.page ; (8vo)",
-          "topics" -> Array("monkeys", "animals"),
-          "media" -> Array("https://wellcomelibrary.org/content/59301/60865")
-        ))
-    }
-
     getWithDoc("/works") { doc =>
       doc
         .summary("/works")


### PR DESCRIPTION
## What is this PR trying to achieve?

Remove the demo endpoint. Resolves #212.

## Who is this change for?

Platform team devs.

## Have the following been considered/are they needed?

- [x] Tests – n/a
- [x] Docs – n/a
- [x] Spoken to the right people – we confirmed in yesterday’s standup that this endpoint is no longer in use by the UX team.