### PR TITLE
Improve logging of WorksIndex

### DIFF
--- a/api/src/test/scala/uk/ac/wellcome/platform/api/ApiWorksTest.scala
+++ b/api/src/test/scala/uk/ac/wellcome/platform/api/ApiWorksTest.scala
@@ -94,8 +94,7 @@ class ApiWorksTest extends FeatureTest with IndexedElasticSearchLocal {
     }
   }
 
-  test(
-    "it should return a not found error when requesting a single work with a non existing id") {
+  test("it should return a not found error when requesting a single work with a non existing id") {
     server.httpGet(
       path = "/catalogue/v0/works/non-existing-id",
       andExpect = Status.NotFound,

--- a/api/src/test/scala/uk/ac/wellcome/platform/api/ApiWorksTest.scala
+++ b/api/src/test/scala/uk/ac/wellcome/platform/api/ApiWorksTest.scala
@@ -4,14 +4,10 @@ import com.sksamuel.elastic4s.ElasticDsl._
 import com.twitter.finagle.http.Status
 import com.twitter.finatra.http.EmbeddedHttpServer
 import com.twitter.inject.server.FeatureTest
-import uk.ac.wellcome.models.{
-  IdentifiedWork,
-  SourceIdentifier,
-  Work
-}
-import uk.ac.wellcome.test.utils.ElasticSearchLocal
+import uk.ac.wellcome.models.{IdentifiedWork, SourceIdentifier, Work}
+import uk.ac.wellcome.test.utils.IndexedElasticSearchLocal
 
-class ApiWorksTest extends FeatureTest with ElasticSearchLocal {
+class ApiWorksTest extends FeatureTest with IndexedElasticSearchLocal {
 
   implicit val jsonMapper = IdentifiedWork
   override val server =
@@ -32,13 +28,13 @@ class ApiWorksTest extends FeatureTest with ElasticSearchLocal {
 
     val firstIdentifiedWork =
       identifiedWorkWith(canonicalId = "1234",
-                                label = "this is the first image label")
+                         label = "this is the first image label")
     val secondIdentifiedWork =
       identifiedWorkWith(canonicalId = "4321",
-                                label = "this is the second image label")
+                         label = "this is the second image label")
     val thirdIdentifiedWork =
       identifiedWorkWith(canonicalId = "9876",
-                                label = "this is the third image label")
+                         label = "this is the third image label")
 
     insertIntoElasticSearch(firstIdentifiedWork)
     insertIntoElasticSearch(secondIdentifiedWork)
@@ -79,7 +75,7 @@ class ApiWorksTest extends FeatureTest with ElasticSearchLocal {
   test("it should return a single work when requested with id") {
     val identifiedWork =
       identifiedWorkWith(canonicalId = "1234",
-                                label = "this is the first image title")
+                         label = "this is the first image title")
     insertIntoElasticSearch(identifiedWork)
 
     eventually {
@@ -98,7 +94,8 @@ class ApiWorksTest extends FeatureTest with ElasticSearchLocal {
     }
   }
 
-  test("it should return a not found error when requesting a single work with a non existing id") {
+  test(
+    "it should return a not found error when requesting a single work with a non existing id") {
     server.httpGet(
       path = "/catalogue/v0/works/non-existing-id",
       andExpect = Status.NotFound,
@@ -106,17 +103,15 @@ class ApiWorksTest extends FeatureTest with ElasticSearchLocal {
     )
   }
 
-  private def insertIntoElasticSearch(
-    identifiedWork: IdentifiedWork): Any = {
-    elasticClient.execute(
-      indexInto(indexName / itemType).doc(identifiedWork))
+  private def insertIntoElasticSearch(identifiedWork: IdentifiedWork): Any = {
+    elasticClient.execute(indexInto(indexName / itemType).doc(identifiedWork))
   }
 
   private def identifiedWorkWith(canonicalId: String, label: String) = {
     IdentifiedWork(canonicalId = canonicalId,
-                          work = Work(
-                            identifiers =
-                              List(SourceIdentifier("Miro", "MiroID", "5678")),
-                            label = label))
+                   work =
+                     Work(identifiers =
+                            List(SourceIdentifier("Miro", "MiroID", "5678")),
+                          label = label))
   }
 }

--- a/api/src/test/scala/uk/ac/wellcome/platform/api/services/ElasticSearchServiceTest.scala
+++ b/api/src/test/scala/uk/ac/wellcome/platform/api/services/ElasticSearchServiceTest.scala
@@ -4,12 +4,12 @@ import com.sksamuel.elastic4s.ElasticDsl._
 import org.scalatest.{AsyncFunSpec, Matchers}
 import uk.ac.wellcome.models.{IdentifiedWork, SourceIdentifier, Work}
 import uk.ac.wellcome.platform.api.models.Record
-import uk.ac.wellcome.test.utils.ElasticSearchLocal
+import uk.ac.wellcome.test.utils.IndexedElasticSearchLocal
 import uk.ac.wellcome.utils.JsonUtil
 
 class ElasticSearchServiceTest
     extends AsyncFunSpec
-    with ElasticSearchLocal
+    with IndexedElasticSearchLocal
     with Matchers {
 
   val elasticService =

--- a/common/src/main/scala/uk/ac/wellcome/elasticsearch/mappings/WorksIndex.scala
+++ b/common/src/main/scala/uk/ac/wellcome/elasticsearch/mappings/WorksIndex.scala
@@ -5,45 +5,63 @@ import com.sksamuel.elastic4s.ElasticDsl._
 import com.sksamuel.elastic4s._
 import com.sksamuel.elastic4s.analyzers._
 import com.sksamuel.elastic4s.mappings.dynamictemplate.DynamicMapping
+import com.twitter.inject.Logging
 import com.twitter.inject.annotations.Flag
 import org.elasticsearch.ResourceAlreadyExistsException
+import org.elasticsearch.action.admin.indices.mapping.put.PutMappingResponse
+import org.elasticsearch.transport.RemoteTransportException
 import uk.ac.wellcome.utils.GlobalExecutionContext.context
 
-class WorksIndex @Inject()(client: TcpClient,
-                 @Flag("es.index") indexName: String,
-                 @Flag("es.type") itemType: String) {
+import scala.concurrent.Future
 
-  def create =
+class WorksIndex @Inject()(client: TcpClient,
+                           @Flag("es.index") indexName: String,
+                           @Flag("es.type") itemType: String)
+    extends Logging {
+
+  val mappingDefinition = putMapping(indexName / itemType)
+    .dynamic(DynamicMapping.Strict)
+    .as(
+      keywordField("canonicalId"),
+      objectField("work").fields(
+        keywordField("type"),
+        objectField("identifiers").fields(keywordField("source"),
+          keywordField("sourceId"),
+          keywordField("value")),
+        textField("label").fields(
+          textField("english").analyzer(EnglishLanguageAnalyzer)),
+        textField("description").fields(
+          textField("english").analyzer(EnglishLanguageAnalyzer)),
+        textField("lettering").fields(
+          textField("english").analyzer(EnglishLanguageAnalyzer)),
+        objectField("hasCreatedDate").fields(
+          textField("label"),
+          keywordField("type")
+        ),
+        objectField("hasCreator").fields(
+          textField("label"),
+          keywordField("type")
+        )
+      )
+    )
+
+  def create: Future[Unit] =
     client
       .execute(createIndex(indexName))
-      .recover { case e: ResourceAlreadyExistsException => () }
+      .recover {
+        case e: RemoteTransportException if e.getCause.isInstanceOf[ResourceAlreadyExistsException] => info(s"Index $indexName already exists")
+        case _: ResourceAlreadyExistsException => info(s"Index $indexName already exists")
+        case e: Throwable =>
+          error(s"Failed creating index $indexName", e)
+          throw e
+      }
       .flatMap { _ =>
         client.execute {
-          putMapping(indexName / itemType)
-            .dynamic(DynamicMapping.Strict)
-            .as(
-              keywordField("canonicalId"),
-              objectField("work").fields(
-                keywordField("type"),
-                objectField("identifiers").fields(keywordField("source"),
-                                                  keywordField("sourceId"),
-                                                  keywordField("value")),
-                textField("label").fields(
-                  textField("english").analyzer(EnglishLanguageAnalyzer)),
-                textField("description").fields(
-                  textField("english").analyzer(EnglishLanguageAnalyzer)),
-                textField("lettering").fields(
-                  textField("english").analyzer(EnglishLanguageAnalyzer)),
-                objectField("hasCreatedDate").fields(
-                  textField("label"),
-                  keywordField("type")
-                ),
-                objectField("hasCreator").fields(
-                  textField("label"),
-                  keywordField("type")
-                )
-              )
-            )
+          mappingDefinition
+        }.recover{
+          case e: Throwable =>
+            error(s"Failed updating index $indexName", e)
+            throw e
         }
-      }
+      }.map {_ => info("Index updated successfully")}
 }

--- a/common/src/main/scala/uk/ac/wellcome/finatra/modules/ElasticClientModule.scala
+++ b/common/src/main/scala/uk/ac/wellcome/finatra/modules/ElasticClientModule.scala
@@ -39,8 +39,6 @@ object ElasticClientModule extends TwitterModule {
   private val clusterName =
     flag[String]("es.name", "elasticsearch", "cluster name")
 
-  val timeout = flag("es.timeout", 30, "default timeout duration of execution")
-
   @Singleton
   @Provides
   def provideElasticClient(xpackConfig: Option[XPackConfig]): TcpClient = {
@@ -63,8 +61,8 @@ object ElasticClientModule extends TwitterModule {
             .put("xpack.security.user", config.user))
       .build()
 
-    settings.getAsMap.asScala.map {
-      case (k, v) => info(s"ElasticClient setting: ${k}=${v}")
+    settings.getAsMap.asScala.foreach {
+      case (k, v) => info(s"ElasticClient setting: $k=$v")
     }
 
     XPackElasticClient(settings, clientUri)

--- a/common/src/test/resources/logback-test.xml
+++ b/common/src/test/resources/logback-test.xml
@@ -1,0 +1,16 @@
+<configuration>
+
+  <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+    <!-- encoders are assigned the type
+         ch.qos.logback.classic.encoder.PatternLayoutEncoder by default -->
+    <encoder>
+      <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+    </encoder>
+  </appender>
+
+  <logger name="org.apache.http" level="WARN"/>
+  <logger name="com.amazonaws" level="INFO"/>
+  <root level="debug">
+    <appender-ref ref="STDOUT" />
+  </root>
+</configuration>

--- a/common/src/test/scala/uk/ac/wellcome/elasticsearch/mappings/WorksIndexTest.scala
+++ b/common/src/test/scala/uk/ac/wellcome/elasticsearch/mappings/WorksIndexTest.scala
@@ -29,7 +29,9 @@ class WorksIndexTest
   val worksIndex = new WorksIndex(elasticClient, indexName, itemType)
 
   override def beforeEach(): Unit = {
-    elasticClient.execute(deleteIndex(indexName)).await
+    if (elasticClient.execute(indexExists(indexName)).await.isExists){
+      elasticClient.execute(deleteIndex(indexName)).await
+    }
     super.beforeEach()
   }
 

--- a/common/src/test/scala/uk/ac/wellcome/elasticsearch/mappings/WorksIndexTest.scala
+++ b/common/src/test/scala/uk/ac/wellcome/elasticsearch/mappings/WorksIndexTest.scala
@@ -1,10 +1,14 @@
 package uk.ac.wellcome.elasticsearch.mappings
 
-import com.sksamuel.elastic4s.testkit.ElasticSugar
-import org.elasticsearch.index.mapper.StrictDynamicMappingException
+import java.util
+
+import com.sksamuel.elastic4s.ElasticDsl._
+import com.sksamuel.elastic4s.mappings.dynamictemplate.DynamicMapping
+import org.elasticsearch.transport.RemoteTransportException
 import org.scalatest.concurrent.{Eventually, IntegrationPatience, ScalaFutures}
 import org.scalatest.{BeforeAndAfterEach, FunSpec, Matchers}
 import uk.ac.wellcome.models.{IdentifiedWork, SourceIdentifier, Work}
+import uk.ac.wellcome.test.utils.ElasticSearchLocal
 import uk.ac.wellcome.utils.GlobalExecutionContext.context
 import uk.ac.wellcome.utils.JsonUtil
 
@@ -12,7 +16,7 @@ import scala.collection.JavaConversions._
 
 class WorksIndexTest
     extends FunSpec
-    with ElasticSugar
+    with ElasticSearchLocal
     with ScalaFutures
     with Eventually
     with IntegrationPatience
@@ -22,14 +26,15 @@ class WorksIndexTest
   val indexName = "records"
   val itemType = "item"
 
-  val worksIndex = new WorksIndex(client, indexName, itemType)
+  val worksIndex = new WorksIndex(elasticClient, indexName, itemType)
 
   override def beforeEach(): Unit = {
-    deleteIndex(indexName)
+    elasticClient.execute(deleteIndex(indexName)).await
+    super.beforeEach()
   }
 
   it("should create an index where it's possible to insert and retrieve a valid Work json") {
-    createAndWaitIndexIsCreated
+    createAndWaitIndexIsCreated()
 
     val workJson = JsonUtil
       .toJson(
@@ -44,11 +49,11 @@ class WorksIndexTest
         ))
       .get
 
-    client.execute(indexInto(indexName / itemType).doc(workJson))
+    elasticClient.execute(indexInto(indexName / itemType).doc(workJson))
 
     eventually {
-      val hits = client
-        .execute(search(s"$indexName/$itemType").matchAll())
+      val hits = elasticClient
+        .execute(search(s"$indexName/$itemType").matchAllQuery())
         .map { _.hits }
         .await
       hits should have size 1
@@ -57,39 +62,57 @@ class WorksIndexTest
   }
 
   it("it should create an index where inserting a document that does not match the mapping of a work fails") {
-    createAndWaitIndexIsCreated
+    createAndWaitIndexIsCreated()
 
-    val eventualIndexResponse = client.execute(
+    val eventualIndexResponse = elasticClient.execute(
       indexInto(indexName / itemType)
         .doc("""{"json":"json not matching the index structure"}"""))
 
     whenReady(eventualIndexResponse.failed) { exception =>
-      exception shouldBe a[StrictDynamicMappingException]
+      exception shouldBe a [RemoteTransportException]
     }
   }
 
   it("should update an already existing index with the mapping") {
-    ensureIndexExists(indexName)
+    createIndexAndInsertDocument()
 
-    worksIndex.create.await
+    worksIndex.create
 
     eventually {
-      val mappings = client
+      val mappings: Map[String, AnyRef] = elasticClient
         .execute(getMapping(indexName / itemType))
         .await
         .mappingFor(indexName / itemType)
         .getSourceAsMap
         .toMap
-      mappings should contain ("dynamic" -> "strict")
+      mappings("properties")
+        .asInstanceOf[util.Map[String, AnyRef]]
+        .keys should contain("work")
     }
 
   }
 
-  private def createAndWaitIndexIsCreated = {
+  private def createIndexAndInsertDocument() = {
+    val futureIndexWithDocument =
+      for {
+        _ <- elasticClient.execute(createIndex(indexName))
+        _ <- elasticClient.execute(putMapping(indexName / itemType).dynamic(DynamicMapping.Strict).as(keywordField("canonicalId")))
+        _ <- elasticClient.execute(indexInto(indexName / itemType).doc(
+          """
+            |{
+            | "canonicalId": "1234"
+            |}
+          """.stripMargin))
+      } yield ()
+
+    futureIndexWithDocument.await
+  }
+
+  private def createAndWaitIndexIsCreated() = {
     worksIndex.create.await
 
     eventually {
-      doesIndexExists(indexName) shouldBe true
+      elasticClient.execute(index exists indexName).await.isExists should be (true)
     }
   }
 }

--- a/common/src/test/scala/uk/ac/wellcome/elasticsearch/mappings/WorksIndexTest.scala
+++ b/common/src/test/scala/uk/ac/wellcome/elasticsearch/mappings/WorksIndexTest.scala
@@ -29,17 +29,7 @@ class WorksIndexTest
   val worksIndex = new WorksIndex(elasticClient, indexName, itemType)
 
   override def beforeEach(): Unit = {
-    elasticClient
-      .execute(indexExists(indexName))
-      .map { result =>
-        if (result.isExists) elasticClient.execute(deleteIndex(indexName))
-      }
-
-    eventually {
-      elasticClient
-        .execute(indexExists(indexName)).await.isExists should be (false)
-    }
-    super.beforeEach()
+    ensureIndexDeleted(indexName)
   }
 
   it("should create an index where it's possible to insert and retrieve a valid Work json") {
@@ -71,10 +61,8 @@ class WorksIndexTest
   }
 
   it("it should create an index where inserting a document that does not match the mapping of a work fails") {
-    println("creating index")
     createAndWaitIndexIsCreated()
 
-    println("index created")
     val eventualIndexResponse = elasticClient.execute(
       indexInto(indexName / itemType)
         .doc("""{"json":"json not matching the index structure"}"""))

--- a/common/src/test/scala/uk/ac/wellcome/test/utils/ElasticSearchLocal.scala
+++ b/common/src/test/scala/uk/ac/wellcome/test/utils/ElasticSearchLocal.scala
@@ -5,12 +5,10 @@ import com.sksamuel.elastic4s.ElasticsearchClientUri
 import com.sksamuel.elastic4s.xpack.security.XPackElasticClient
 import org.elasticsearch.common.settings.Settings
 import org.scalatest.concurrent.{Eventually, IntegrationPatience}
-import org.scalatest.{BeforeAndAfterAll, BeforeAndAfterEach, Matchers, Suite}
-import uk.ac.wellcome.elasticsearch.mappings.WorksIndex
+import org.scalatest.{BeforeAndAfterAll, Matchers, Suite}
 
 trait ElasticSearchLocal
     extends BeforeAndAfterAll
-    with BeforeAndAfterEach
     with Eventually
     with IntegrationPatience
     with Matchers { this: Suite =>
@@ -23,24 +21,11 @@ trait ElasticSearchLocal
   val elasticClient =
     XPackElasticClient(settings, ElasticsearchClientUri("localhost", 9300))
 
-  val indexName = "records"
-  val itemType = "item"
-
   override def beforeAll(): Unit = {
     // Elasticsearch takes a while to start up so check that it actually started before running tests
     eventually {
       elasticClient.execute(clusterHealth()).await.getNumberOfNodes shouldBe 1
     }
-
-    if (elasticClient.execute(indexExists(indexName)).await.isExists){
-      elasticClient.execute(deleteIndex(indexName)).await
-    }
-    new WorksIndex(elasticClient, indexName, itemType).create.await
     super.beforeAll()
-  }
-
-  override def beforeEach(): Unit = {
-    elasticClient.execute(deleteIn(indexName).by(matchAllQuery())).await
-    super.beforeEach()
   }
 }

--- a/common/src/test/scala/uk/ac/wellcome/test/utils/ElasticSearchLocal.scala
+++ b/common/src/test/scala/uk/ac/wellcome/test/utils/ElasticSearchLocal.scala
@@ -8,10 +8,10 @@ import org.scalatest.concurrent.{Eventually, IntegrationPatience}
 import org.scalatest.{BeforeAndAfterAll, Matchers, Suite}
 
 trait ElasticSearchLocal
-    extends BeforeAndAfterAll
-    with Eventually
+    extends Eventually
     with IntegrationPatience
     with Matchers { this: Suite =>
+
   private val settings = Settings
     .builder()
     .put("cluster.name", "wellcome")
@@ -21,11 +21,8 @@ trait ElasticSearchLocal
   val elasticClient =
     XPackElasticClient(settings, ElasticsearchClientUri("localhost", 9300))
 
-  override def beforeAll(): Unit = {
-    // Elasticsearch takes a while to start up so check that it actually started before running tests
-    eventually {
-      elasticClient.execute(clusterHealth()).await.getNumberOfNodes shouldBe 1
-    }
-    super.beforeAll()
+  // Elasticsearch takes a while to start up so check that it actually started before running tests
+  eventually {
+    elasticClient.execute(clusterHealth()).await.getNumberOfNodes shouldBe 1
   }
 }

--- a/common/src/test/scala/uk/ac/wellcome/test/utils/IndexedElasticSearchLocal.scala
+++ b/common/src/test/scala/uk/ac/wellcome/test/utils/IndexedElasticSearchLocal.scala
@@ -1,34 +1,21 @@
 package uk.ac.wellcome.test.utils
 
 import com.sksamuel.elastic4s.ElasticDsl._
-import org.scalatest.{BeforeAndAfterAll, BeforeAndAfterEach, Suite}
+import org.scalatest.{BeforeAndAfterEach, Suite}
 import uk.ac.wellcome.elasticsearch.mappings.WorksIndex
 import uk.ac.wellcome.utils.GlobalExecutionContext.context
 
 trait IndexedElasticSearchLocal
     extends ElasticSearchLocal
-    with BeforeAndAfterEach
-    with BeforeAndAfterAll { this: Suite =>
+    with BeforeAndAfterEach { this: Suite =>
 
   val indexName = "records"
   val itemType = "item"
 
-  override def beforeAll(): Unit = {
-    elasticClient
-      .execute(indexExists(indexName))
-      .map { result =>
-        if (result.isExists) elasticClient.execute(deleteIndex(indexName))
-      }
-
-    eventually {
-      elasticClient
-        .execute(indexExists(indexName)).await.isExists should be (false)
-    }
-    new WorksIndex(elasticClient, indexName, itemType).create.await
-  }
-
   override def beforeEach(): Unit = {
-    elasticClient.execute(deleteIn(indexName).by(matchAllQuery())).await
-    super.beforeEach()
+    ensureIndexDeleted(indexName)
+    new WorksIndex(elasticClient, indexName, itemType).create.map { _ =>
+      elasticClient.execute(indexExists(indexName)).await.isExists should be(true)
+    }.await
   }
 }

--- a/common/src/test/scala/uk/ac/wellcome/test/utils/IndexedElasticSearchLocal.scala
+++ b/common/src/test/scala/uk/ac/wellcome/test/utils/IndexedElasticSearchLocal.scala
@@ -18,9 +18,12 @@ trait IndexedElasticSearchLocal
   override def beforeAll(): Unit = {
     super.beforeAll()
 
-    if (elasticClient.execute(indexExists(indexName)).await.isExists){
-      elasticClient.execute(deleteIndex(indexName)).await
-    }
+    elasticClient
+      .execute(indexExists(indexName))
+      .map { result =>
+        if (result.isExists) elasticClient.execute(deleteIndex(indexName))
+      }
+      .await
     new WorksIndex(elasticClient, indexName, itemType).create.await
   }
 

--- a/common/src/test/scala/uk/ac/wellcome/test/utils/IndexedElasticSearchLocal.scala
+++ b/common/src/test/scala/uk/ac/wellcome/test/utils/IndexedElasticSearchLocal.scala
@@ -1,0 +1,31 @@
+package uk.ac.wellcome.test.utils
+
+import com.sksamuel.elastic4s.ElasticDsl._
+import com.sksamuel.elastic4s.ElasticsearchClientUri
+import com.sksamuel.elastic4s.xpack.security.XPackElasticClient
+import org.elasticsearch.common.settings.Settings
+import org.scalatest.concurrent.{Eventually, IntegrationPatience}
+import org.scalatest.{BeforeAndAfterAll, BeforeAndAfterEach, Matchers, Suite}
+import uk.ac.wellcome.elasticsearch.mappings.WorksIndex
+
+trait IndexedElasticSearchLocal
+    extends ElasticSearchLocal
+      with BeforeAndAfterEach { this: Suite =>
+
+  val indexName = "records"
+  val itemType = "item"
+
+  override def beforeAll(): Unit = {
+    super.beforeAll()
+
+    if (elasticClient.execute(indexExists(indexName)).await.isExists){
+      elasticClient.execute(deleteIndex(indexName)).await
+    }
+    new WorksIndex(elasticClient, indexName, itemType).create.await
+  }
+
+  override def beforeEach(): Unit = {
+    elasticClient.execute(deleteIn(indexName).by(matchAllQuery())).await
+    super.beforeEach()
+  }
+}

--- a/id_minter/src/test/scala/uk/ac/wellcome/platform/idminter/IdMinterFeatureTest.scala
+++ b/id_minter/src/test/scala/uk/ac/wellcome/platform/idminter/IdMinterFeatureTest.scala
@@ -11,12 +11,7 @@ import com.twitter.inject.server.FeatureTestMixin
 import org.scalatest.FunSpec
 import org.scalatest.concurrent.{Eventually, IntegrationPatience}
 import uk.ac.wellcome.models.aws.SQSMessage
-import uk.ac.wellcome.models.{
-  IdentifiedWork,
-  Identifier,
-  SourceIdentifier,
-  Work
-}
+import uk.ac.wellcome.models.{IdentifiedWork, Identifier, SourceIdentifier, Work}
 import uk.ac.wellcome.test.utils.{DynamoDBLocal, SNSLocal, SQSLocal}
 import uk.ac.wellcome.utils.JsonUtil
 

--- a/ingestor/src/test/scala/uk/ac/wellcome/platform/ingestor/IngestorFeatureTest.scala
+++ b/ingestor/src/test/scala/uk/ac/wellcome/platform/ingestor/IngestorFeatureTest.scala
@@ -7,9 +7,7 @@ import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.{FunSpec, Matchers}
 import uk.ac.wellcome.models.aws.SQSMessage
 import uk.ac.wellcome.models.{IdentifiedWork, SourceIdentifier, Work}
-import uk.ac.wellcome.test.utils.{ElasticSearchLocal, SQSLocal}
-import uk.ac.wellcome.platform.ingestor.modules.{SQSWorker, WorksIndexModule}
-import uk.ac.wellcome.test.utils.{SQSLocal, IndexedElasticSearchLocal}
+import uk.ac.wellcome.test.utils.{IndexedElasticSearchLocal, SQSLocal}
 import uk.ac.wellcome.utils.GlobalExecutionContext.context
 import uk.ac.wellcome.utils.JsonUtil
 

--- a/ingestor/src/test/scala/uk/ac/wellcome/platform/ingestor/IngestorFeatureTest.scala
+++ b/ingestor/src/test/scala/uk/ac/wellcome/platform/ingestor/IngestorFeatureTest.scala
@@ -2,14 +2,13 @@ package uk.ac.wellcome.platform.ingestor
 
 import com.sksamuel.elastic4s.ElasticDsl._
 import com.twitter.finatra.http.EmbeddedHttpServer
-import com.twitter.inject.server.FeatureTestMixin
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.{FunSpec, Matchers}
 import uk.ac.wellcome.finatra.modules._
 import uk.ac.wellcome.models.aws.SQSMessage
 import uk.ac.wellcome.models.{IdentifiedWork, SourceIdentifier, Work}
 import uk.ac.wellcome.platform.ingestor.modules.{SQSWorker, WorksIndexModule}
-import uk.ac.wellcome.test.utils.{ElasticSearchLocal, SQSLocal}
+import uk.ac.wellcome.test.utils.{SQSLocal, IndexedElasticSearchLocal}
 import uk.ac.wellcome.utils.GlobalExecutionContext.context
 import uk.ac.wellcome.utils.JsonUtil
 
@@ -17,10 +16,10 @@ class IngestorFeatureTest
     extends FunSpec
     with SQSLocal
     with Matchers
-    with ElasticSearchLocal
+    with IndexedElasticSearchLocal
     with ScalaFutures {
 
-  val ingestorQueueUrl = createQueueAndReturnUrl("test_es_ingestor_queue")
+  val ingestorQueueUrl: String = createQueueAndReturnUrl("test_es_ingestor_queue")
 
   private def createServer = {
     new EmbeddedHttpServer(

--- a/ingestor/src/test/scala/uk/ac/wellcome/platform/ingestor/services/IdentifiedWorkIndexerTest.scala
+++ b/ingestor/src/test/scala/uk/ac/wellcome/platform/ingestor/services/IdentifiedWorkIndexerTest.scala
@@ -5,7 +5,7 @@ import com.sksamuel.elastic4s.ElasticDsl._
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.{FunSpec, Matchers}
 import uk.ac.wellcome.models.{IdentifiedWork, SourceIdentifier, Work}
-import uk.ac.wellcome.test.utils.ElasticSearchLocal
+import uk.ac.wellcome.test.utils.IndexedElasticSearchLocal
 import uk.ac.wellcome.utils.GlobalExecutionContext.context
 import uk.ac.wellcome.utils.JsonUtil
 
@@ -15,7 +15,7 @@ class IdentifiedWorkIndexerTest
     extends FunSpec
     with ScalaFutures
     with Matchers
-    with ElasticSearchLocal {
+    with IndexedElasticSearchLocal {
 
   val identifiedWorkIndexer =
     new IdentifiedWorkIndexer(indexName, itemType, elasticClient)


### PR DESCRIPTION
Improve logging of WorksIndex so that it shows errors when it tries to update an index. Making tests connect to the local elasticsearch instead of the localnode. And lastly, improving test around index update to have a more significant starting status

## What is this PR trying to achieve?
Better logs and tests that better reflect reality
## Who is this change for?
Developers who investigate bugs
## Have the following been considered/are they needed?

- [x] Tests?
- [x] Docs?
- [x] Spoken to the right people?
