### PR TITLE
Add support for full-text search

### DIFF
--- a/api/src/main/scala/uk/ac/wellcome/platform/api/services/ElasticSearchService.scala
+++ b/api/src/main/scala/uk/ac/wellcome/platform/api/services/ElasticSearchService.scala
@@ -39,7 +39,7 @@ class ElasticSearchService @Inject()(@Flag("es.index") index: String,
     elasticClient
       .execute {
         search(s"$index/$itemType")
-          .query(queryString)
+          .query(simpleStringQuery(queryString))
           .limit(10)
       }
       .map { _.hits.map { DisplayWork(_) } }

--- a/api/src/main/scala/uk/ac/wellcome/platform/api/services/ElasticSearchService.scala
+++ b/api/src/main/scala/uk/ac/wellcome/platform/api/services/ElasticSearchService.scala
@@ -35,4 +35,13 @@ class ElasticSearchService @Inject()(@Flag("es.index") index: String,
       }
       .map { _.hits.map { DisplayWork(_) } }
 
+  def fullTextSearchWorks(queryString: String): Future[Array[DisplayWork]] =
+    elasticClient
+      .execute {
+        search(s"$index/$itemType")
+          .query(queryString)
+          .limit(10)
+      }
+      .map { _.hits.map { DisplayWork(_) } }
+
 }

--- a/api/src/test/scala/uk/ac/wellcome/platform/api/ApiWorksTest.scala
+++ b/api/src/test/scala/uk/ac/wellcome/platform/api/ApiWorksTest.scala
@@ -1,13 +1,13 @@
 package uk.ac.wellcome.platform.api
 
-import com.sksamuel.elastic4s.ElasticDsl._
 import com.twitter.finagle.http.Status
 import com.twitter.finatra.http.EmbeddedHttpServer
-import com.twitter.inject.server.FeatureTest
+import com.twitter.inject.server.FeatureTestMixin
+import org.scalatest.FunSpec
 import uk.ac.wellcome.models._
 import uk.ac.wellcome.test.utils.IndexedElasticSearchLocal
 
