### PR TITLE
Turn logs off for StartupTests

### DIFF
--- a/calm_adapter/src/test/scala/uk/ac/wellcome/calm_adapter/StartupTest.scala
+++ b/calm_adapter/src/test/scala/uk/ac/wellcome/calm_adapter/StartupTest.scala
@@ -2,14 +2,15 @@ package uk.ac.wellcome.platform.calm_adapter
 
 import com.google.inject.Stage
 import com.twitter.finatra.http.EmbeddedHttpServer
-import com.twitter.inject.server.WordSpecFeatureTest
+import com.twitter.inject.server.FeatureTest
+import uk.ac.wellcome.test.utils.StartupLogbackOverride
 
-class StartupTest extends WordSpecFeatureTest {
+class StartupTest extends FeatureTest with StartupLogbackOverride  {
 
   val server = new EmbeddedHttpServer(stage = Stage.PRODUCTION,
                                       twitterServer = new Server)
 
-  "server" in {
+  test("server starts up correctly") {
     server.assertHealthy()
   }
 }

--- a/common/src/test/resources/logback-startup-test.xml
+++ b/common/src/test/resources/logback-startup-test.xml
@@ -1,0 +1,13 @@
+<configuration>
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <!-- encoders are assigned the type
+             ch.qos.logback.classic.encoder.PatternLayoutEncoder by default -->
+        <encoder>
+            <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <root level="OFF">
+        <appender-ref ref="STDOUT" />
+    </root>
+</configuration>

--- a/common/src/test/scala/uk/ac/wellcome/test/utils/StartupLogbackOverride.scala
+++ b/common/src/test/scala/uk/ac/wellcome/test/utils/StartupLogbackOverride.scala
@@ -1,0 +1,19 @@
+package uk.ac.wellcome.test.utils
+
+import ch.qos.logback.classic.LoggerContext
+import ch.qos.logback.classic.joran.JoranConfigurator
+import org.apache.commons.io.IOUtils
+import org.slf4j.LoggerFactory
+
+import scala.tools.nsc.classpath.FileUtils
+
+trait StartupLogbackOverride {
+  val loggerContext =
+    LoggerFactory.getILoggerFactory.asInstanceOf[LoggerContext]
+  loggerContext.reset
+  val configurator = new JoranConfigurator
+  configurator.setContext(loggerContext)
+  configurator.doConfigure(
+    getClass
+      .getResourceAsStream("/logback-startup-test.xml"))
+}

--- a/common/src/test/scala/uk/ac/wellcome/test/utils/StartupLogbackOverride.scala
+++ b/common/src/test/scala/uk/ac/wellcome/test/utils/StartupLogbackOverride.scala
@@ -2,10 +2,7 @@ package uk.ac.wellcome.test.utils
 
 import ch.qos.logback.classic.LoggerContext
 import ch.qos.logback.classic.joran.JoranConfigurator
-import org.apache.commons.io.IOUtils
 import org.slf4j.LoggerFactory
-
-import scala.tools.nsc.classpath.FileUtils
 
 trait StartupLogbackOverride {
   val loggerContext =

--- a/id_minter/src/test/scala/uk/ac/wellcome/platform/idminter/StartupTest.scala
+++ b/id_minter/src/test/scala/uk/ac/wellcome/platform/idminter/StartupTest.scala
@@ -4,8 +4,9 @@ import com.google.inject.Stage
 import com.twitter.finatra.http.EmbeddedHttpServer
 import com.twitter.inject.server.FeatureTest
 import com.twitter.finagle.http.Status._
+import uk.ac.wellcome.test.utils.StartupLogbackOverride
 
-class StartupTest extends FeatureTest {
+class StartupTest extends FeatureTest with StartupLogbackOverride {
 
   val server = new EmbeddedHttpServer(stage = Stage.PRODUCTION,
                                       twitterServer = new Server)

--- a/ingestor/src/test/scala/uk/ac/wellcome/platform/ingestor/StartupTest.scala
+++ b/ingestor/src/test/scala/uk/ac/wellcome/platform/ingestor/StartupTest.scala
@@ -3,8 +3,9 @@ package uk.ac.wellcome.platform.ingestor
 import com.google.inject.Stage
 import com.twitter.finatra.http.EmbeddedHttpServer
 import com.twitter.inject.server.FeatureTest
+import uk.ac.wellcome.test.utils.StartupLogbackOverride
 
-class StartupTest extends FeatureTest {
+class StartupTest extends FeatureTest with StartupLogbackOverride {
 
   val server = new EmbeddedHttpServer(stage = Stage.PRODUCTION,
                                       twitterServer = new Server)

--- a/transformer/src/test/scala/uk/ac/wellcome/transformer/StartupTest.scala
+++ b/transformer/src/test/scala/uk/ac/wellcome/transformer/StartupTest.scala
@@ -3,8 +3,9 @@ package uk.ac.wellcome.platform.transformer
 import com.google.inject.Stage
 import com.twitter.finatra.http.EmbeddedHttpServer
 import com.twitter.inject.server.FeatureTest
+import uk.ac.wellcome.test.utils.StartupLogbackOverride
 
-class StartupTest extends FeatureTest {
+class StartupTest extends FeatureTest with StartupLogbackOverride {
 
   val server = new EmbeddedHttpServer(
     stage = Stage.PRODUCTION,


### PR DESCRIPTION
StartupTests start servers without the overridden modules to connect to the local instances of Dynamo, SQS, etc. Since they try to connect to the real AWS instances but none of the flags with resource names are set (and shouldn't be) they output a lot of errors about not being able to connect to them. The tests still pass as these tests are only testing that all the Guice wiring is correct and the application can startup. So, the error logs are meaningless and make debugging failing tests quite hard. Hence this shitty hack, which does make logs more sane

## What is this PR trying to achieve?
More sensible test logs (resolves #199 )
## Who is this change for?
Devs
## Have the following been considered/are they needed?

- [x] Tests?
- [x] Docs?
- [x] Spoken to the right people?
