### PR TITLE
Add single work endpoint

### DIFF
--- a/api/src/main/scala/uk/ac/wellcome/platform/api/models/Record.scala
+++ b/api/src/main/scala/uk/ac/wellcome/platform/api/models/Record.scala
@@ -3,13 +3,17 @@ package uk.ac.wellcome.platform.api.models
 import com.fasterxml.jackson.annotation.JsonProperty
 import com.sksamuel.elastic4s.searches.RichSearchHit
 import org.elasticsearch.action.get.GetResponse
-import uk.ac.wellcome.models.{IdentifiedWork, Work}
+import uk.ac.wellcome.models.{Agent, IdentifiedWork, Period, Work}
 import uk.ac.wellcome.utils.JsonUtil
 
 case class Record(
   @JsonProperty("type") ontologyType: String = "Work",
   id: String,
-  label: String
+  label: String,
+  description: Option[String] = None,
+  lettering: Option[String] = None,
+  hasCreatedDate: Option[Period] = None,
+  hasCreator: List[Agent] = Nil
 )
 case object Record {
   def apply(hit: RichSearchHit): Record = {
@@ -26,7 +30,11 @@ case object Record {
 
     Record(
       id = identifiedWork.canonicalId,
-      label = identifiedWork.work.label
+      label = identifiedWork.work.label,
+      description = identifiedWork.work.description,
+      lettering = identifiedWork.work.lettering,
+      hasCreatedDate = identifiedWork.work.hasCreatedDate,
+      hasCreator = identifiedWork.work.hasCreator
     )
   }
 }

--- a/api/src/main/scala/uk/ac/wellcome/platform/api/models/Record.scala
+++ b/api/src/main/scala/uk/ac/wellcome/platform/api/models/Record.scala
@@ -13,7 +13,7 @@ case class Record(
   description: Option[String] = None,
   lettering: Option[String] = None,
   hasCreatedDate: Option[Period] = None,
-  hasCreator: List[Agent] = Nil
+  hasCreator: List[Agent] = List()
 )
 case object Record {
   def apply(hit: RichSearchHit): Record = {
@@ -34,7 +34,8 @@ case object Record {
       description = identifiedWork.work.description,
       lettering = identifiedWork.work.lettering,
       hasCreatedDate = identifiedWork.work.hasCreatedDate,
-      hasCreator = identifiedWork.work.hasCreator
+      // Wrapping this in Option to catch null value from Jackson
+      hasCreator = Option(identifiedWork.work.hasCreator).getOrElse(Nil)
     )
   }
 }

--- a/api/src/test/scala/uk/ac/wellcome/platform/api/ApiWorksTest.scala
+++ b/api/src/test/scala/uk/ac/wellcome/platform/api/ApiWorksTest.scala
@@ -24,29 +24,17 @@ class ApiWorksTest extends FeatureTest with IndexedElasticSearchLocal {
       )
     )
 
-  ignore("it should return a list of works") {
+  test("it should return a list of works") {
 
     val firstIdentifiedWork =
       identifiedWorkWith(canonicalId = "1234",
-                         label = "this is the first image label",
-                         description = "",
-                         lettering = "",
-                         createdDate = Period(""),
-                         creator = Agent(""))
+                         label = "this is the first image label")
     val secondIdentifiedWork =
       identifiedWorkWith(canonicalId = "4321",
-                         label = "this is the second image label",
-                         description = "",
-                         lettering = "",
-                         createdDate = Period(""),
-                         creator = Agent(""))
+                         label = "this is the second image label")
     val thirdIdentifiedWork =
       identifiedWorkWith(canonicalId = "9876",
-                         label = "this is the third image label",
-                         description = "",
-                         lettering = "",
-                         createdDate = Period(""),
-                         creator = Agent(""))
+                         label = "this is the third image label")
 
     insertIntoElasticSearch(firstIdentifiedWork)
     insertIntoElasticSearch(secondIdentifiedWork)
