### PR TITLE
Make the ingestor create an index with mappings in Elasticsearch

### DIFF
--- a/api/src/test/scala/uk/ac/wellcome/platform/api/services/ElasticSearchServiceTest.scala
+++ b/api/src/test/scala/uk/ac/wellcome/platform/api/services/ElasticSearchServiceTest.scala
@@ -2,11 +2,7 @@ package uk.ac.wellcome.platform.api.services
 
 import com.sksamuel.elastic4s.ElasticDsl._
 import org.scalatest.{AsyncFunSpec, Matchers}
-import uk.ac.wellcome.models.{
-  IdentifiedWork,
-  SourceIdentifier,
-  Work
-}
+import uk.ac.wellcome.models.{IdentifiedWork, SourceIdentifier, Work}
 import uk.ac.wellcome.platform.api.models.Record
 import uk.ac.wellcome.test.utils.ElasticSearchLocal
 import uk.ac.wellcome.utils.JsonUtil
@@ -16,37 +12,35 @@ class ElasticSearchServiceTest
     with ElasticSearchLocal
     with Matchers {
 
-  val elasticService = new ElasticSearchService(indexName, itemType, elasticClient)
+  val elasticService =
+    new ElasticSearchService(indexName, itemType, elasticClient)
 
   it("should return the records in Elasticsearch") {
     val firstIdentifiedWork =
       identifiedWorkWith(canonicalId = "1234",
-                                label = "this is the first item label")
+                         label = "this is the first item label")
     val secondIdentifiedWork =
       identifiedWorkWith(canonicalId = "5678",
-                                label = "this is the second item label")
-    insertIntoElasticSearch(firstIdentifiedWork,
-                            secondIdentifiedWork)
+                         label = "this is the second item label")
+    insertIntoElasticSearch(firstIdentifiedWork, secondIdentifiedWork)
 
     val recordsFuture = elasticService.findRecords()
 
     recordsFuture map { records =>
       records should have size 2
-      records.head shouldBe Record(
-        "Work",
-        firstIdentifiedWork.canonicalId,
-        firstIdentifiedWork.work.label)
-      records.tail.head shouldBe Record(
-        "Work",
-        secondIdentifiedWork.canonicalId,
-        secondIdentifiedWork.work.label)
+      records.head shouldBe Record("Work",
+                                   firstIdentifiedWork.canonicalId,
+                                   firstIdentifiedWork.work.label)
+      records.tail.head shouldBe Record("Work",
+                                        secondIdentifiedWork.canonicalId,
+                                        secondIdentifiedWork.work.label)
     }
   }
 
   it("should find a record by id") {
     insertIntoElasticSearch(
       identifiedWorkWith(canonicalId = "1234",
-                                label = "this is the item label"))
+                         label = "this is the item label"))
 
     val recordsFuture = elasticService.findRecordById("1234")
 
@@ -56,8 +50,7 @@ class ElasticSearchServiceTest
     }
   }
 
