### PR TITLE
Remove accessStatus from Work

### DIFF
--- a/common/src/main/scala/uk/ac/wellcome/models/Transformable.scala
+++ b/common/src/main/scala/uk/ac/wellcome/models/Transformable.scala
@@ -16,8 +16,7 @@ case class CalmDataTransformable(
   def transform: Try[Work] = Try {
     Work(
       identifiers = List(SourceIdentifier("source", "key", "value")),
-      label = "calm data label",
-      accessStatus = AccessStatus.headOption
+      label = "calm data label"
     )
   }
 }

--- a/common/src/main/scala/uk/ac/wellcome/models/Work.scala
+++ b/common/src/main/scala/uk/ac/wellcome/models/Work.scala
@@ -21,10 +21,7 @@ case class Work(
   description: Option[String] = None,
   lettering: Option[String] = None,
   hasCreatedDate: Option[Period] = None,
-  hasCreator: List[Agent] = List(),
-
-  // TODO: Remove this field?
-  accessStatus: Option[String] = None
+  hasCreator: List[Agent] = List()
 ) {
   @JsonProperty("type") val ldType: String = "Work"
 }

--- a/common/src/test/scala/uk/ac/wellcome/elasticsearch/mappings/WorksIndexTest.scala
+++ b/common/src/test/scala/uk/ac/wellcome/elasticsearch/mappings/WorksIndexTest.scala
@@ -43,8 +43,7 @@ class WorksIndexTest
                         SourceIdentifier(source = "Miro",
                                          sourceId = "MiroID",
                                          value = "4321")),
-                      label = "this is the miro image label",
-                      accessStatus = None)
+                      label = "this is the miro image label")
         ))
       .get
 

--- a/common/src/test/scala/uk/ac/wellcome/test/ModelsTest.scala
+++ b/common/src/test/scala/uk/ac/wellcome/test/ModelsTest.scala
@@ -23,8 +23,7 @@ class JsonUtilTest extends FunSpec with Matchers {
   it("should not include fields where the value is empty or None") {
     val work = Work(
       identifiers=List(),
-      label="A haiku about a heron",
-      accessStatus=None
+      label="A haiku about a heron"
     )
     val jsonString = JsonUtil.toJson(work).get
 

--- a/id_minter/src/test/scala/uk/ac/wellcome/platform/idminter/IdMinterFeatureTest.scala
+++ b/id_minter/src/test/scala/uk/ac/wellcome/platform/idminter/IdMinterFeatureTest.scala
@@ -43,13 +43,10 @@ class IdMinterFeatureTest
   it("should read a work from the SQS queue, generate a canonical ID, save it in dynamoDB and send a message to the SNS topic with the original work and the id") {
     val miroID = "M0001234"
     val label = "A limerick about a lion"
-    val accessStatus = Option("open access")
 
     val work = Work(
       identifiers = List(SourceIdentifier("Miro", "MiroID", miroID)),
-      label = label,
-      accessStatus = accessStatus
-    )
+      label = label)
     val sqsMessage = SQSMessage(Some("subject"),
                                 JsonUtil.toJson(work).get,
                                 "topic",
@@ -75,7 +72,6 @@ class IdMinterFeatureTest
       parsedIdentifiedWork.canonicalId shouldBe id.CanonicalID
       parsedIdentifiedWork.work.identifiers.head.value shouldBe miroID
       parsedIdentifiedWork.work.label shouldBe label
-      parsedIdentifiedWork.work.accessStatus shouldBe accessStatus
 
       messages.head.subject should be("identified-item")
     }
@@ -120,8 +116,7 @@ class IdMinterFeatureTest
   private def generateSqsMessage(MiroID: String) = {
     val work = Work(identifiers =
                       List(SourceIdentifier("Miro", "MiroID", MiroID)),
-                    label = "some label",
-                    accessStatus = Option("super-secret"))
+                    label = "some label")
     SQSMessage(Some("subject"),
                JsonUtil.toJson(work).get,
                "topic",

--- a/id_minter/src/test/scala/uk/ac/wellcome/platform/idminter/steps/WorkExtractorTest.scala
+++ b/id_minter/src/test/scala/uk/ac/wellcome/platform/idminter/steps/WorkExtractorTest.scala
@@ -18,12 +18,10 @@ class WorkExtractorTest
 
     val miroID = "M0000001"
     val label = "A note about a narwhal"
-    val accessStatus = Option("open access")
 
     val work = Work(
       identifiers = List(SourceIdentifier("Miro", "MiroId", miroID)),
-      label = label,
-      accessStatus = accessStatus
+      label = label
     )
     val sqsMessage = SQSMessage(Some("subject"),
                                 JsonUtil.toJson(work).get,
@@ -38,7 +36,6 @@ class WorkExtractorTest
     whenReady(eventualWork) { extractedWork =>
       extractedWork.identifiers.head.value shouldBe miroID
       extractedWork.label shouldBe label
-      extractedWork.accessStatus shouldBe accessStatus
     }
   }
 

--- a/transformer/src/test/scala/uk/ac/wellcome/transformer/CalmTransformerFeatureTest.scala
+++ b/transformer/src/test/scala/uk/ac/wellcome/transformer/CalmTransformerFeatureTest.scala
@@ -5,7 +5,6 @@ import com.amazonaws.services.dynamodbv2.streamsadapter.AmazonDynamoDBStreamsAda
 import com.amazonaws.services.kinesis.AmazonKinesis
 import com.amazonaws.services.kinesis.clientlibrary.lib.worker.KinesisClientLibConfiguration
 import com.amazonaws.services.sns.AmazonSNS
-import com.amazonaws.services.sqs.AmazonSQS
 import com.gu.scanamo.Scanamo
 import com.twitter.finatra.http.EmbeddedHttpServer
 import org.scalatest.FunSpec
@@ -72,8 +71,7 @@ class CalmTransformerFeatureTest extends FunSpec with TransformerFeatureTest {
       .toJson(
         Work(
           identifiers = List(SourceIdentifier("source", "key", "value")),
-          label = "calm data label",
-          accessStatus = AccessStatus
+          label = "calm data label"
         ))
       .get
   }

--- a/transformer/src/test/scala/uk/ac/wellcome/transformer/receive/RecordReceiverTest.scala
+++ b/transformer/src/test/scala/uk/ac/wellcome/transformer/receive/RecordReceiverTest.scala
@@ -34,8 +34,7 @@ class RecordReceiverTest
 
   val work = Work(
     identifiers = List(SourceIdentifier("Calm", "AltRefNo", "AB/CD/12")),
-    label = "calm data label",
-    accessStatus = Some("restricted"))
+    label = "calm data label")
 
   it("should receive a message and send it to SNS client") {
     val snsWriter = mockSNSWriter


### PR DESCRIPTION
## What is this PR trying to achieve?
Remove accessStatus from Works as it isn't output in the api and any item with a value in it will be rejected by elasticsearch
## Who is this change for?
Everyone
## Have the following been considered/are they needed?

- [x] Tests?
- [x] Docs?
- [x] Spoken to the right people?