@@ -65,17 +53,20 @@ class ApiWorksTest extends FeatureTest with IndexedElasticSearchLocal {
             |   {
             |     "type": "Work",
             |     "id": "${firstIdentifiedWork.canonicalId}",
-            |     "label": "${firstIdentifiedWork.work.label}"
+            |     "label": "${firstIdentifiedWork.work.label}",
+            |     "hasCreator":[]
             |   },
             |   {
             |     "type": "Work",
             |     "id": "${secondIdentifiedWork.canonicalId}",
-            |     "label": "${secondIdentifiedWork.work.label}"
+            |     "label": "${secondIdentifiedWork.work.label}",
+            |     "hasCreator":[]
             |   },
             |   {
             |     "type": "Work",
             |     "id": "${thirdIdentifiedWork.canonicalId}",
-            |     "label": "${thirdIdentifiedWork.work.label}"
+            |     "label": "${thirdIdentifiedWork.work.label}",
+            |     "hasCreator":[]
             |   }
             |  ]
             |}
@@ -145,7 +136,13 @@ class ApiWorksTest extends FeatureTest with IndexedElasticSearchLocal {
         .id(identifiedWork.canonicalId)
         .doc(identifiedWork))
   }
+  private def identifiedWorkWith(canonicalId: String, label: String) = {
+    IdentifiedWork(canonicalId,
+                   Work(identifiers =
+                          List(SourceIdentifier("Miro", "MiroID", "5678")),
+                        label = label))
 
+  }
   private def identifiedWorkWith(canonicalId: String,
                                  label: String,
                                  description: String,

--- a/api/src/test/scala/uk/ac/wellcome/platform/api/services/ElasticSearchServiceTest.scala
+++ b/api/src/test/scala/uk/ac/wellcome/platform/api/services/ElasticSearchServiceTest.scala
@@ -47,7 +47,10 @@ class ElasticSearchServiceTest
 
     recordsFuture map { records =>
       records.isDefined shouldBe true
-      records.get shouldBe Record("Work", "1234", "this is the item label", None)
+      records.get shouldBe Record("Work",
+                                  "1234",
+                                  "this is the item label",
+                                  None)
     }
   }
 

--- a/api/src/test/scala/uk/ac/wellcome/platform/api/services/ElasticSearchServiceTest.scala
+++ b/api/src/test/scala/uk/ac/wellcome/platform/api/services/ElasticSearchServiceTest.scala
@@ -1,6 +1,7 @@
 package uk.ac.wellcome.platform.api.services
 
 import com.sksamuel.elastic4s.ElasticDsl._
+import org.junit.Test
 import org.scalatest.{AsyncFunSpec, Matchers}
 import uk.ac.wellcome.models.{IdentifiedWork, SourceIdentifier, Work}
 import uk.ac.wellcome.platform.api.models.Record
@@ -46,7 +47,7 @@ class ElasticSearchServiceTest
 
     recordsFuture map { records =>
       records.isDefined shouldBe true
-      records.get shouldBe Record("Work", "1234", "this is the item label")
+      records.get shouldBe Record("Work", "1234", "this is the item label", None)
     }
   }
 
@@ -61,7 +62,8 @@ class ElasticSearchServiceTest
   private def insertIntoElasticSearch(identifiedWorks: IdentifiedWork*) = {
     identifiedWorks.foreach { identifiedWork =>
       elasticClient.execute(
-        indexInto(indexName / itemType).id(identifiedWork.canonicalId)
+        indexInto(indexName / itemType)
+          .id(identifiedWork.canonicalId)
           .doc(JsonUtil.toJson(identifiedWork).get))
     }
     eventually {


### PR DESCRIPTION
## What is this PR trying to achieve?

Return the expected result for a single `Work`

## Who is this change for?

Those wishing to consume single Work API results.

## Have the following been considered/are they needed?

- [X] Tests?
- [X] Docs?
- [X] Spoken to the right people?
