### PR TITLE
Split out the region config into a separate module

### DIFF
--- a/calm_adapter/src/main/scala/uk/ac/wellcome/calm_adapter/modules/DynamoWarmupModule.scala
+++ b/calm_adapter/src/main/scala/uk/ac/wellcome/calm_adapter/modules/DynamoWarmupModule.scala
@@ -4,7 +4,11 @@ import com.amazonaws.services.dynamodbv2._
 import uk.ac.wellcome.models.aws.DynamoConfig
 import com.twitter.inject.{Injector, Logging, TwitterModule}
 
-import uk.ac.wellcome.finatra.modules.{DynamoClientModule, DynamoConfigModule}
+import uk.ac.wellcome.finatra.modules.{
+  AWSConfigModule,
+  DynamoClientModule,
+  DynamoConfigModule
+}
 import uk.ac.wellcome.utils._
 
 /** Scale up/down Dynamo write capacity while the adapter is running.
@@ -22,7 +26,7 @@ import uk.ac.wellcome.utils._
   * a high write capacity for as short a period as possible.
   */
 object DynamoWarmupModule extends TwitterModule {
-  override val modules = Seq(DynamoClientModule, DynamoConfigModule)
+  override val modules = Seq(AWSConfigModule, DynamoClientModule, DynamoConfigModule)
 
   val writeCapacity =
     flag(

--- a/common/src/main/scala/uk/ac/wellcome/finatra/modules/AWSConfigModule.scala
+++ b/common/src/main/scala/uk/ac/wellcome/finatra/modules/AWSConfigModule.scala
@@ -1,0 +1,15 @@
+package uk.ac.wellcome.finatra.modules
+
+import javax.inject.Singleton
+
+import com.google.inject.Provides
+import com.twitter.inject.TwitterModule
+import uk.ac.wellcome.models.aws.AWSConfig
+
+object AWSConfigModule extends TwitterModule {
+  private val region = flag[String]("aws.region", "eu-west-1", "AWS region")
+
+  @Singleton
+  @Provides
+  def providesAWSConfig(): AWSConfig = AWSConfig(region())
+}

--- a/common/src/main/scala/uk/ac/wellcome/finatra/modules/DynamoClientModule.scala
+++ b/common/src/main/scala/uk/ac/wellcome/finatra/modules/DynamoClientModule.scala
@@ -4,27 +4,26 @@ import javax.inject.Singleton
 
 import com.google.inject.Provides
 import com.twitter.inject.TwitterModule
-import uk.ac.wellcome.models.aws.DynamoConfig
+import uk.ac.wellcome.models.aws.AWSConfig
 
 import com.amazonaws.services.dynamodbv2._
 
 object DynamoClientModule extends TwitterModule {
-  override val modules = Seq(DynamoConfigModule)
+  override val modules = Seq(AWSConfigModule)
 
   @Singleton
   @Provides
-  def providesDynamoClient(dynamoConfig: DynamoConfig): AmazonDynamoDB =
+  def providesDynamoClient(awsConfig: AWSConfig): AmazonDynamoDB =
     AmazonDynamoDBClientBuilder
       .standard()
-      .withRegion(dynamoConfig.region)
+      .withRegion(awsConfig.region)
       .build()
 
   @Singleton
   @Provides
-  def providesDynamoAsyncClient(
-    dynamoConfig: DynamoConfig): AmazonDynamoDBAsync =
+  def providesDynamoAsyncClient(awsConfig: AWSConfig): AmazonDynamoDBAsync =
     AmazonDynamoDBAsyncClientBuilder
       .standard()
-      .withRegion(dynamoConfig.region)
+      .withRegion(awsConfig.region)
       .build()
 }

--- a/common/src/main/scala/uk/ac/wellcome/finatra/modules/DynamoConfigModule.scala
+++ b/common/src/main/scala/uk/ac/wellcome/finatra/modules/DynamoConfigModule.scala
@@ -7,7 +7,6 @@ import com.twitter.inject.TwitterModule
 import uk.ac.wellcome.models.aws.DynamoConfig
 
 object DynamoConfigModule extends TwitterModule {
-  private val region = flag[String]("aws.region", "eu-west-1", "AWS region")
   private val applicationName = flag[String]("aws.dynamo.streams.appName",
                                              "dynamodb-streams-app",
                                              "Name of the Kinesis app")
@@ -19,5 +18,5 @@ object DynamoConfigModule extends TwitterModule {
   @Singleton
   @Provides
   def providesDynamoConfig(): DynamoConfig =
-    DynamoConfig(region(), applicationName(), arn(), table())
+    DynamoConfig(applicationName(), arn(), table())
 }

--- a/common/src/main/scala/uk/ac/wellcome/finatra/modules/SNSClientModule.scala
+++ b/common/src/main/scala/uk/ac/wellcome/finatra/modules/SNSClientModule.scala
@@ -4,7 +4,7 @@ import javax.inject.Singleton
 
 import com.google.inject.Provides
 import com.twitter.inject.TwitterModule
-import uk.ac.wellcome.models.aws.SNSConfig
+import uk.ac.wellcome.models.aws.AWSConfig
 
 import com.amazonaws.services.sns._
 
@@ -12,9 +12,9 @@ object SNSClientModule extends TwitterModule {
 
   @Singleton
   @Provides
-  def providesSNSClient(snsConfig: SNSConfig): AmazonSNS =
+  def providesSNSClient(awsConfig: AWSConfig): AmazonSNS =
     AmazonSNSClientBuilder
       .standard()
-      .withRegion(snsConfig.region)
+      .withRegion(awsConfig.region)
       .build()
 }

--- a/common/src/main/scala/uk/ac/wellcome/finatra/modules/SNSConfigModule.scala
+++ b/common/src/main/scala/uk/ac/wellcome/finatra/modules/SNSConfigModule.scala
@@ -7,11 +7,10 @@ import com.twitter.inject.TwitterModule
 import uk.ac.wellcome.models.aws.SNSConfig
 
 object SNSConfigModule extends TwitterModule {
-  private val region = flag[String]("aws.region", "eu-west-1", "AWS region")
   private val topicArn =
     flag[String]("aws.sns.topic.arn", "", "ARN of the SNS topic")
 
   @Singleton
   @Provides
-  def providesSNSConfig(): SNSConfig = SNSConfig(region(), topicArn())
+  def providesSNSConfig(): SNSConfig = SNSConfig(topicArn())
 }

--- a/common/src/main/scala/uk/ac/wellcome/finatra/modules/SQSClientModule.scala
+++ b/common/src/main/scala/uk/ac/wellcome/finatra/modules/SQSClientModule.scala
@@ -4,7 +4,7 @@ import javax.inject.Singleton
 
 import com.google.inject.Provides
 import com.twitter.inject.TwitterModule
-import uk.ac.wellcome.models.aws.SQSConfig
+import uk.ac.wellcome.models.aws.AWSConfig
 
 import com.amazonaws.services.sqs._
 
@@ -13,10 +13,10 @@ object SQSClientModule extends TwitterModule {
 
   @Singleton
   @Provides
-  def providesSQSClient(sqsConfig: SQSConfig): AmazonSQS =
+  def providesSQSClient(awsConfig: AWSConfig): AmazonSQS =
     AmazonSQSClientBuilder
       .standard()
-      .withRegion(sqsConfig.region)
+      .withRegion(awsConfig.region)
       .build()
 
 }

--- a/common/src/main/scala/uk/ac/wellcome/finatra/modules/SQSConfigModule.scala
+++ b/common/src/main/scala/uk/ac/wellcome/finatra/modules/SQSConfigModule.scala
@@ -9,7 +9,6 @@ import uk.ac.wellcome.models.aws.SQSConfig
 import scala.concurrent.duration._
 
 object SQSConfigModule extends TwitterModule {
-  private val region = flag[String]("aws.region", "eu-west-1", "AWS region")
   private val queueUrl =
     flag[String]("aws.sqs.queue.url", "", "URL of the SQS Queue")
   val waitTime = flag(
@@ -22,5 +21,5 @@ object SQSConfigModule extends TwitterModule {
   @Singleton
   @Provides
   def providesSQSConfig(): SQSConfig =
-    SQSConfig(region(), queueUrl(), waitTime() seconds, maxMessages())
+    SQSConfig(queueUrl(), waitTime() seconds, maxMessages())
 }

--- a/common/src/main/scala/uk/ac/wellcome/models/aws/AWSConfig.scala
+++ b/common/src/main/scala/uk/ac/wellcome/models/aws/AWSConfig.scala
@@ -1,0 +1,3 @@
+package uk.ac.wellcome.models.aws
+
+case class AWSConfig(region: String)

--- a/common/src/main/scala/uk/ac/wellcome/models/aws/DynamoConfig.scala
+++ b/common/src/main/scala/uk/ac/wellcome/models/aws/DynamoConfig.scala
@@ -1,6 +1,5 @@
 package uk.ac.wellcome.models.aws
 
-case class DynamoConfig(region: String,
-                        applicationName: String,
+case class DynamoConfig(applicationName: String,
                         arn: String,
                         table: String)

--- a/common/src/main/scala/uk/ac/wellcome/models/aws/SNSConfig.scala
+++ b/common/src/main/scala/uk/ac/wellcome/models/aws/SNSConfig.scala
@@ -1,3 +1,3 @@
 package uk.ac.wellcome.models.aws
 
-case class SNSConfig(region: String, topicArn: String)
+case class SNSConfig(topicArn: String)

--- a/common/src/main/scala/uk/ac/wellcome/models/aws/SQSConfig.scala
+++ b/common/src/main/scala/uk/ac/wellcome/models/aws/SQSConfig.scala
@@ -2,7 +2,6 @@ package uk.ac.wellcome.models.aws
 
 import scala.concurrent.duration.Duration
 
-case class SQSConfig(region: String,
-                     queueUrl: String,
+case class SQSConfig(queueUrl: String,
                      waitTime: Duration,
                      maxMessages: Integer)

--- a/common/src/test/scala/uk/ac/wellcome/sns/SNSWriterTest.scala
+++ b/common/src/test/scala/uk/ac/wellcome/sns/SNSWriterTest.scala
@@ -13,7 +13,7 @@ class SNSWriterTest
     with IntegrationPatience {
 
   val topicArn = createTopicAndReturnArn("test-topic-name")
-  val snsConfig = SNSConfig("eu-west-1", topicArn)
+  val snsConfig = SNSConfig(topicArn)
 
   it("should send a message with subject to the SNS client and return a publish attempt with the id of the request") {
     val snsWriter = new SNSWriter(amazonSNS, snsConfig)
@@ -45,7 +45,7 @@ class SNSWriterTest
 
   it("should return a failed future if it fails to publish the message") {
     val snsWriter =
-      new SNSWriter(amazonSNS, SNSConfig("eu-west-1", "not a valid topic"))
+      new SNSWriter(amazonSNS, SNSConfig("not a valid topic"))
 
     val futurePublishAttempt =
       snsWriter.writeMessage("someMessage", Some("subject"))

--- a/common/src/test/scala/uk/ac/wellcome/sqs/SQSReaderTest.scala
+++ b/common/src/test/scala/uk/ac/wellcome/sqs/SQSReaderTest.scala
@@ -25,8 +25,7 @@ class SQSReaderTest
 
   it("should get messages from the SQS queue, limited by the maximum number of messages and return them") {
     val sqsConfig =
-      SQSConfig("eu-west-1",
-                queueUrl,
+      SQSConfig(queueUrl,
                 waitTime = 20 seconds,
                 maxMessages = 2)
     val messageStrings = List("someMessage1", "someMessage2", "someMessage3")
@@ -54,8 +53,7 @@ class SQSReaderTest
 
   it("should return a failed future if reading from the SQS queue fails") {
     val sqsConfig =
-      SQSConfig("eu-west-1",
-                "not a valid queue url",
+      SQSConfig("not a valid queue url",
                 waitTime = 20 seconds,
                 maxMessages = 1)
     val sqsReader = new SQSReader(sqsClient, sqsConfig)
@@ -69,8 +67,7 @@ class SQSReaderTest
 
   it("should return a failed future if processing one of the messages throws an exception - the failed message should not be deleted") {
     val sqsConfig =
-      SQSConfig("eu-west-1",
-                queueUrl,
+      SQSConfig(queueUrl,
                 waitTime = 20 seconds,
                 maxMessages = 10)
 
@@ -97,8 +94,7 @@ class SQSReaderTest
 
   it("should return a failed future if processing one of the messages returns a failed future - the failed message should not be deleted") {
     val sqsConfig =
-      SQSConfig("eu-west-1",
-                queueUrl,
+      SQSConfig(queueUrl,
                 waitTime = 20 seconds,
                 maxMessages = 10)
 

--- a/id_minter/src/main/scala/uk/ac/wellcome/platform/idminter/Server.scala
+++ b/id_minter/src/main/scala/uk/ac/wellcome/platform/idminter/Server.scala
@@ -18,6 +18,7 @@ class Server extends HttpServer {
   override val name = "uk.ac.wellcome.platform.id_minter IdMinter"
   override val modules = Seq(AkkaModule,
                              IdMinterModule,
+                             AWSConfigModule,
                              SQSClientModule,
                              SQSConfigModule,
                              SQSReaderModule,

--- a/id_minter/src/test/scala/uk/ac/wellcome/platform/idminter/steps/IdentifierGeneratorTest.scala
+++ b/id_minter/src/test/scala/uk/ac/wellcome/platform/idminter/steps/IdentifierGeneratorTest.scala
@@ -18,8 +18,7 @@ class IdentifierGeneratorTest
 
   val identifierGenerator = new IdentifierGenerator(
     dynamoDbClient,
-    DynamoConfig("local",
-                 "applicationName",
+    DynamoConfig("applicationName",
                  "streamArn",
                  identifiersTableName))
 

--- a/ingestor/src/main/scala/uk/ac/wellcome/platform/ingestor/Server.scala
+++ b/ingestor/src/main/scala/uk/ac/wellcome/platform/ingestor/Server.scala
@@ -12,7 +12,8 @@ object ServerMain extends Server
 
 class Server extends HttpServer {
   override val name = "uk.ac.wellcome.platform.ingestor Ingestor"
-  override val modules = Seq(SQSConfigModule,
+  override val modules = Seq(AWSConfigModule,
+                             SQSConfigModule,
                              SQSClientModule,
                              AkkaModule,
                              SQSReaderModule,

--- a/transformer/src/main/scala/uk/ac/wellcome/transformer/Server.scala
+++ b/transformer/src/main/scala/uk/ac/wellcome/transformer/Server.scala
@@ -26,6 +26,7 @@ class Server extends HttpServer {
     KinesisClientLibConfigurationModule,
     AmazonKinesisModule,
     AmazonCloudWatchModule,
+    AWSConfigModule,
     DynamoConfigModule,
     AkkaModule,
     SNSConfigModule,

--- a/transformer/src/main/scala/uk/ac/wellcome/transformer/modules/AmazonCloudWatchModule.scala
+++ b/transformer/src/main/scala/uk/ac/wellcome/transformer/modules/AmazonCloudWatchModule.scala
@@ -6,16 +6,16 @@ import com.amazonaws.services.cloudwatch.{
 }
 import com.google.inject.{Provides, Singleton}
 import com.twitter.inject.TwitterModule
-import uk.ac.wellcome.models.aws.DynamoConfig
+import uk.ac.wellcome.models.aws.AWSConfig
 
 object AmazonCloudWatchModule extends TwitterModule {
 
   @Provides
   @Singleton
-  def providesAmazonCloudWatch(dynamoConfig: DynamoConfig): AmazonCloudWatch = {
+  def providesAmazonCloudWatch(awsConfig: AWSConfig): AmazonCloudWatch = {
     AmazonCloudWatchClientBuilder
       .standard()
-      .withRegion(dynamoConfig.region)
+      .withRegion(awsConfig.region)
       .build()
   }
 }

--- a/transformer/src/main/scala/uk/ac/wellcome/transformer/modules/AmazonKinesisModule.scala
+++ b/transformer/src/main/scala/uk/ac/wellcome/transformer/modules/AmazonKinesisModule.scala
@@ -6,17 +6,17 @@ import com.amazonaws.services.dynamodbv2.streamsadapter.AmazonDynamoDBStreamsAda
 import com.amazonaws.services.kinesis.AmazonKinesis
 import com.google.inject.{Provides, Singleton}
 import com.twitter.inject.TwitterModule
-import uk.ac.wellcome.models.aws.DynamoConfig
+import uk.ac.wellcome.models.aws.AWSConfig
 
 object AmazonKinesisModule extends TwitterModule {
 
   @Provides
   @Singleton
-  def providesAmazonKinesis(dynamoConfig: DynamoConfig): AmazonKinesis = {
+  def providesAmazonKinesis(awsConfig: AWSConfig): AmazonKinesis = {
     val adapter = new AmazonDynamoDBStreamsAdapterClient(
       new DefaultAWSCredentialsProviderChain()
     )
-    adapter.setRegion(RegionUtils.getRegion(dynamoConfig.region))
+    adapter.setRegion(RegionUtils.getRegion(awsConfig.region))
     adapter
   }
 }


### PR DESCRIPTION
## What is this PR trying to achieve?

Put the `aws.region` flag in a separate module. This is spun out of my and @kenoir's work on the reindexer, as we look at supplying more than one instance of `DynamoConfig` into the application. We may need to rethink this if we ever support cross-region applications, but this is strictly no worse than the current position.

As a side-effect, resolves #153.

## Who is this change for?

Developers who want to Dynamo table/SQS queue/SNS topic config decoupled from details of the individual tables.

## Have the following been considered/are they needed?

- [x] Tests?
- [x] Docs?
- [x] Spoken to the right people?