### PR TITLE
Add proper bounds to ?page and ?pageSize queries

### DIFF
--- a/api/src/main/scala/uk/ac/wellcome/platform/api/controllers/WorksController.scala
+++ b/api/src/main/scala/uk/ac/wellcome/platform/api/controllers/WorksController.scala
@@ -16,7 +16,7 @@ import uk.ac.wellcome.platform.api.services.WorksService
 import uk.ac.wellcome.utils.GlobalExecutionContext.context
 import com.twitter.finatra.validation._
 
-case class UsersRequest(@QueryParam page: Int = 1,
+case class UsersRequest(@Min(1) @QueryParam page: Int = 1,
                         @Min(1) @Max(100) @QueryParam pageSize: Option[Int],
                         @QueryParam query: Option[String]) {
 }

--- a/api/src/main/scala/uk/ac/wellcome/platform/api/controllers/WorksController.scala
+++ b/api/src/main/scala/uk/ac/wellcome/platform/api/controllers/WorksController.scala
@@ -17,7 +17,7 @@ import uk.ac.wellcome.utils.GlobalExecutionContext.context
 import com.twitter.finatra.validation._
 
 case class UsersRequest(@QueryParam page: Int = 1,
-                        @Max(100) @QueryParam pageSize: Option[Int],
+                        @Min(1) @Max(100) @QueryParam pageSize: Option[Int],
                         @QueryParam query: Option[String]) {
 }
 

--- a/api/src/test/scala/uk/ac/wellcome/platform/api/ApiWorksTest.scala
+++ b/api/src/test/scala/uk/ac/wellcome/platform/api/ApiWorksTest.scala
@@ -220,6 +220,15 @@ class ApiWorksTest
     )
   }
 
+  it("should return an HTTP Bad Request error if the user asks for a page size just over the maximum") {
+    val pageSize = 101
+    server.httpGet(
+      path = s"/catalogue/v0/works?pageSize=$pageSize",
+      andExpect = Status.BadRequest,
+      withJsonBody = s"""{"errors":["pageSize: [$pageSize] is not less than or equal to 100"]}"""
+    )
+  }
+
   it("should return an HTTP Bad Request error if the user asks for an overly large page size") {
     val pageSize = 100000
     server.httpGet(

--- a/api/src/test/scala/uk/ac/wellcome/platform/api/ApiWorksTest.scala
+++ b/api/src/test/scala/uk/ac/wellcome/platform/api/ApiWorksTest.scala
@@ -220,6 +220,15 @@ class ApiWorksTest
     )
   }
 
+  it("should return an HTTP Bad Request error if the user asks for an overly large page size") {
+    val pageSize = 100000
+    server.httpGet(
+      path = s"/catalogue/v0/works?pageSize=$pageSize",
+      andExpect = Status.BadRequest,
+      withJsonBody = s"""{"errors":["pageSize: [$pageSize] is not less than or equal to 100"]}"""
+    )
+  }
+
   it("should return matching results if doing a full-text search") {
     val work1 = identifiedWorkWith(
       canonicalId = "1234",

--- a/api/src/test/scala/uk/ac/wellcome/platform/api/ApiWorksTest.scala
+++ b/api/src/test/scala/uk/ac/wellcome/platform/api/ApiWorksTest.scala
@@ -229,6 +229,22 @@ class ApiWorksTest
     )
   }
 
+  it("should return an HTTP Bad Request error if the user asks for zero-length pages") {
+    server.httpGet(
+      path = "/catalogue/v0/works?pageSize=0",
+      andExpect = Status.BadRequest,
+      withJsonBody = s"""{"errors":["pageSize: [0] is not greater than or equal to 1"]}"""
+    )
+  }
+
+  it("should return an HTTP Bad Request error if the user asks for a negative page size") {
+    server.httpGet(
+      path = s"/catalogue/v0/works?pageSize=-50",
+      andExpect = Status.BadRequest,
+      withJsonBody = s"""{"errors":["pageSize: [-50] is not greater than or equal to 1"]}"""
+    )
+  }
+
   it("should return matching results if doing a full-text search") {
     val work1 = identifiedWorkWith(
       canonicalId = "1234",

--- a/api/src/test/scala/uk/ac/wellcome/platform/api/ApiWorksTest.scala
+++ b/api/src/test/scala/uk/ac/wellcome/platform/api/ApiWorksTest.scala
@@ -245,6 +245,22 @@ class ApiWorksTest
     )
   }
 
+  it("should return an HTTP Bad Request error if the user asks for page 0") {
+    server.httpGet(
+      path = "/catalogue/v0/works?page=0",
+      andExpect = Status.BadRequest,
+      withJsonBody = s"""{"errors":["page: [0] is not greater than or equal to 1"]}"""
+    )
+  }
+
+  it("should return an HTTP Bad Request error if the user asks for a page before 0") {
+    server.httpGet(
+      path = "/catalogue/v0/works?page=-50",
+      andExpect = Status.BadRequest,
+      withJsonBody = s"""{"errors":["page: [-50] is not greater than or equal to 1"]}"""
+    )
+  }
+
   it("should return matching results if doing a full-text search") {
     val work1 = identifiedWorkWith(
       canonicalId = "1234",


### PR DESCRIPTION
## What is this PR trying to achieve?

Add some extra bounds checking and tests around extreme page and pageSize query parameters. Resolves #279.

## Who is this change for?

Users who want helpful error messages. Developers who don't like server errors.

## Have the following been considered/are they needed?

- [x] Tests – in the patch
- [x] Docs – no explicit docs, error messages should be sufficient
- [x] Spoken to the right people – not required