### PR TITLE
Fix transformer flakyness

### DIFF
--- a/transformer/src/test/scala/uk/ac/wellcome/transformer/CalmTransformerFeatureTest.scala
+++ b/transformer/src/test/scala/uk/ac/wellcome/transformer/CalmTransformerFeatureTest.scala
@@ -7,7 +7,7 @@ import com.amazonaws.services.kinesis.clientlibrary.lib.worker.KinesisClientLibC
 import com.amazonaws.services.sns.AmazonSNS
 import com.gu.scanamo.Scanamo
 import com.twitter.finatra.http.EmbeddedHttpServer
-import org.scalatest.concurrent.{Eventually, IntegrationPatience}
+import org.scalatest.concurrent.Eventually
 import org.scalatest.{FunSpec, Matchers}
 import uk.ac.wellcome.models.{CalmTransformable, SourceIdentifier, Work}
 import uk.ac.wellcome.platform.transformer.Server
@@ -19,7 +19,6 @@ class CalmTransformerFeatureTest
     extends FunSpec
     with TransformerFeatureTest
     with Eventually
-    with IntegrationPatience
     with Matchers {
 
   private val appName = "test-transformer-calm"

--- a/transformer/src/test/scala/uk/ac/wellcome/transformer/MiroTransformerFeatureTest.scala
+++ b/transformer/src/test/scala/uk/ac/wellcome/transformer/MiroTransformerFeatureTest.scala
@@ -7,7 +7,7 @@ import com.amazonaws.services.kinesis.clientlibrary.lib.worker.KinesisClientLibC
 import com.amazonaws.services.sns.AmazonSNS
 import com.gu.scanamo.Scanamo
 import com.twitter.finatra.http.EmbeddedHttpServer
-import org.scalatest.concurrent.{Eventually, IntegrationPatience}
+import org.scalatest.concurrent.Eventually
 import org.scalatest.{FunSpec, Matchers}
 import uk.ac.wellcome.models.{MiroTransformable, Work}
 import uk.ac.wellcome.platform.transformer.Server
@@ -19,7 +19,6 @@ class MiroTransformerFeatureTest
     extends FunSpec
     with TransformerFeatureTest
     with Eventually
-    with IntegrationPatience
     with Matchers {
 
   private val appName = "test-transformer-miro"

--- a/transformer/src/test/scala/uk/ac/wellcome/transformer/utils/TransformerFeatureTest.scala
+++ b/transformer/src/test/scala/uk/ac/wellcome/transformer/utils/TransformerFeatureTest.scala
@@ -5,10 +5,13 @@ import com.amazonaws.services.kinesis.clientlibrary.lib.worker.KinesisClientLibC
 import com.amazonaws.services.kinesis.metrics.interfaces.MetricsLevel
 import com.twitter.inject.server.FeatureTestMixin
 import org.scalatest.Suite
+import org.scalatest.concurrent.PatienceConfiguration
+import org.scalatest.time.{Millis, Seconds, Span}
 import uk.ac.wellcome.test.utils.{DynamoDBLocal, SNSLocal}
 
 trait TransformerFeatureTest
     extends FeatureTestMixin
+    with PatienceConfiguration
     with SNSLocal
     with DynamoDBLocal { this: Suite =>
 
@@ -25,4 +28,9 @@ trait TransformerFeatureTest
       java.util.UUID.randomUUID.toString)
     //turn off metric logging in tests so we don't see error logs about not being able to publish to cloudwatch
       .withMetricsLevel(MetricsLevel.NONE)
+
+  override implicit val patienceConfig = PatienceConfig(
+    timeout = scaled(Span(40, Seconds)),
+    interval = scaled(Span(150, Millis))
+  )
 }


### PR DESCRIPTION
## What is this PR trying to achieve?
Again, fix some of our flakey tests. We seem to have a too strict timeout sometimes on the transformer finishing and also the kinesis worker keeps working long after the server has stopped 
## Who is this change for?
Developers who like reliable builds
## Have the following been considered/are they needed?

- [x] Tests?
- [x] Docs?
- [x] Spoken to the right people?
