### PR TITLE
Add the "type" field to the Work class when serialising to JSON

### DIFF
--- a/api/src/test/scala/uk/ac/wellcome/platform/api/ModelsTest.scala
+++ b/api/src/test/scala/uk/ac/wellcome/platform/api/ModelsTest.scala
@@ -1,0 +1,16 @@
+package uk.ac.wellcome.platform.api
+
+import org.scalatest.{FunSpec, Matchers}
+
+import uk.ac.wellcome.models.Work
+import uk.ac.wellcome.utils.JsonUtil
+
+
+class WorkTest extends FunSpec with Matchers {
+  it("should have an LD type 'Work' when serialised to JSON") {
+    val work = Work(identifiers=List(), label="A book about a thing")
+    val jsonString = JsonUtil.toJson(work).get
+
+    jsonString.contains("""type":"Work"""") should be (true)
+  }
+}

--- a/common/src/main/scala/uk/ac/wellcome/models/Work.scala
+++ b/common/src/main/scala/uk/ac/wellcome/models/Work.scala
@@ -1,6 +1,7 @@
 package uk.ac.wellcome.models
 
-import com.sksamuel.elastic4s._
+import com.fasterxml.jackson.annotation.JsonProperty
+import com.sksamuel.elastic4s.Indexable
 import uk.ac.wellcome.utils.JsonUtil
 
 /** Represents a set of identifiers as stored in DynamoDB */
@@ -12,9 +13,13 @@ case class SourceIdentifier(source: String, sourceId: String, value: String)
 case class IdentifiedWork(canonicalId: String, work: Work)
 
 /** A representation of an item in our ontology, without a canonical identifier */
-case class Work(identifiers: List[SourceIdentifier],
-                       label: String,
-                       accessStatus: Option[String] = None)
+case class Work(
+  identifiers: List[SourceIdentifier],
+  label: String,
+  accessStatus: Option[String] = None
+) {
+  @JsonProperty("type") val ldType: String = "Work"
+}
 
 object IdentifiedWork extends Indexable[IdentifiedWork] {
   override def json(t: IdentifiedWork): String =


### PR DESCRIPTION
## What is this PR trying to achieve?

When we serialise a `Work` object to JSON, it includes a "type" field that contains the value "Work". Part of #234.

## Who is this change for?

Users of the API.

## Have the following been considered/are they needed?

- [x] Tests – done
- [x] Docs – not required.
- [x] Spoken to the right people?