### PR TITLE
Don't run Travis build for doc changes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,14 @@ sudo: required
 
 dist: trusty
 
+before_install:
+  - |
+      if ! git diff --name-only $TRAVIS_COMMIT_RANGE | grep -qvE '(.md)|(.png)|(.pdf)|(.html)|^(LICENSE)|^(docs)'
+      then
+        echo "Only doc files were updated, not running the CI."
+        exit
+      fi
+
 install:
   - ./.travis/install.sh
 


### PR DESCRIPTION
## What is this PR trying to achieve?

In order to reduce build contention, and allow faster builds - don't run CI builds for documentation changes.

## Who is this change for?

Folk who want faster releases.

## Have the following been considered/are they needed?

- [X] Tests?
- [X] Docs?
- [X] Spoken to the right people?

Code cribbed from: https://github.com/google/EarlGrey/pull/383/files