-  private def insertIntoElasticSearch(
-    identifiedWorks: IdentifiedWork*) = {
+  private def insertIntoElasticSearch(identifiedWorks: IdentifiedWork*) = {
     identifiedWorks.foreach { identifiedWork =>
       elasticClient.execute(
         indexInto(indexName / itemType)
@@ -75,10 +68,10 @@ class ElasticSearchServiceTest
 
   private def identifiedWorkWith(canonicalId: String, label: String) = {
     IdentifiedWork(canonicalId,
-                          Work(identifiers = List(
-                                        SourceIdentifier(source = "Calm",
-                                                         sourceId = "AltRefNo",
-                                                         value = "calmid")),
-                                      label = label))
+                   Work(identifiers = List(
+                          SourceIdentifier(source = "Calm",
+                                           sourceId = "AltRefNo",
+                                           value = "calmid")),
+                        label = label))
   }
 }

--- a/common/src/main/scala/uk/ac/wellcome/elasticsearch/mappings/WorksIndex.scala
+++ b/common/src/main/scala/uk/ac/wellcome/elasticsearch/mappings/WorksIndex.scala
@@ -34,7 +34,7 @@ class WorksIndex(client: TcpClient, indexName: String, itemType: String) {
                   textField("label"),
                   keywordField("type")
                 ),
-                nestedField("hasCreator").fields(
+                objectField("hasCreator").fields(
                   textField("label"),
                   keywordField("type")
                 )

--- a/common/src/main/scala/uk/ac/wellcome/elasticsearch/mappings/WorksIndex.scala
+++ b/common/src/main/scala/uk/ac/wellcome/elasticsearch/mappings/WorksIndex.scala
@@ -1,13 +1,17 @@
 package uk.ac.wellcome.elasticsearch.mappings
 
+import com.google.inject.Inject
 import com.sksamuel.elastic4s.ElasticDsl._
 import com.sksamuel.elastic4s._
 import com.sksamuel.elastic4s.analyzers._
 import com.sksamuel.elastic4s.mappings.dynamictemplate.DynamicMapping
+import com.twitter.inject.annotations.Flag
 import org.elasticsearch.ResourceAlreadyExistsException
 import uk.ac.wellcome.utils.GlobalExecutionContext.context
 
-class WorksIndex(client: TcpClient, indexName: String, itemType: String) {
+class WorksIndex @Inject()(client: TcpClient,
+                 @Flag("es.index") indexName: String,
+                 @Flag("es.type") itemType: String) {
 
   def create =
     client
@@ -22,8 +26,8 @@ class WorksIndex(client: TcpClient, indexName: String, itemType: String) {
               objectField("work").fields(
                 keywordField("type"),
                 objectField("identifiers").fields(keywordField("source"),
-                                              keywordField("sourceId"),
-                                              keywordField("value")),
+                                                  keywordField("sourceId"),
+                                                  keywordField("value")),
                 textField("label").fields(
                   textField("english").analyzer(EnglishLanguageAnalyzer)),
                 textField("description").fields(

--- a/ingestor/src/main/scala/uk/ac/wellcome/platform/ingestor/Server.scala
+++ b/ingestor/src/main/scala/uk/ac/wellcome/platform/ingestor/Server.scala
@@ -17,8 +17,10 @@ class Server extends HttpServer {
                              AkkaModule,
                              SQSReaderModule,
                              SQSWorker,
-                             ElasticClientModule)
-
+                             ElasticClientModule,
+                             WorksIndexModule)
+  flag[String]("es.index", "records", "ES index name")
+  flag[String]("es.type", "item", "ES document type")
   override def configureHttp(router: HttpRouter) {
     router
       .filter[CommonFilters]

--- a/ingestor/src/main/scala/uk/ac/wellcome/platform/ingestor/modules/WorksIndexModule.scala
+++ b/ingestor/src/main/scala/uk/ac/wellcome/platform/ingestor/modules/WorksIndexModule.scala
@@ -1,0 +1,18 @@
+package uk.ac.wellcome.platform.ingestor.modules
+
+import com.sksamuel.elastic4s.TcpClient
+import com.twitter.inject.{Injector, TwitterModule}
+import uk.ac.wellcome.elasticsearch.mappings.WorksIndex
+
+object WorksIndexModule extends TwitterModule {
+
+  override def singletonStartup(injector: Injector) {
+    info("Creating/Updating Elasticsearch index")
+
+    val indexName = flag[String]("es.index", "records", "ES index name")
+    val itemType = flag[String]("es.type", "item", "ES document type")
+    val elasticClient = injector.instance[TcpClient]
+
+    new WorksIndex(elasticClient, indexName(), itemType()).create
+  }
+}

--- a/ingestor/src/main/scala/uk/ac/wellcome/platform/ingestor/modules/WorksIndexModule.scala
+++ b/ingestor/src/main/scala/uk/ac/wellcome/platform/ingestor/modules/WorksIndexModule.scala
@@ -9,10 +9,8 @@ object WorksIndexModule extends TwitterModule {
   override def singletonStartup(injector: Injector) {
     info("Creating/Updating Elasticsearch index")
 
-    val indexName = flag[String]("es.index", "records", "ES index name")
-    val itemType = flag[String]("es.type", "item", "ES document type")
-    val elasticClient = injector.instance[TcpClient]
+    val indexCreator = injector.instance[WorksIndex]
 
-    new WorksIndex(elasticClient, indexName(), itemType()).create
+    indexCreator.create
   }
 }

--- a/ingestor/src/test/scala/uk/ac/wellcome/platform/ingestor/IngestorFeatureTest.scala
+++ b/ingestor/src/test/scala/uk/ac/wellcome/platform/ingestor/IngestorFeatureTest.scala
@@ -8,46 +8,52 @@ import org.scalatest.{FunSpec, Matchers}
 import uk.ac.wellcome.finatra.modules._
 import uk.ac.wellcome.models.aws.SQSMessage
 import uk.ac.wellcome.models.{IdentifiedWork, SourceIdentifier, Work}
-import uk.ac.wellcome.platform.ingestor.modules.SQSWorker
+import uk.ac.wellcome.platform.ingestor.modules.{SQSWorker, WorksIndexModule}
 import uk.ac.wellcome.test.utils.{ElasticSearchLocal, SQSLocal}
 import uk.ac.wellcome.utils.GlobalExecutionContext.context
 import uk.ac.wellcome.utils.JsonUtil
 
 class IngestorFeatureTest
     extends FunSpec
-    with FeatureTestMixin
     with SQSLocal
     with Matchers
-    with ElasticSearchLocal with ScalaFutures{
+    with ElasticSearchLocal
+    with ScalaFutures {
 
   val ingestorQueueUrl = createQueueAndReturnUrl("test_es_ingestor_queue")
 
-  override val server = new EmbeddedHttpServer(
-    new Server() {
-      override val modules = Seq(SQSConfigModule,
-                                 AkkaModule,
-                                 SQSReaderModule,
-                                 SQSWorker,
-                                 SQSLocalClientModule,
-                                 ElasticClientModule)
-    },
-    flags = Map(
-      "aws.region" -> "eu-west-1",
-      "aws.sqs.queue.url" -> ingestorQueueUrl,
-      "aws.sqs.waitTime" -> "1",
-      "es.host" -> "localhost",
-      "es.port" -> "9300",
-      "es.name" -> "wellcome",
-      "es.xpack.enabled" -> "true",
-      "es.xpack.user" -> "elastic:changeme",
-      "es.xpack.sslEnabled" -> "false",
-      "es.sniff" -> "false",
-      "es.index" -> indexName,
-      "es.type" -> itemType
+  private def createServer = {
+    new EmbeddedHttpServer(
+      new Server() {
+        override val modules = Seq(SQSConfigModule,
+                                   AkkaModule,
+                                   SQSReaderModule,
+                                   SQSWorker,
+                                   SQSLocalClientModule,
+                                   ElasticClientModule,
+                                   WorksIndexModule)
+      },
+      flags = Map(
+        "aws.region" -> "eu-west-1",
+        "aws.sqs.queue.url" -> ingestorQueueUrl,
+        "aws.sqs.waitTime" -> "1",
+        "es.host" -> "localhost",
+        "es.port" -> "9300",
+        "es.name" -> "wellcome",
+        "es.xpack.enabled" -> "true",
+        "es.xpack.user" -> "elastic:changeme",
+        "es.xpack.sslEnabled" -> "false",
+        "es.sniff" -> "false",
+        "es.index" -> indexName,
+        "es.type" -> itemType
+      )
     )
-  )
+  }
 
   it("should read an identified unified item from the SQS queue and ingest it into Elasticsearch") {
+    val server = createServer
+    server.start()
+
     val identifiedWork = JsonUtil
       .toJson(
         IdentifiedWork(
@@ -73,6 +79,29 @@ class IngestorFeatureTest
       whenReady(hitsFuture) { hits =>
         hits should have size 1
         hits.head.sourceAsString shouldBe identifiedWork
+      }
+    }
+
+    server.close()
+  }
+
+  it("should create the index at startup in elasticsearch if it doesn't already exist") {
+    elasticClient.execute(deleteIndex(indexName))
+
+    eventually {
+      val future = elasticClient.execute(index exists indexName)
+      whenReady(future) { result =>
+        result.isExists should be(false)
+      }
+    }
+
+    val server = createServer
+    server.start()
+
+    eventually {
+      val future = elasticClient.execute(index exists indexName)
+      whenReady(future) { result =>
+        result.isExists should be(true)
       }
     }
   }


### PR DESCRIPTION
## What is this PR trying to achieve?
Create and update the works index when the ingestor starts up
## Who is this change for?
Us, to have an automated way of updating elasticsearch index
## Have the following been considered/are they needed?

- [x] Tests?
- [x] Docs?
- [x] Spoken to the right people?
