### PR TITLE
Fix Ingestor DLQ behaviour

### DIFF
--- a/common/src/test/scala/uk/ac/wellcome/sqs/SQSReaderTest.scala
+++ b/common/src/test/scala/uk/ac/wellcome/sqs/SQSReaderTest.scala
@@ -7,7 +7,10 @@ import uk.ac.wellcome.models.aws.SQSConfig
 import uk.ac.wellcome.test.utils.SQSLocal
 
 import scala.collection.JavaConversions._
+import scala.concurrent.Future
 import scala.concurrent.duration._
+
+import uk.ac.wellcome.utils.GlobalExecutionContext.context
 
 class SQSReaderTest
     extends FunSpec
@@ -17,11 +20,15 @@ class SQSReaderTest
 
   val queuesInfo = createQueueAndDlqReturnUrls("test_queue")
   // Setting 1 second timeout for tests, so that test don't have to wait too long to test message deletion
-  sqsClient.setQueueAttributes(queuesInfo.queueUrl, Map("VisibilityTimeout" -> "1"))
+  sqsClient.setQueueAttributes(queuesInfo.queueUrl,
+                               Map("VisibilityTimeout" -> "1"))
 
   it("should get messages from the SQS queue, limited by the maximum number of messages and return them") {
     val sqsConfig =
-      SQSConfig("eu-west-1", queuesInfo.queueUrl, waitTime = 20 seconds, maxMessages = 2)
+      SQSConfig("eu-west-1",
+                queuesInfo.queueUrl,
+                waitTime = 20 seconds,
+                maxMessages = 2)
     val messageStrings = List("someMessage1", "someMessage2", "someMessage3")
     messageStrings.foreach(sqsClient.sendMessage(queuesInfo.queueUrl, _))
     val sqsReader =
@@ -29,8 +36,10 @@ class SQSReaderTest
 
     var receivedMessages: List[Message] = Nil
 
-    val futureMessages = sqsReader.retrieveAndDeleteMessages(message =>
-      receivedMessages = message :: receivedMessages)
+    val futureMessages = sqsReader.retrieveAndDeleteMessages(message => {
+      receivedMessages = message :: receivedMessages
+      Future.successful(())
+    })
 
     whenReady(futureMessages) { _ =>
       receivedMessages should have size 2
@@ -51,16 +60,19 @@ class SQSReaderTest
                 maxMessages = 1)
     val sqsReader = new SQSReader(sqsClient, sqsConfig)
 
-    val futureMessages = sqsReader.retrieveAndDeleteMessages(_ => ())
+    val futureMessages = sqsReader.retrieveAndDeleteMessages(_ => Future.successful(()))
 
     whenReady(futureMessages.failed) { exception =>
       exception.getMessage should not be (empty)
     }
   }
 
