### PR TITLE
Revert "Don't run Travis build for doc changes"

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,14 +4,6 @@ sudo: required
 
 dist: trusty
 
-before_install:
-  - |
-      if ! git diff --name-only $TRAVIS_COMMIT_RANGE | grep -qvE '(.md)|(.png)|(.pdf)|(.html)|^(LICENSE)|^(docs)'
-      then
-        echo "Only doc files were updated, not running the CI."
-        exit
-      fi
-
 install:
   - ./.travis/install.sh
 


### PR DESCRIPTION
This reverts commit 8d8280665e8dfe10afb29e17a7cc3919db3577c1.

It’s causing builds to be incorrectly skipped: https://travis-ci.org/wellcometrust/platform-api/jobs/229136296

I like this idea, perhaps in conjunction with #203, but it’s going to be more complicated than we thought. 😕 

