### PR TITLE
Extract lower level ElasticSearchService from WorksService

### DIFF
--- a/api/src/main/scala/uk/ac/wellcome/platform/api/Server.scala
+++ b/api/src/main/scala/uk/ac/wellcome/platform/api/Server.scala
@@ -2,7 +2,11 @@ package uk.ac.wellcome.platform.api
 
 import com.twitter.finagle.http.{Request, Response}
 import com.twitter.finatra.http.HttpServer
-import com.twitter.finatra.http.filters.{CommonFilters, LoggingMDCFilter, TraceIdMDCFilter}
+import com.twitter.finatra.http.filters.{
+  CommonFilters,
+  LoggingMDCFilter,
+  TraceIdMDCFilter
+}
 import com.twitter.finatra.http.routing.HttpRouter
 import com.twitter.finatra.json.modules.FinatraJacksonModule
 import com.twitter.finatra.json.utils.CamelCasePropertyNamingStrategy
@@ -10,6 +14,7 @@ import io.swagger.models.Swagger
 import uk.ac.wellcome.finatra.modules._
 import uk.ac.wellcome.platform.api.controllers._
 import uk.ac.wellcome.platform.api.finatra.exceptions.ElasticsearchExceptionMapper
+import uk.ac.wellcome.platform.api.finatra.modules.ElasticSearchServiceModule.ElasticSearchServiceModule.flag
 
 object ServerMain extends Server
 object ApiSwagger extends Swagger