-  it("should return a failed future if processing one of the messages fails - the failed message should not be deleted") {
+  it("should return a failed future if processing one of the messages throws an exception - the failed message should not be deleted") {
     val sqsConfig =
-      SQSConfig("eu-west-1", queuesInfo.queueUrl, waitTime = 20 seconds, maxMessages = 10)
+      SQSConfig("eu-west-1",
+                queuesInfo.queueUrl,
+                waitTime = 20 seconds,
+                maxMessages = 10)
 
     val failingMessage = "This message will fail"
     val messageStrings = List("This is the first message",
@@ -73,7 +85,36 @@ class SQSReaderTest
     val futureMessages = sqsReader.retrieveAndDeleteMessages { message =>
       if (message.getBody == failingMessage)
         throw new RuntimeException(s"$failingMessage is not valid")
-      else message
+      else Future.successful(message)
+    }
+
+    whenReady(futureMessages.failed) { exception =>
+      exception shouldBe a[RuntimeException]
+    }
+
+    assertNumberOfMessagesAfterVisibilityTimeoutIs(1, sqsReader)
+  }
+
+  it("should return a failed future if processing one of the messages returns a failed future - the failed message should not be deleted") {
+    val sqsConfig =
+      SQSConfig("eu-west-1",
+                queuesInfo.queueUrl,
+                waitTime = 20 seconds,
+                maxMessages = 10)
+
+    val failingMessage = "This message will fail"
+    val messageStrings = List("This is the first message",
+                              failingMessage,
+                              "This is the final message")
+    messageStrings.foreach(sqsClient.sendMessage(queuesInfo.queueUrl, _))
+    val sqsReader =
+      new SQSReader(sqsClient, sqsConfig)
+
+    val futureMessages = sqsReader.retrieveAndDeleteMessages { message =>
+      if (message.getBody == failingMessage)
+        Future { throw new RuntimeException(s"$failingMessage is not valid") }
+      else
+        Future.successful(message)
     }
 
     whenReady(futureMessages.failed) { exception =>
@@ -90,7 +131,10 @@ class SQSReaderTest
     Thread.sleep(1500)
     var receivedMessages: List[Message] = Nil
     val nextMessages = sqsReader.retrieveAndDeleteMessages(message =>
-      receivedMessages = message :: receivedMessages)
+      {
+        receivedMessages = message :: receivedMessages
+        Future.successful(())
+      })
     whenReady(nextMessages) { _ =>
       receivedMessages should have size expectedNumberOfMessages
     }

--- a/common/src/test/scala/uk/ac/wellcome/sqs/SQSReaderTest.scala
+++ b/common/src/test/scala/uk/ac/wellcome/sqs/SQSReaderTest.scala
@@ -18,19 +18,19 @@ class SQSReaderTest
     with ScalaFutures
     with SQSLocal {
 
-  val queuesInfo = createQueueAndDlqReturnUrls("test_queue")
+  val queueUrl = createQueueAndReturnUrl("test_queue")
   // Setting 1 second timeout for tests, so that test don't have to wait too long to test message deletion
-  sqsClient.setQueueAttributes(queuesInfo.queueUrl,
+  sqsClient.setQueueAttributes(queueUrl,
                                Map("VisibilityTimeout" -> "1"))
 
   it("should get messages from the SQS queue, limited by the maximum number of messages and return them") {
     val sqsConfig =
       SQSConfig("eu-west-1",
-                queuesInfo.queueUrl,
+                queueUrl,
                 waitTime = 20 seconds,
                 maxMessages = 2)
     val messageStrings = List("someMessage1", "someMessage2", "someMessage3")
-    messageStrings.foreach(sqsClient.sendMessage(queuesInfo.queueUrl, _))
+    messageStrings.foreach(sqsClient.sendMessage(queueUrl, _))
     val sqsReader =
       new SQSReader(sqsClient, sqsConfig)
 
@@ -70,7 +70,7 @@ class SQSReaderTest
   it("should return a failed future if processing one of the messages throws an exception - the failed message should not be deleted") {
     val sqsConfig =
       SQSConfig("eu-west-1",
-                queuesInfo.queueUrl,
+                queueUrl,
                 waitTime = 20 seconds,
                 maxMessages = 10)
 
@@ -78,7 +78,7 @@ class SQSReaderTest
     val messageStrings = List("This is the first message",
                               failingMessage,
                               "This is the final message")
-    messageStrings.foreach(sqsClient.sendMessage(queuesInfo.queueUrl, _))
+    messageStrings.foreach(sqsClient.sendMessage(queueUrl, _))
     val sqsReader =
       new SQSReader(sqsClient, sqsConfig)
 
@@ -98,7 +98,7 @@ class SQSReaderTest
   it("should return a failed future if processing one of the messages returns a failed future - the failed message should not be deleted") {
     val sqsConfig =
       SQSConfig("eu-west-1",
-                queuesInfo.queueUrl,
+                queueUrl,
                 waitTime = 20 seconds,
                 maxMessages = 10)
 
@@ -106,7 +106,7 @@ class SQSReaderTest
     val messageStrings = List("This is the first message",
                               failingMessage,
                               "This is the final message")
-    messageStrings.foreach(sqsClient.sendMessage(queuesInfo.queueUrl, _))
+    messageStrings.foreach(sqsClient.sendMessage(queueUrl, _))
     val sqsReader =
       new SQSReader(sqsClient, sqsConfig)
 

--- a/common/src/test/scala/uk/ac/wellcome/sqs/SQSReaderTest.scala
+++ b/common/src/test/scala/uk/ac/wellcome/sqs/SQSReaderTest.scala
@@ -1,7 +1,7 @@
 package uk.ac.wellcome.sqs
 
 import com.amazonaws.services.sqs.model.Message
-import org.scalatest.concurrent.{IntegrationPatience, ScalaFutures}
+import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.{FunSpec, Matchers}
 import uk.ac.wellcome.models.aws.SQSConfig
 import uk.ac.wellcome.test.utils.SQSLocal
@@ -13,7 +13,6 @@ class SQSReaderTest
     extends FunSpec
     with Matchers
     with ScalaFutures
-    with IntegrationPatience
     with SQSLocal {
 
   val queuesInfo = createQueueAndDlqReturnUrls("test_queue")

--- a/common/src/test/scala/uk/ac/wellcome/test/utils/ExtendedPatience.scala
+++ b/common/src/test/scala/uk/ac/wellcome/test/utils/ExtendedPatience.scala
@@ -1,10 +1,10 @@
 package uk.ac.wellcome.test.utils
 
-import org.scalatest.concurrent.AbstractPatienceConfiguration
+import org.scalatest.concurrent.PatienceConfiguration
 import org.scalatest.time.{Millis, Seconds, Span}
 
-trait ExtendedPatience extends AbstractPatienceConfiguration {
-  implicit override val patienceConfig: PatienceConfig = PatienceConfig(
+trait ExtendedPatience extends PatienceConfiguration {
+  override implicit val patienceConfig: PatienceConfig = PatienceConfig(
     timeout = scaled(Span(15, Seconds)),
     interval = scaled(Span(150, Millis))
   )

--- a/common/src/test/scala/uk/ac/wellcome/test/utils/ExtendedPatience.scala
+++ b/common/src/test/scala/uk/ac/wellcome/test/utils/ExtendedPatience.scala
@@ -1,12 +1,11 @@
 package uk.ac.wellcome.test.utils
 
-import org.scalatest.concurrent.PatienceConfiguration
+import org.scalatest.concurrent.AbstractPatienceConfiguration
 import org.scalatest.time.{Millis, Seconds, Span}
 
-trait ExtendedPatience extends PatienceConfiguration{
-
-  override implicit val patienceConfig = PatienceConfig(
-    timeout = scaled(Span(40, Seconds)),
+trait ExtendedPatience extends AbstractPatienceConfiguration {
+  implicit override val patienceConfig: PatienceConfig = PatienceConfig(
+    timeout = scaled(Span(15, Seconds)),
     interval = scaled(Span(150, Millis))
   )
 }

--- a/common/src/test/scala/uk/ac/wellcome/test/utils/SQSLocal.scala
+++ b/common/src/test/scala/uk/ac/wellcome/test/utils/SQSLocal.scala
@@ -2,17 +2,18 @@ package uk.ac.wellcome.test.utils
 
 import com.amazonaws.auth.{AWSStaticCredentialsProvider, BasicAWSCredentials}
 import com.amazonaws.client.builder.AwsClientBuilder.EndpointConfiguration
-import com.amazonaws.services.sqs.model.PurgeQueueRequest
+import com.amazonaws.services.sqs.model.{ListQueuesResult, PurgeQueueRequest}
 import com.amazonaws.services.sqs.{AmazonSQS, AmazonSQSClientBuilder}
-import com.google.inject.{Provides, Singleton}
-import com.twitter.inject.TwitterModule
 import org.scalatest.concurrent.{Eventually, IntegrationPatience}
-import org.scalatest.{BeforeAndAfterEach, Suite}
+import org.scalatest.{BeforeAndAfterEach, Matchers, Suite}
+
+import scala.collection.JavaConversions._
 
 trait SQSLocal
     extends BeforeAndAfterEach
     with Eventually
-    with IntegrationPatience { this: Suite =>
+    with IntegrationPatience
+    with Matchers { this: Suite =>
 
   val sqsClient: AmazonSQS = AmazonSQSClientBuilder
     .standard()
@@ -22,20 +23,38 @@ trait SQSLocal
       new EndpointConfiguration(s"http://localhost:9324", "localhost"))
     .build()
 
+  // Use eventually to allow some time for the local SQS to start up.
+  // If it is not started all suites using this will crash at start up time.
+  eventually {
+    sqsClient.listQueues() shouldBe a[ListQueuesResult]
+  }
+
   private var queueUrls: List[String] = Nil
 
-  def createQueueAndReturnUrl(queueName: String): String = {
-    // Use eventually to allow some time for the local SQS to start up.
-    // If it is not started all suites using this will crash at start up time.
-    val queueUrl = eventually {
-      sqsClient.createQueue(queueName).getQueueUrl
-    }
+  def createQueueAndDlqReturnUrls(queueName: String): QueueInfo = {
+    val deadLetterQueueUrl = sqsClient.createQueue(queueName).getQueueUrl
+    val queueUrl = sqsClient.createQueue(s"$queueName-dlq").getQueueUrl
+    val deadLetterQueueArn = sqsClient
+      .getQueueAttributes(deadLetterQueueUrl, List("QueueArn"))
+      .getAttributes
+      .get("QueueArn")
+    val redrivePolicy =
+      s"""
+        |{
+        | "maxReceiveCount":"1",
+        | "deadLetterTargetArn":"$deadLetterQueueArn"
+        |}""".stripMargin
+    sqsClient.setQueueAttributes(queueUrl,
+                                 Map("RedrivePolicy" -> redrivePolicy))
     queueUrls = queueUrl :: queueUrls
-    queueUrl
+    QueueInfo(queueUrl, deadLetterQueueUrl)
   }
 
   override def beforeEach(): Unit = {
     super.beforeEach()
-    queueUrls.foreach(queueUrl => sqsClient.purgeQueue(new PurgeQueueRequest().withQueueUrl(queueUrl)))
+    queueUrls.foreach(queueUrl =>
+      sqsClient.purgeQueue(new PurgeQueueRequest().withQueueUrl(queueUrl)))
   }
 }
+
+case class QueueInfo(queueUrl: String, deadLetterQueueUrl: String)

--- a/common/src/test/scala/uk/ac/wellcome/test/utils/SQSLocal.scala
+++ b/common/src/test/scala/uk/ac/wellcome/test/utils/SQSLocal.scala
@@ -4,15 +4,13 @@ import com.amazonaws.auth.{AWSStaticCredentialsProvider, BasicAWSCredentials}
 import com.amazonaws.client.builder.AwsClientBuilder.EndpointConfiguration
 import com.amazonaws.services.sqs.model.PurgeQueueRequest
 import com.amazonaws.services.sqs.{AmazonSQS, AmazonSQSClientBuilder}
-import com.google.inject.{Provides, Singleton}
-import com.twitter.inject.TwitterModule
-import org.scalatest.concurrent.{Eventually, IntegrationPatience}
+import org.scalatest.concurrent.Eventually
 import org.scalatest.{BeforeAndAfterEach, Suite}
 
 trait SQSLocal
     extends BeforeAndAfterEach
     with Eventually
-    with IntegrationPatience { this: Suite =>
+    with ExtendedPatience { this: Suite =>
 
   val sqsClient: AmazonSQS = AmazonSQSClientBuilder
     .standard()

--- a/common/src/test/scala/uk/ac/wellcome/test/utils/SQSLocal.scala
+++ b/common/src/test/scala/uk/ac/wellcome/test/utils/SQSLocal.scala
@@ -2,18 +2,17 @@ package uk.ac.wellcome.test.utils
 
 import com.amazonaws.auth.{AWSStaticCredentialsProvider, BasicAWSCredentials}
 import com.amazonaws.client.builder.AwsClientBuilder.EndpointConfiguration
-import com.amazonaws.services.sqs.model.{ListQueuesResult, PurgeQueueRequest}
+import com.amazonaws.services.sqs.model.PurgeQueueRequest
 import com.amazonaws.services.sqs.{AmazonSQS, AmazonSQSClientBuilder}
-import org.scalatest.concurrent.Eventually
-import org.scalatest.{BeforeAndAfterEach, Matchers, Suite}
-
-import scala.collection.JavaConversions._
+import com.google.inject.{Provides, Singleton}
+import com.twitter.inject.TwitterModule
+import org.scalatest.concurrent.{Eventually, IntegrationPatience}
+import org.scalatest.{BeforeAndAfterEach, Suite}
 
 trait SQSLocal
     extends BeforeAndAfterEach
     with Eventually
-    with ExtendedPatience
-    with Matchers { this: Suite =>
+    with IntegrationPatience { this: Suite =>
 
   val sqsClient: AmazonSQS = AmazonSQSClientBuilder
     .standard()
@@ -23,38 +22,20 @@ trait SQSLocal
       new EndpointConfiguration(s"http://localhost:9324", "localhost"))
     .build()
 
-  // Use eventually to allow some time for the local SQS to start up.
-  // If it is not started all suites using this will crash at start up time.
-  eventually {
-    sqsClient.listQueues() shouldBe a[ListQueuesResult]
-  }
-
   private var queueUrls: List[String] = Nil
 
-  def createQueueAndDlqReturnUrls(queueName: String): QueueInfo = {
-    val deadLetterQueueUrl = sqsClient.createQueue(queueName).getQueueUrl
-    val queueUrl = sqsClient.createQueue(s"$queueName-dlq").getQueueUrl
-    val deadLetterQueueArn = sqsClient
-      .getQueueAttributes(deadLetterQueueUrl, List("QueueArn"))
-      .getAttributes
-      .get("QueueArn")
-    val redrivePolicy =
-      s"""
-        |{
-        | "maxReceiveCount":"1",
-        | "deadLetterTargetArn":"$deadLetterQueueArn"
-        |}""".stripMargin
-    sqsClient.setQueueAttributes(queueUrl,
-                                 Map("RedrivePolicy" -> redrivePolicy))
+  def createQueueAndReturnUrl(queueName: String): String = {
+    // Use eventually to allow some time for the local SQS to start up.
+    // If it is not started all suites using this will crash at start up time.
+    val queueUrl = eventually {
+      sqsClient.createQueue(queueName).getQueueUrl
+    }
     queueUrls = queueUrl :: queueUrls
-    QueueInfo(queueUrl, deadLetterQueueUrl)
+    queueUrl
   }
 
   override def beforeEach(): Unit = {
     super.beforeEach()
-    queueUrls.foreach(queueUrl =>
-      sqsClient.purgeQueue(new PurgeQueueRequest().withQueueUrl(queueUrl)))
+    queueUrls.foreach(queueUrl => sqsClient.purgeQueue(new PurgeQueueRequest().withQueueUrl(queueUrl)))
   }
 }
-
-case class QueueInfo(queueUrl: String, deadLetterQueueUrl: String)

--- a/common/src/test/scala/uk/ac/wellcome/test/utils/SQSLocal.scala
+++ b/common/src/test/scala/uk/ac/wellcome/test/utils/SQSLocal.scala
@@ -4,7 +4,7 @@ import com.amazonaws.auth.{AWSStaticCredentialsProvider, BasicAWSCredentials}
 import com.amazonaws.client.builder.AwsClientBuilder.EndpointConfiguration
 import com.amazonaws.services.sqs.model.{ListQueuesResult, PurgeQueueRequest}
 import com.amazonaws.services.sqs.{AmazonSQS, AmazonSQSClientBuilder}
-import org.scalatest.concurrent.{Eventually, IntegrationPatience}
+import org.scalatest.concurrent.Eventually
 import org.scalatest.{BeforeAndAfterEach, Matchers, Suite}
 
 import scala.collection.JavaConversions._
@@ -12,7 +12,7 @@ import scala.collection.JavaConversions._
 trait SQSLocal
     extends BeforeAndAfterEach
     with Eventually
-    with IntegrationPatience
+    with ExtendedPatience
     with Matchers { this: Suite =>
 
   val sqsClient: AmazonSQS = AmazonSQSClientBuilder

--- a/id_minter/src/test/scala/uk/ac/wellcome/platform/idminter/IdMinterFeatureTest.scala
+++ b/id_minter/src/test/scala/uk/ac/wellcome/platform/idminter/IdMinterFeatureTest.scala
@@ -9,7 +9,7 @@ import com.gu.scanamo.syntax._
 import com.twitter.finatra.http.EmbeddedHttpServer
 import com.twitter.inject.server.FeatureTestMixin
 import org.scalatest.FunSpec
-import org.scalatest.concurrent.{Eventually, IntegrationPatience}
+import org.scalatest.concurrent.Eventually
 import uk.ac.wellcome.models.aws.SQSMessage
 import uk.ac.wellcome.models.{IdentifiedWork, Identifier, SourceIdentifier, Work}
 import uk.ac.wellcome.test.utils.{DynamoDBLocal, SNSLocal, SQSLocal}
@@ -21,8 +21,7 @@ class IdMinterFeatureTest
     with SQSLocal
     with DynamoDBLocal
     with SNSLocal
-    with Eventually
-    with IntegrationPatience {
+    with Eventually {
 
   val ingestorTopicArn: String = createTopicAndReturnArn("test_ingestor")
   val idMinterQueueInfo = createQueueAndDlqReturnUrls("test_id_minter")

--- a/id_minter/src/test/scala/uk/ac/wellcome/platform/idminter/IdMinterFeatureTest.scala
+++ b/id_minter/src/test/scala/uk/ac/wellcome/platform/idminter/IdMinterFeatureTest.scala
@@ -24,13 +24,13 @@ class IdMinterFeatureTest
     with Eventually {
 
   val ingestorTopicArn: String = createTopicAndReturnArn("test_ingestor")
-  val idMinterQueueUrl = createQueueAndReturnUrl("test_id_minter")
+  val idMinterQueue: String = createQueueAndReturnUrl("test_id_minter")
 
   override val server: EmbeddedHttpServer = new EmbeddedHttpServer(
     new Server(),
     flags = Map(
       "aws.region" -> "local",
-      "aws.sqs.queue.url" -> idMinterQueueUrl,
+      "aws.sqs.queue.url" -> idMinterQueue,
       "aws.sqs.waitTime" -> "1",
       "aws.sns.topic.arn" -> ingestorTopicArn,
       "aws.dynamo.tableName" -> identifiersTableName
@@ -52,7 +52,7 @@ class IdMinterFeatureTest
                                 "messageType",
                                 "timestamp")
 
-    sqsClient.sendMessage(idMinterQueueUrl, JsonUtil.toJson(sqsMessage).get)
+    sqsClient.sendMessage(idMinterQueue, JsonUtil.toJson(sqsMessage).get)
 
     eventually {
       val dynamoIdentifiersRecords =
@@ -80,7 +80,7 @@ class IdMinterFeatureTest
     val firstMiroId = "1234"
     val sqsMessage = generateSqsMessage(firstMiroId)
 
-    sqsClient.sendMessage(idMinterQueueUrl, JsonUtil.toJson(sqsMessage).get)
+    sqsClient.sendMessage(idMinterQueue, JsonUtil.toJson(sqsMessage).get)
 
     eventually {
       Scanamo.queryIndex[Identifier](dynamoDbClient)("Identifiers", "MiroID")(
@@ -89,7 +89,7 @@ class IdMinterFeatureTest
 
     val secondMiroId = "5678"
     val secondSqsMessage = generateSqsMessage(secondMiroId)
-    sqsClient.sendMessage(idMinterQueueUrl, JsonUtil.toJson(secondSqsMessage).get)
+    sqsClient.sendMessage(idMinterQueue, JsonUtil.toJson(secondSqsMessage).get)
 
     eventually {
       Scanamo.queryIndex[Identifier](dynamoDbClient)("Identifiers", "MiroID")(
@@ -99,12 +99,12 @@ class IdMinterFeatureTest
   }
 
   it("should keep polling if something fails processing a message") {
-    sqsClient.sendMessage(idMinterQueueUrl, "not a json string")
+    sqsClient.sendMessage(idMinterQueue, "not a json string")
 
     val miroId = "1234"
     val sqsMessage = generateSqsMessage(miroId)
 
-    sqsClient.sendMessage(idMinterQueueUrl, JsonUtil.toJson(sqsMessage).get)
+    sqsClient.sendMessage(idMinterQueue, JsonUtil.toJson(sqsMessage).get)
     eventually {
       Scanamo.queryIndex[Identifier](dynamoDbClient)("Identifiers", "MiroID")(
         'MiroID -> miroId) should have size (1)

--- a/id_minter/src/test/scala/uk/ac/wellcome/platform/idminter/IdMinterFeatureTest.scala
+++ b/id_minter/src/test/scala/uk/ac/wellcome/platform/idminter/IdMinterFeatureTest.scala
@@ -14,6 +14,7 @@ import uk.ac.wellcome.models.aws.SQSMessage
 import uk.ac.wellcome.models.{IdentifiedWork, Identifier, SourceIdentifier, Work}
 import uk.ac.wellcome.test.utils.{DynamoDBLocal, SNSLocal, SQSLocal}
 import uk.ac.wellcome.utils.JsonUtil
+import scala.collection.JavaConversions._
 
 class IdMinterFeatureTest
     extends FunSpec
@@ -26,6 +27,8 @@ class IdMinterFeatureTest
   val ingestorTopicArn: String = createTopicAndReturnArn("test_ingestor")
   val idMinterQueue: String = createQueueAndReturnUrl("test_id_minter")
 
+  // Setting 1 second timeout for tests, so that test don't have to wait too long to test message deletion
+  sqsClient.setQueueAttributes(idMinterQueue, Map("VisibilityTimeout" -> "1"))
   override val server: EmbeddedHttpServer = new EmbeddedHttpServer(
     new Server(),
     flags = Map(
@@ -110,6 +113,26 @@ class IdMinterFeatureTest
         'MiroID -> miroId) should have size (1)
     }
 
+  }
+
+
+  it("should not delete a message from the sqs queue if it fails processing it") {
+    sqsClient.sendMessage(idMinterQueue, "not a json string")
+
+    // After a message is read, it stays invisible for 1 second and then it gets sent again.
+    // So we wait for longer than the visibility timeout and then we assert that it has become
+    // invisible again, which means that the id_minter picked it up again,
+    // and so it wasn't deleted as part of the first run.
+    // TODO Write this test using dead letter queues once https://github.com/adamw/elasticmq/issues/69 is closed
+    Thread.sleep(2000)
+
+    eventually {
+      sqsClient
+        .getQueueAttributes(idMinterQueue,
+          List("ApproximateNumberOfMessagesNotVisible"))
+        .getAttributes
+        .get("ApproximateNumberOfMessagesNotVisible") shouldBe "1"
+    }
   }
 
   private def generateSqsMessage(MiroID: String) = {

--- a/ingestor/src/test/scala/uk/ac/wellcome/platform/ingestor/IngestorFeatureTest.scala
+++ b/ingestor/src/test/scala/uk/ac/wellcome/platform/ingestor/IngestorFeatureTest.scala
@@ -30,7 +30,7 @@ class IngestorFeatureTest
       .get
 
     sqsClient.sendMessage(
-      ingestorQueueInfo.queueUrl,
+      ingestorQueueUrl,
       JsonUtil
         .toJson(
           SQSMessage(Some("identified-item"),
@@ -47,27 +47,6 @@ class IngestorFeatureTest
         hits should have size 1
         hits.head.sourceAsString shouldBe identifiedWork
       }
-    }
-  }
-
-  it("should not delete a message from the sqs queue if it fails processing it") {
-    val invalidMessage = JsonUtil
-      .toJson(
-        SQSMessage(Some("identified-item"),
-          "not a json string - this will fail parsing",
-          "ingester",
-          "messageType",
-          "timestamp"))
-      .get
-    sqsClient.sendMessage(
-      ingestorQueueInfo.queueUrl,
-      invalidMessage
-    )
-
-    eventually {
-      val messages = sqsClient.receiveMessage(ingestorQueueInfo.deadLetterQueueUrl).getMessages
-      messages should have size (1)
-      messages.head.getBody should be (invalidMessage)
     }
   }
 }

--- a/ingestor/src/test/scala/uk/ac/wellcome/platform/ingestor/IngestorFeatureTest.scala
+++ b/ingestor/src/test/scala/uk/ac/wellcome/platform/ingestor/IngestorFeatureTest.scala
@@ -1,5 +1,6 @@
 package uk.ac.wellcome.platform.ingestor
 
+import com.amazonaws.services.sqs.model.ReceiveMessageRequest
 import com.sksamuel.elastic4s.ElasticDsl._
 import com.twitter.finatra.http.EmbeddedHttpServer
 import com.twitter.inject.server.FeatureTestMixin
@@ -9,6 +10,7 @@ import uk.ac.wellcome.models.aws.SQSMessage
 import uk.ac.wellcome.models.{IdentifiedWork, SourceIdentifier, Work}
 import uk.ac.wellcome.utils.GlobalExecutionContext.context
 import uk.ac.wellcome.utils.JsonUtil
+
 import scala.collection.JavaConversions._
 
 class IngestorFeatureTest
@@ -20,13 +22,19 @@ class IngestorFeatureTest
 
   override val server: EmbeddedHttpServer = createServer
 
-  it("should read an identified unified item from the SQS queue and ingest it into Elasticsearch") {
+  // Setting 1 second timeout for tests, so that test don't have to wait too long to test message deletion
+  sqsClient.setQueueAttributes(ingestorQueueUrl,
+    Map("VisibilityTimeout" -> "1"))
+
+  it(
+    "should read an identified unified item from the SQS queue and ingest it into Elasticsearch") {
     val identifiedWork = JsonUtil
       .toJson(
         IdentifiedWork(
           canonicalId = "1234",
-          work = Work(
-            identifiers = List(SourceIdentifier("Miro", "MiroID", "5678")), label = "some label")))
+          work = Work(identifiers =
+                        List(SourceIdentifier("Miro", "MiroID", "5678")),
+                      label = "some label")))
       .get
 
     sqsClient.sendMessage(
@@ -42,11 +50,43 @@ class IngestorFeatureTest
     )
 
     eventually {
-      val hitsFuture = elasticClient.execute(search(s"$indexName/$itemType").matchAllQuery()).map(_.hits)
+      val hitsFuture = elasticClient
+        .execute(search(s"$indexName/$itemType").matchAllQuery())
+        .map(_.hits)
       whenReady(hitsFuture) { hits =>
         hits should have size 1
         hits.head.sourceAsString shouldBe identifiedWork
       }
+    }
+  }
+
+  it("should not delete a message from the sqs queue if it fails processing it") {
+    val invalidMessage = JsonUtil
+      .toJson(
+        SQSMessage(Some("identified-item"),
+                   "not a json string - this will fail parsing",
+                   "ingester",
+                   "messageType",
+                   "timestamp"))
+      .get
+    sqsClient.sendMessage(
+      ingestorQueueUrl,
+      invalidMessage
+    )
+
+    // After a message is read, it stays invisible for 1 second and then it gets sent again.
+    // So we wait for longer than the visibility timeout and then we assert that it has become
+    // invisible again, which means that the ingestor picked it up again,
+    // and so it wasn't deleted as part of the first run.
+    // TODO Write this test using dead letter queues once https://github.com/adamw/elasticmq/issues/69 is closed
+    Thread.sleep(2000)
+
+    eventually {
+      sqsClient
+        .getQueueAttributes(ingestorQueueUrl,
+                            List("ApproximateNumberOfMessagesNotVisible"))
+        .getAttributes
+        .get("ApproximateNumberOfMessagesNotVisible") shouldBe "1"
     }
   }
 }

--- a/ingestor/src/test/scala/uk/ac/wellcome/platform/ingestor/IngestorIndexTest.scala
+++ b/ingestor/src/test/scala/uk/ac/wellcome/platform/ingestor/IngestorIndexTest.scala
@@ -1,0 +1,34 @@
+package uk.ac.wellcome.platform.ingestor
+
+import com.sksamuel.elastic4s.ElasticDsl.{deleteIndex, index}
+import org.scalatest.concurrent.ScalaFutures
+import org.scalatest.{FunSpec, Matchers}
+import com.sksamuel.elastic4s.ElasticDsl._
+
+class IngestorIndexTest extends FunSpec
+  with IngestorUtils
+  with Matchers
+  with ScalaFutures {
+
+  it("should create the index at startup in elasticsearch if it doesn't already exist") {
+    elasticClient.execute(deleteIndex(indexName))
+
+    eventually {
+      val future = elasticClient.execute(index exists indexName)
+      whenReady(future) { result =>
+        result.isExists should be(false)
+      }
+    }
+
+    val server = createServer
+    server.start()
+
+    eventually {
+      val future = elasticClient.execute(index exists indexName)
+      whenReady(future) { result =>
+        result.isExists should be(true)
+      }
+    }
+    server.close()
+  }
+}

--- a/ingestor/src/test/scala/uk/ac/wellcome/platform/ingestor/IngestorUtils.scala
+++ b/ingestor/src/test/scala/uk/ac/wellcome/platform/ingestor/IngestorUtils.scala
@@ -7,14 +7,14 @@ import uk.ac.wellcome.test.utils.{IndexedElasticSearchLocal, SQSLocal}
 
 trait IngestorUtils extends IndexedElasticSearchLocal with SQSLocal {
   this: Suite =>
-  val ingestorQueueInfo = createQueueAndDlqReturnUrls("test_es_ingestor_queue")
+  val ingestorQueueUrl = createQueueAndReturnUrl("test_es_ingestor_queue")
 
   def createServer: EmbeddedHttpServer = {
     new EmbeddedHttpServer(
       new Server(),
       flags = Map(
         "aws.region" -> "eu-west-1",
-        "aws.sqs.queue.url" -> ingestorQueueInfo.queueUrl,
+        "aws.sqs.queue.url" -> ingestorQueueUrl,
         "aws.sqs.waitTime" -> "1",
         "es.host" -> "localhost",
         "es.port" -> "9300",

--- a/ingestor/src/test/scala/uk/ac/wellcome/platform/ingestor/IngestorUtils.scala
+++ b/ingestor/src/test/scala/uk/ac/wellcome/platform/ingestor/IngestorUtils.scala
@@ -1,0 +1,31 @@
+package uk.ac.wellcome.platform.ingestor
+
+import com.amazonaws.services.sqs.AmazonSQS
+import com.twitter.finatra.http.EmbeddedHttpServer
+import org.scalatest.Suite
+import uk.ac.wellcome.test.utils.{IndexedElasticSearchLocal, SQSLocal}
+
+trait IngestorUtils extends IndexedElasticSearchLocal with SQSLocal {
+  this: Suite =>
+  val ingestorQueueInfo = createQueueAndDlqReturnUrls("test_es_ingestor_queue")
+
+  def createServer: EmbeddedHttpServer = {
+    new EmbeddedHttpServer(
+      new Server(),
+      flags = Map(
+        "aws.region" -> "eu-west-1",
+        "aws.sqs.queue.url" -> ingestorQueueInfo.queueUrl,
+        "aws.sqs.waitTime" -> "1",
+        "es.host" -> "localhost",
+        "es.port" -> "9300",
+        "es.name" -> "wellcome",
+        "es.xpack.enabled" -> "true",
+        "es.xpack.user" -> "elastic:changeme",
+        "es.xpack.sslEnabled" -> "false",
+        "es.sniff" -> "false",
+        "es.index" -> indexName,
+        "es.type" -> itemType
+      )
+    ).bind[AmazonSQS](sqsClient)
+  }
+}

--- a/transformer/src/test/scala/uk/ac/wellcome/transformer/CalmTransformerFeatureTest.scala
+++ b/transformer/src/test/scala/uk/ac/wellcome/transformer/CalmTransformerFeatureTest.scala
@@ -18,7 +18,6 @@ import uk.ac.wellcome.utils.JsonUtil
 class CalmTransformerFeatureTest
     extends FunSpec
     with TransformerFeatureTest
-    with Eventually
     with Matchers {
 
   private val appName = "test-transformer-calm"

--- a/transformer/src/test/scala/uk/ac/wellcome/transformer/MiroTransformerFeatureTest.scala
+++ b/transformer/src/test/scala/uk/ac/wellcome/transformer/MiroTransformerFeatureTest.scala
@@ -18,7 +18,6 @@ import uk.ac.wellcome.utils.JsonUtil
 class MiroTransformerFeatureTest
     extends FunSpec
     with TransformerFeatureTest
-    with Eventually
     with Matchers {
 
   private val appName = "test-transformer-miro"

--- a/transformer/src/test/scala/uk/ac/wellcome/transformer/utils/TransformerFeatureTest.scala
+++ b/transformer/src/test/scala/uk/ac/wellcome/transformer/utils/TransformerFeatureTest.scala
@@ -15,7 +15,6 @@ trait TransformerFeatureTest
     with SNSLocal
     with DynamoDBLocal { this: Suite =>
 
-  patienceConfig
   val idMinterTopicArn: String = createTopicAndReturnArn("test_id_minter")
 
   def kinesisClientLibConfiguration(

--- a/transformer/src/test/scala/uk/ac/wellcome/transformer/utils/TransformerFeatureTest.scala
+++ b/transformer/src/test/scala/uk/ac/wellcome/transformer/utils/TransformerFeatureTest.scala
@@ -5,14 +5,17 @@ import com.amazonaws.services.kinesis.clientlibrary.lib.worker.KinesisClientLibC
 import com.amazonaws.services.kinesis.metrics.interfaces.MetricsLevel
 import com.twitter.inject.server.FeatureTestMixin
 import org.scalatest.Suite
+import org.scalatest.concurrent.Eventually
 import uk.ac.wellcome.test.utils.{DynamoDBLocal, ExtendedPatience, SNSLocal}
 
 trait TransformerFeatureTest
     extends FeatureTestMixin
     with ExtendedPatience
+    with Eventually
     with SNSLocal
     with DynamoDBLocal { this: Suite =>
 
+  patienceConfig
   val idMinterTopicArn: String = createTopicAndReturnArn("test_id_minter")
 
   def kinesisClientLibConfiguration(


### PR DESCRIPTION
## What is this PR trying to achieve?
The ingestor (and id_minter) doesn't redirect messages to the dead letter queue when it fails evaluating them for whatever reason. This is to change them so that they both do
## Who is this change for?
Everyone who uses our platform. We should be able to find messages that failed to process and deal with them 
## Have the following been considered/are they needed?

- [x] Tests?
- [x] Docs?
- [x] Spoken to the right people?
