### PR TITLE
Only build pushes to master

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,10 @@ sudo: required
 
 dist: trusty
 
+branches:
+  only:
+    - master
+
 install:
   - ./.travis/install.sh
 


### PR DESCRIPTION
## What is this PR trying to achieve?

Make the builds go faster! Right now we have Travis configured to build pushes and pull requests:

* Pushes are required for us to build master (and deploy new applications)
* PRs are required if we ever want to accept contributions to people who aren’t in the core team

But the side-effect is that if we ever have a PR that's based from a branch in the main repo, we do all the builds and tests for that PR twice. This limits the Pushes to only build on master.

## Who is this change for?

Core developers who want to get their patches merged faster.

## Have the following been considered/are they needed?

- [x] Tests?
- [x] Docs?
- [x] Spoken to the right people?