### PR TITLE
Reduce logging in ingestor and id_minter

### DIFF
--- a/common/src/main/scala/uk/ac/wellcome/sqs/SQSReader.scala
+++ b/common/src/main/scala/uk/ac/wellcome/sqs/SQSReader.scala
@@ -28,6 +28,7 @@ class SQSReader @Inject()(sqsClient: AmazonSQS, sqsConfig: SQSConfig)
       }
     } flatMap { messages =>
       if(messages.nonEmpty) info(s"Received messages $messages from queue ${sqsConfig.queueUrl}")
+      else debug(s"Received messages $messages from queue ${sqsConfig.queueUrl}")
       processAndDeleteMessages(messages, process).map {_ => ()}
     } recover {
       case exception: Throwable =>

--- a/common/src/main/scala/uk/ac/wellcome/sqs/SQSReader.scala
+++ b/common/src/main/scala/uk/ac/wellcome/sqs/SQSReader.scala
@@ -1,11 +1,7 @@
 package uk.ac.wellcome.sqs
 
 import com.amazonaws.services.sqs.AmazonSQS
-import com.amazonaws.services.sqs.model.{
-  DeleteMessageRequest,
-  Message,
-  ReceiveMessageRequest
-}
+import com.amazonaws.services.sqs.model.{DeleteMessageRequest, Message, ReceiveMessageRequest}
 import com.google.inject.Inject
 import com.twitter.inject.Logging
 import uk.ac.wellcome.models.aws.SQSConfig
@@ -13,7 +9,7 @@ import uk.ac.wellcome.utils.GlobalExecutionContext.context
 
 import scala.collection.JavaConversions._
 import scala.concurrent.{Future, blocking}
-import scala.util.{Failure, Success, Try}
+import scala.util.Try
 
 class SQSReader @Inject()(sqsClient: AmazonSQS, sqsConfig: SQSConfig)
     extends Logging {
@@ -31,7 +27,7 @@ class SQSReader @Inject()(sqsClient: AmazonSQS, sqsConfig: SQSConfig)
         receiveMessages()
       }
     } flatMap { messages =>
-      info(s"Received messages $messages from queue ${sqsConfig.queueUrl}")
+      if(messages.nonEmpty) info(s"Received messages $messages from queue ${sqsConfig.queueUrl}")
       processAndDeleteMessages(messages, process).map {_ => ()}
     } recover {
       case exception: Throwable =>


### PR DESCRIPTION
## What is this PR trying to achieve?
The ingestor and the id_minter poll the SQS queue every 100 milliseconds and currently log every 100 milliseconds even if no messages have been received. This makes logs hard to read when we try to investigate if a message has been reveiced
## Who is this change for?
Developers who want to see what's going on
## Have the following been considered/are they needed?

- [x] Tests?
- [x] Docs?
- [ ] Spoken to the right people?