-class ApiWorksTest extends FeatureTest with IndexedElasticSearchLocal {
+class ApiWorksTest extends FunSpec with FeatureTestMixin with IndexedElasticSearchLocal {
 
   implicit val jsonMapper = IdentifiedWork
   override val server =
@@ -32,7 +32,7 @@ class ApiWorksTest extends FeatureTest with IndexedElasticSearchLocal {
   val period = Period("the past")
   val agent = Agent("a person")
 
-  test("it should return a list of works") {
+  it("should return a list of works") {
 
     val works = (1 to 3).map(
       (idx: Int) =>
@@ -111,7 +111,7 @@ class ApiWorksTest extends FeatureTest with IndexedElasticSearchLocal {
     }
   }
 
-  test("it should return a single work when requested with id") {
+  it("should return a single work when requested with id") {
     val identifiedWork =
       identifiedWorkWith(
         canonicalId = canonicalId,
@@ -149,8 +149,7 @@ class ApiWorksTest extends FeatureTest with IndexedElasticSearchLocal {
     }
   }
 
-  test(
-    "it should return a not found error when requesting a single work with a non existing id") {
+  it("should return a not found error when requesting a single work with a non existing id") {
     server.httpGet(
       path = "/catalogue/v0/works/non-existing-id",
       andExpect = Status.NotFound,

--- a/api/src/test/scala/uk/ac/wellcome/platform/api/ApiWorksTest.scala
+++ b/api/src/test/scala/uk/ac/wellcome/platform/api/ApiWorksTest.scala
@@ -45,7 +45,7 @@ class ApiWorksTest extends FunSpec with FeatureTestMixin with IndexedElasticSear
           creator = agent.copy(label = s"${idx}-${agent.label}")
       ))
 
-    works.map(insertIntoElasticSearch)
+    insertIntoElasticSearch(works: _*)
 
     eventually {
       server.httpGet(
@@ -157,11 +157,6 @@ class ApiWorksTest extends FunSpec with FeatureTestMixin with IndexedElasticSear
     )
   }
 
-  private def insertIntoElasticSearch(identifiedWork: IdentifiedWork): Any = {
-    elasticClient.execute(
-      indexInto(indexName / itemType)
-        .id(identifiedWork.canonicalId)
-        .doc(identifiedWork))
   }
   private def identifiedWorkWith(canonicalId: String, label: String) = {
     IdentifiedWork(canonicalId,

--- a/api/src/test/scala/uk/ac/wellcome/platform/api/services/ElasticSearchServiceTest.scala
+++ b/api/src/test/scala/uk/ac/wellcome/platform/api/services/ElasticSearchServiceTest.scala
@@ -1,17 +1,18 @@
 package uk.ac.wellcome.platform.api.services
 
 import com.sksamuel.elastic4s.ElasticDsl._
-import org.junit.Test
-import org.scalatest.{AsyncFunSpec, Matchers}
+import org.scalatest.{FunSpec, Matchers}
+import org.scalatest.concurrent.ScalaFutures
 import uk.ac.wellcome.models.{IdentifiedWork, SourceIdentifier, Work}
 import uk.ac.wellcome.platform.api.models.DisplayWork
 import uk.ac.wellcome.test.utils.IndexedElasticSearchLocal
 import uk.ac.wellcome.utils.JsonUtil
 
 class ElasticSearchServiceTest
-    extends AsyncFunSpec
+    extends FunSpec
     with IndexedElasticSearchLocal
-    with Matchers {
+    with Matchers
+    with ScalaFutures {
 
   val elasticService =
     new ElasticSearchService(indexName, itemType, elasticClient)
@@ -45,7 +46,7 @@ class ElasticSearchServiceTest
 
     val recordsFuture = elasticService.findWorkById("1234")
 
-    recordsFuture map { records =>
+    whenReady(recordsFuture) { records =>
       records.isDefined shouldBe true
       records.get shouldBe DisplayWork("Work",
                                   "1234",
@@ -57,7 +58,7 @@ class ElasticSearchServiceTest
   it("should return a future of None if it cannot get arecord by id") {
     val recordsFuture = elasticService.findWorkById("1234")
 
-    recordsFuture map { record =>
+    whenReady(recordsFuture) { record =>
       record shouldBe None
     }
   }

--- a/api/src/test/scala/uk/ac/wellcome/platform/api/services/ElasticSearchServiceTest.scala
+++ b/api/src/test/scala/uk/ac/wellcome/platform/api/services/ElasticSearchServiceTest.scala
@@ -55,6 +55,29 @@ class ElasticSearchServiceTest
     }
   }
 
+  it("should only find results that match a query if doing a full-text search") {
+    val workDodo = identifiedWorkWith(
+      canonicalId = "1234",
+      label = "A drawing of a dodo"
+    )
+    val workMouse = identifiedWorkWith(
+      canonicalId = "5678",
+      label = "A mezzotint of a mouse"
+    )
+    insertIntoElasticSearch(workDodo, workMouse)
+
+    val searchForCat = elasticService.fullTextSearchWorks("cat")
+    whenReady(searchForCat) { works =>
+      works should have size 0
+    }
+
+    val searchForDodo = elasticService.fullTextSearchWorks("dodo")
+    whenReady(searchForDodo) { works =>
+      works should have size 1
+      works.head shouldBe DisplayWork("Work", workDodo.canonicalId, workDodo.work.label)
+    }
+  }
+
   it("should return a future of None if it cannot get arecord by id") {
     val recordsFuture = elasticService.findWorkById("1234")
 

--- a/api/src/test/scala/uk/ac/wellcome/platform/api/services/ElasticSearchServiceTest.scala
+++ b/api/src/test/scala/uk/ac/wellcome/platform/api/services/ElasticSearchServiceTest.scala
@@ -86,23 +86,6 @@ class ElasticSearchServiceTest
     }
   }
 
-  private def insertIntoElasticSearch(identifiedWorks: IdentifiedWork*) = {
-    identifiedWorks.foreach { identifiedWork =>
-      elasticClient.execute(
-        indexInto(indexName / itemType)
-          .id(identifiedWork.canonicalId)
-          .doc(JsonUtil.toJson(identifiedWork).get))
-    }
-    eventually {
-      elasticClient
-        .execute {
-          search(indexName).matchAllQuery()
-        }
-        .await
-        .hits should have size identifiedWorks.size
-    }
-  }
-
   private def identifiedWorkWith(canonicalId: String, label: String) = {
     IdentifiedWork(canonicalId,
                    Work(identifiers = List(

--- a/api/src/test/scala/uk/ac/wellcome/platform/api/services/ElasticSearchServiceTest.scala
+++ b/api/src/test/scala/uk/ac/wellcome/platform/api/services/ElasticSearchServiceTest.scala
@@ -1,12 +1,11 @@
 package uk.ac.wellcome.platform.api.services
 
-import com.sksamuel.elastic4s.ElasticDsl._
 import org.scalatest.{FunSpec, Matchers}
 import org.scalatest.concurrent.ScalaFutures
 import uk.ac.wellcome.models.{IdentifiedWork, SourceIdentifier, Work}
 import uk.ac.wellcome.platform.api.models.DisplayWork
 import uk.ac.wellcome.test.utils.IndexedElasticSearchLocal
-import uk.ac.wellcome.utils.JsonUtil
+import scala.concurrent.ExecutionContext.Implicits.global
 
 class ElasticSearchServiceTest
     extends FunSpec
@@ -31,11 +30,12 @@ class ElasticSearchServiceTest
     displayWorksFuture map { displayWork =>
       displayWork should have size 2
       displayWork.head shouldBe DisplayWork("Work",
-                                   firstIdentifiedWork.canonicalId,
-                                   firstIdentifiedWork.work.label)
-      displayWork.tail.head shouldBe DisplayWork("Work",
-                                        secondIdentifiedWork.canonicalId,
-                                        secondIdentifiedWork.work.label)
+                                            firstIdentifiedWork.canonicalId,
+                                            firstIdentifiedWork.work.label)
+      displayWork.tail.head shouldBe DisplayWork(
+        "Work",
+        secondIdentifiedWork.canonicalId,
+        secondIdentifiedWork.work.label)
     }
   }
 
@@ -49,9 +49,9 @@ class ElasticSearchServiceTest
     whenReady(recordsFuture) { records =>
       records.isDefined shouldBe true
       records.get shouldBe DisplayWork("Work",
-                                  "1234",
-                                  "this is the item label",
-                                  None)
+                                       "1234",
+                                       "this is the item label",
+                                       None)
     }
   }
 
@@ -74,7 +74,9 @@ class ElasticSearchServiceTest
     val searchForDodo = elasticService.fullTextSearchWorks("dodo")
     whenReady(searchForDodo) { works =>
       works should have size 1
-      works.head shouldBe DisplayWork("Work", workDodo.canonicalId, workDodo.work.label)
+      works.head shouldBe DisplayWork("Work",
+                                      workDodo.canonicalId,
+                                      workDodo.work.label)
     }
   }
 

--- a/common/src/test/scala/uk/ac/wellcome/test/utils/IndexedElasticSearchLocal.scala
+++ b/common/src/test/scala/uk/ac/wellcome/test/utils/IndexedElasticSearchLocal.scala
@@ -3,7 +3,9 @@ package uk.ac.wellcome.test.utils
 import com.sksamuel.elastic4s.ElasticDsl._
 import org.scalatest.{BeforeAndAfterEach, Suite}
 import uk.ac.wellcome.elasticsearch.mappings.WorksIndex
+import uk.ac.wellcome.models.IdentifiedWork
 import uk.ac.wellcome.utils.GlobalExecutionContext.context
+import uk.ac.wellcome.utils.JsonUtil
 
 trait IndexedElasticSearchLocal
     extends ElasticSearchLocal
@@ -17,5 +19,23 @@ trait IndexedElasticSearchLocal
     new WorksIndex(elasticClient, indexName, itemType).create.map { _ =>
       elasticClient.execute(indexExists(indexName)).await.isExists should be(true)
     }.await
+  }
+
+  def insertIntoElasticSearch(identifiedWorks: IdentifiedWork*): Unit = {
+    identifiedWorks.foreach { identifiedWork =>
+      elasticClient.execute(
+        indexInto(indexName / itemType)
+          .id(identifiedWork.canonicalId)
+          .doc(JsonUtil.toJson(identifiedWork).get)
+      )
+    }
+    eventually {
+      elasticClient
+        .execute {
+          search(indexName).matchAllQuery()
+        }
+        .await
+        .hits should have size identifiedWorks.size
+    }
   }
 }


### PR DESCRIPTION
## What is this PR trying to achieve?

Add a `query` parameter to the API for full text search.

Resolves #135.

## Who is this change for?

Users who want to see results in a way other than “the ordering of our arbitrarily assigned identifiers”.

UX team who want to do user research around search.

## Have the following been considered/are they needed?

- [x] Tests – see patch
- [x] Docs – Swagger should automatically pick up the API changes
- [x] Spoken to the right people – based on @jtweed’s design in #135