### PR TITLE
Add a test that we successfully process malformed query strings

### DIFF
--- a/api/src/test/scala/uk/ac/wellcome/platform/api/services/ElasticSearchServiceTest.scala
+++ b/api/src/test/scala/uk/ac/wellcome/platform/api/services/ElasticSearchServiceTest.scala
@@ -88,7 +88,7 @@ class ElasticSearchServiceTest
     }
   }
 
-  it("should correctly handle an invalid query string") {
+  it("should not throw an exception if passed an invalid query string for full-text search") {
     val workEmu = identifiedWorkWith(
       canonicalId = "1234",
       label = "An etching of an emu"

--- a/api/src/test/scala/uk/ac/wellcome/platform/api/services/ElasticSearchServiceTest.scala
+++ b/api/src/test/scala/uk/ac/wellcome/platform/api/services/ElasticSearchServiceTest.scala
@@ -88,6 +88,25 @@ class ElasticSearchServiceTest
     }
   }
 
+  it("should correctly handle an invalid query string") {
+    val workEmu = identifiedWorkWith(
+      canonicalId = "1234",
+      label = "An etching of an emu"
+    )
+    insertIntoElasticSearch(workEmu)
+
+    val searchForEmu = elasticService.fullTextSearchWorks(
+      "emu \"unmatched quotes are a lexical error in the Elasticsearch parser"
+    )
+
+    whenReady(searchForEmu) { works =>
+      works should have size 1
+      works.head shouldBe DisplayWork("Work",
+                                      workEmu.canonicalId,
+                                      workEmu.work.label)
+    }
+  }
+
   private def identifiedWorkWith(canonicalId: String, label: String) = {
     IdentifiedWork(canonicalId,
                    Work(identifiers = List(


### PR DESCRIPTION
This checks that we really are using the simple text parser, and won't return an error on a malformed query.

## What is this PR trying to achieve?

Prevent us regressing our search functionality.

## Who is this change for?

Developers who want a safety net.

## Have the following been considered/are they needed?

- [x] Tests – in the patch
- [x] Docs – not required
- [x] Spoken to the right people – discussed with @alicefuzier to write patch