### PR TITLE
Adds hard coded host and scheme to SwaggerController as other API endoints

### DIFF
--- a/api/src/main/scala/uk/ac/wellcome/platform/api/controllers/SwaggerController.scala
+++ b/api/src/main/scala/uk/ac/wellcome/platform/api/controllers/SwaggerController.scala
@@ -13,9 +13,17 @@ import uk.ac.wellcome.platform.api.ApiSwagger
 
 @Singleton
 class SwaggerController @Inject()(
+  @Flag("api.scheme") apiScheme: String,
   @Flag("api.prefix") apiPrefix: String,
-  @Flag("api.version") apiVersion: String
+  @Flag("api.version") apiVersion: String,
+  @Flag("api.host") apiHost: String
 ) extends Controller {
+
+
+  val scheme = apiScheme match {
+    case "https" => Scheme.HTTPS
+    case _ => Scheme.HTTP
+  }
 
   prefix(apiPrefix) {
 
@@ -25,8 +33,8 @@ class SwaggerController @Inject()(
           .description("Search our collections")
           .version(apiVersion)
           .title("Catalogue"))
-      ApiSwagger.scheme(Scheme.HTTPS)
-      ApiSwagger.host(request.host.getOrElse("api.wellcomecollection.org"))
+      ApiSwagger.scheme(scheme)
+      ApiSwagger.host(apiHost)
       ApiSwagger.basePath(apiPrefix)
       ApiSwagger.produces("application/json")
       ApiSwagger.produces("application/ld+json")

--- a/api/src/test/scala/uk/ac/wellcome/platform/api/ApiSwaggerTest.scala
+++ b/api/src/test/scala/uk/ac/wellcome/platform/api/ApiSwaggerTest.scala
@@ -1,0 +1,45 @@
+package uk.ac.wellcome.platform.api
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.twitter.finagle.http.{Response, Status}
+import com.twitter.finatra.http.EmbeddedHttpServer
+import com.twitter.inject.server.FeatureTestMixin
+import org.scalatest.FunSpec
+import uk.ac.wellcome.models._
+import uk.ac.wellcome.test.utils.IndexedElasticSearchLocal
+import uk.ac.wellcome.utils.JsonUtil.mapper
+
+class ApiSwaggerTest
+    extends FunSpec
+    with FeatureTestMixin {
+
+  implicit val jsonMapper = IdentifiedWork
+  override val server =
+    new EmbeddedHttpServer(
+      new Server,
+      flags = Map(
+        "api.host" -> "test.host",
+        "api.scheme" -> "http",
+        "api.version" -> "v99",
+        "api.name" -> "test"
+      )
+    )
+
+  it("should return a valid JSON response") {
+    val response: Response = server.httpGet(
+      path = "/test/v99/swagger.json",
+      andExpect = Status.Ok
+    )
+
+    val mapper = new ObjectMapper()
+
+    noException should be thrownBy { mapper.readTree(response.contentString) }
+
+    val tree = mapper.readTree(response.contentString)
+
+    tree.at("/host").toString should be ("\"test.host\"")
+    tree.at("/schemes").toString should be ("[\"http\"]")
+    tree.at("/info/version").toString should be ("\"v99\"")
+    tree.at("/basePath").toString should be ("\"/test/v99\"")
+  }
+}


### PR DESCRIPTION
## What is this PR trying to achieve?

Being able to update the API docs.

## Who is this change for?

Folks who want to see and use the API docs.

## Have the following been considered/are they needed?

- [X] Tests?
- [X] Docs?
- [X] Spoken to the right people?
