### PR TITLE
Update dependencies for Elasticsearch 5.4.0

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,7 +11,7 @@ sqs:
   ports:
     - "9324:9324"
 elasticsearch:
-  image: docker.elastic.co/elasticsearch/elasticsearch:5.3.2
+  image: docker.elastic.co/elasticsearch/elasticsearch:5.4.0
   ports:
     - "9200:9200"
     - "9300:9300"

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -14,7 +14,7 @@ object Dependencies {
     val mockito = "1.9.5"
     val scalatest = "3.0.1"
     val junitInterface = "0.11"
-    val elastic4s = "5.3.2"
+    val elastic4s = "5.4.1"
     val scanamo = "0.9.1"
     val jacksonYamlVersion = "2.8.8"
   }


### PR DESCRIPTION
## What is this PR trying to achieve?

Update our dependencies for Elasticsearch 5.4.0, as there was a new elastic4s release over the weekend. Addresses the first two parts of #243.

## Who is this change for?

Developers who like to stay up-to-date.

## Have the following been considered/are they needed?

- [x] Tests?
- [x] Docs?
- [x] Spoken to the right people?
