### PR TITLE
Add a bare bones demo search form

### DIFF
--- a/demo_search_form.html
+++ b/demo_search_form.html
@@ -1,0 +1,56 @@
+<html>
+
+<head>
+  <style>
+    input, button {
+      font-size: 1.1em;
+    }
+    body {
+      padding-top: 1em;
+      max-width: 800px;
+      margin-left:  auto;
+      margin-right: auto;
+    }
+    li {
+      line-height: 1.4em;
+      margin-bottom: 8px;
+    }
+  </style>
+  <script src="http://code.jquery.com/jquery-3.2.1.min.js"></script>
+</head>
+
+<body>
+
+  <h1>Platform search demo</h1>
+
+  <input type="text" size="40" id="search_box">
+  <button onclick="script:doASearch()">Search!</button>
+
+  <p id="search_url"></p>
+  <ul id="results"></ul>
+
+  <script>
+
+    doASearch = function() {
+      var searchQuery = $('#search_box')[0].value;
+      var searchUrl = 'https://api.wellcomecollection.org/catalogue/v0/works?' + $.param({query: searchQuery});
+
+      $('#search_url')[0].innerHTML = "Fetching API response from <a href=" + searchUrl + ">" + searchUrl + "</a>:";
+      $('#results')[0].innerHTML = "";
+      $.ajax({
+        url: searchUrl,
+        success: function(response) {
+          var results = response.results;
+          for (var i = 0; i < results.length; i++) {
+            var result = results[i];
+            console.log(result);
+            $('#results')[0].innerHTML += "<li><strong>ID:</strong> " + result.id + "<br><strong>Label: </strong>" + result.label + "<br><strong>Description: </strong>" + result.description + "</li>";
+          }
+        },
+      });
+    };
+  </script>
+
+</body>
+
+</html>

--- a/demo_search_form.html
+++ b/demo_search_form.html
@@ -10,10 +10,14 @@
       max-width: 800px;
       margin-left:  auto;
       margin-right: auto;
+      padding: 15px;
     }
     li {
       line-height: 1.4em;
       margin-bottom: 8px;
+    }
+    input {
+      width: 70%;
     }
   </style>
   <script src="http://code.jquery.com/jquery-3.2.1.min.js"></script>
@@ -23,7 +27,7 @@
 
   <h1>Platform search demo</h1>
 
-  <input type="text" size="40" id="search_box">
+  <input type="text" id="search_box">
   <button onclick="script:doASearch()">Search!</button>
 
   <p id="search_url"></p>


### PR DESCRIPTION
## What is this PR trying to achieve?

Add a barebones page that demonstrates the full text search. Resolves #272.

![screen shot 2017-05-10 at 17 07 50](https://cloud.githubusercontent.com/assets/301220/25908978/9f4e39d0-35a3-11e7-8864-320f27768c5b.png)

## Who is this change for?

* A team that want something pretty to demo
* Users who don't want to look at JSON
* Awestruck developers who want to appreciate my l33t HTML and CSS skills

## Have the following been considered/are they needed?

- [x] Tests – not required
- [x] Docs – ditto
- [x] Spoken to the right people?