### PR TITLE
Stop scheduling id_minter and ingestor run if they are being shutdown

### DIFF
--- a/ingestor/src/main/scala/uk/ac/wellcome/platform/ingestor/modules/SQSWorker.scala
+++ b/ingestor/src/main/scala/uk/ac/wellcome/platform/ingestor/modules/SQSWorker.scala
@@ -45,7 +45,7 @@ object SQSWorker extends TwitterModule with TryBackoff {
 
   override def singletonShutdown(injector: Injector) {
     info("Terminating SQS worker")
-
+    cancelRun()
     val system = injector.instance[ActorSystem]
     system.terminate()
   }

--- a/ingestor/src/test/scala/uk/ac/wellcome/platform/ingestor/IngestorFeatureTest.scala
+++ b/ingestor/src/test/scala/uk/ac/wellcome/platform/ingestor/IngestorFeatureTest.scala
@@ -94,5 +94,6 @@ class IngestorFeatureTest
         result.isExists should be(true)
       }
     }
+    server.close()
   }
 }


### PR DESCRIPTION
## What is this PR trying to achieve?
Reduce fake error logs in tests, so partially addressing #199 .Also, It looks like stuff hanging around makes tests timeout more often although I haven't seen it happen on CI
## Who is this change for?
Developers who like to able to read test logs
## Have the following been considered/are they needed?

- [x] Tests? There are none. Not sure if it's possible to test this really, but TryBackoff should have tests, I'll create them in another pull request
- [ ] Docs?
- [ ] Spoken to the right people?