@@ -22,8 +27,8 @@ class Server extends HttpServer {
   override val name = "uk.ac.wellcome.platform.api Platformapi"
   override val modules = Seq(ElasticClientModule)
 
-  private final val apiHost =
-    flag(name = "api.host", default = "localhost:8888", help = "API hostname")
+  flag(name = "api.host", default = "localhost:8888", help = "API hostname")
+  
   private final val apiName =
     flag(name = "api.name", default = "catalogue", help = "API name path part")
   private final val apiVersion =
@@ -32,6 +37,7 @@ class Server extends HttpServer {
     name = "api.prefix",
     default = "/" + apiName() + "/" + apiVersion(),
     help = "API path prefix")
+
   flag[String](name = "es.index", default = "records", help = "ES index name")
   flag[String](name = "es.type", default = "item", help = "ES document type")
   flag(name = "api.context",

--- a/api/src/main/scala/uk/ac/wellcome/platform/api/controllers/WorksController.scala
+++ b/api/src/main/scala/uk/ac/wellcome/platform/api/controllers/WorksController.scala
@@ -5,25 +5,28 @@ import javax.inject.{Inject, Singleton}
 import com.github.xiaodongw.swagger.finatra.SwaggerSupport
 import com.twitter.finagle.http.Request
 import com.twitter.finatra.http.Controller
+import com.twitter.finatra.http.response.ResponseBuilder
 import com.twitter.inject.annotations.Flag
 import uk.ac.wellcome.platform.api.ApiSwagger
 import uk.ac.wellcome.platform.api.responses.{ResultListResponse, ResultResponse}
-import uk.ac.wellcome.platform.api.services.ElasticSearchService
+import uk.ac.wellcome.platform.api.services.WorksService
 import uk.ac.wellcome.platform.api.utils.ApiRequestUtils
 import uk.ac.wellcome.utils.GlobalExecutionContext.context
+
+import scala.concurrent.Future
 
 @Singleton
 class WorksController @Inject()(@Flag("api.prefix") apiPrefix: String,
                                 @Flag("api.context") apiContext: String,
                                 @Flag("api.host") apiHost: String,
-                                elasticService: ElasticSearchService)
+                                worksService: WorksService)
     extends Controller
     with SwaggerSupport
     with ApiRequestUtils {
 
   override implicit protected val swagger = ApiSwagger
 
-  override val hostName = apiHost
+  override val hostName: String = apiHost
 
   prefix(apiPrefix) {
     getWithDoc("/works") { doc =>
@@ -39,22 +42,22 @@ class WorksController @Inject()(@Flag("api.prefix") apiPrefix: String,
           "pageSize",
           "The number of works to return per page (default: 10)",
           required = false)
-        .queryParam[String](
-          "query",
-          "Full-text search query",
-          required = false)
+        .queryParam[String]("query",
+                            "Full-text search query",
+                            required = false)
     } { request: Request =>
       val works = request.params.get("query") match {
-        case Some(queryString) => elasticService.fullTextSearchWorks(queryString)
-        case None => elasticService.findWork()
+        case Some(queryString) => worksService.searchWorks(queryString)
+        case None => worksService.findWorks()
       }
+
       works
         .map(
           results =>
             response.ok.json(
-              ResultListResponse(
-                context = hostUrl(request) + apiContext,
-                results = results)))
+              ResultListResponse(context = hostUrl(request) + apiContext,
+                                 results = results)))
+
     }
 
     getWithDoc("/works/:id") { doc =>
@@ -65,14 +68,13 @@ class WorksController @Inject()(@Flag("api.prefix") apiPrefix: String,
         .routeParam[String]("id", "The work to return", required = true)
         .responseWith[Object](200, "Work")
     } { request: Request =>
-      elasticService
+      worksService
         .findWorkById(request.params("id"))
         .map {
           case Some(result) =>
             response.ok.json(
-              ResultResponse(
-                context = hostUrl(request) + apiContext,
-                result = result))
+              ResultResponse(context = hostUrl(request) + apiContext,
+                             result = result))
           case None => response.notFound
         }
     }

--- a/api/src/main/scala/uk/ac/wellcome/platform/api/finatra/modules/ElasticSearchServiceModule/ElasticSearchServiceModule.scala
+++ b/api/src/main/scala/uk/ac/wellcome/platform/api/finatra/modules/ElasticSearchServiceModule/ElasticSearchServiceModule.scala
@@ -1,0 +1,25 @@
+package uk.ac.wellcome.platform.api.finatra.modules.ElasticSearchServiceModule
+
+import com.google.inject.Provides
+import com.sksamuel.elastic4s.TcpClient
+import com.twitter.inject.TwitterModule
+import uk.ac.wellcome.finatra.modules.ElasticClientModule
+import uk.ac.wellcome.platform.api.services.ElasticSearchService
+
+object ElasticSearchServiceModule extends TwitterModule {
+  override val modules = Seq(ElasticClientModule)
+
+  private val indexName = flag[String](name = "es.index",
+                                       default = "records",
+                                       help = "ES index name")
+  private val documentType =
+    flag[String](name = "es.type", default = "item", help = "ES document type")
+
+  @Provides
+  def providesElasticSearchService(
+    elasticClient: TcpClient): ElasticSearchService =
+    new ElasticSearchService(index = indexName(),
+                             itemType = documentType(),
+                             elasticClient = elasticClient)
+
+}

--- a/api/src/main/scala/uk/ac/wellcome/platform/api/services/WorksService.scala
+++ b/api/src/main/scala/uk/ac/wellcome/platform/api/services/WorksService.scala
@@ -1,0 +1,32 @@
+package uk.ac.wellcome.platform.api.services
+
+import javax.inject.{Inject, Singleton}
+
+import com.twitter.inject.Logging
+import uk.ac.wellcome.platform.api.models.DisplayWork
+import uk.ac.wellcome.utils.GlobalExecutionContext.context
+
+import scala.concurrent.Future
+
+@Singleton
+class WorksService @Inject()(
+  searchService: ElasticSearchService
+) {
+
+  def findWorkById(canonicalId: String): Future[Option[DisplayWork]] =
+    searchService
+      .findResultById(canonicalId)
+      .map { result =>
+        if (result.exists) Some(DisplayWork(result.original)) else None
+      }
+
+  def findWorks(): Future[Array[DisplayWork]] =
+    searchService
+      .findResults(sortByField = "canonicalId")
+      .map { _.hits.map { DisplayWork(_) } }
+
+  def searchWorks(query: String): Future[Array[DisplayWork]] =
+    searchService
+      .simpleStringQueryResults(query)
+      .map { _.hits.map { DisplayWork(_) } }
+}


### PR DESCRIPTION
## What is this PR trying to achieve?

By extracting the Works specific operations from ElasticSearchService, we can then separate more reasonably the underlying generic searching operations from those specific to the Works data type.

## Who is this change for?

Developers who wish to remain sane.

## Have the following been considered/are they needed?

- [x] Tests?
- [X] Docs?
- [x] Spoken to the right people?

Depends https://github.com/wellcometrust/platform-api/pull/266
