### PR TITLE
Start to separate the Travis logic from the build steps

### DIFF
--- a/.travis/run.sh
+++ b/.travis/run.sh
@@ -2,7 +2,7 @@
 
 set -o errexit
 set -o nounset
-set -o verbose
+set -o xtrace
 
 # https://graysonkoonce.com/getting-the-current-branch-name-during-a-pull-request-in-travis-ci/
 if [[ "$TRAVIS_PULL_REQUEST" == "false" ]]
@@ -19,34 +19,28 @@ echo "TRAVIS_BRANCH=$TRAVIS_BRANCH, PR=$TRAVIS_PULL_REQUEST, BRANCH=$BRANCH"
 # http://www.scala-sbt.org/0.12.2/docs/Howto/runningcommands.html
 sbt "project $PROJECT" ";dockerComposeUp;test;dockerComposeStop"
 
-# If we're on master, build a Docker image and push it to ECR
-export AWS_DEFAULT_REGION=eu-west-1
+# If we're on the master branch and in an application project, we should
+# build a new Docker image and push it to ECR.
 
 if [[ "$BRANCH" != "master" ]]
 then
-  echo "Not on master; skipping deploy..."
+  echo "Not on master (BRANCH=$BRANCH); skipping deploy..."
   exit 0
 fi
 
-if [[ "$BRANCH" == "master" && "$PROJECT" == "common" ]]
+if [[ "$PROJECT" == "common" ]]
 then
-  echo "Not an application (common); skipping deploy"
+  echo "Common lib doesn't have a Docker container; skipping deploy..."
   exit 0
 fi
 
-sbt "project $PROJECT" stage
-export RELEASE_ID="0.0.1-$(git rev-parse HEAD)_prod"
-$(aws ecr get-login)
+export VERSION="0.0.1"
+export BUILD_ENV="prod"
+export RELEASE_ID="$VERSION-$(git rev-parse HEAD)_$BUILD_ENV"
+export TAG="$AWS_ECR_REPO/uk.ac.wellcome/$PROJECT:$RELEASE_ID"
 
-docker build  \
-        --build-arg project=$PROJECT \
-        --build-arg config_bucket=$CONFIG_BUCKET \
-        --build-arg build_env=prod \
-        --tag=$AWS_ECR_REPO/uk.ac.wellcome/$PROJECT:$RELEASE_ID .
+./scripts/build_docker_image.sh
 
-docker push $AWS_ECR_REPO/uk.ac.wellcome/$PROJECT:$RELEASE_ID
-echo "New container image is $RELEASE_ID"
+export AWS_DEFAULT_REGION=eu-west-1
 
-echo "$RELEASE_ID" | aws s3 cp - "s3://$CONFIG_BUCKET/releases/$PROJECT"
-
-exit 0
+./scripts/push_docker_image_to_ecr.sh

--- a/.travis/run.sh
+++ b/.travis/run.sh
@@ -14,10 +14,9 @@ fi
 
 echo "TRAVIS_BRANCH=$TRAVIS_BRANCH, PR=$TRAVIS_PULL_REQUEST, BRANCH=$BRANCH"
 
-# Run the commands for the test.  Chaining them together means we don't
-# have to pay the cost of starting the JVM three times.
-# http://www.scala-sbt.org/0.12.2/docs/Howto/runningcommands.html
-sbt "project $PROJECT" ";dockerComposeUp;test;dockerComposeStop"
+# Run the tests themselves.
+
+./scripts/run_tests.sh
 
 # If we're on the master branch and in an application project, we should
 # build a new Docker image and push it to ECR.

--- a/scripts/build_docker_image.sh
+++ b/scripts/build_docker_image.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+# Build a Docker image for an application.
+
+set -o errexit
+set -o nounset
+
+sbt "project $PROJECT" stage
+
+docker build \
+  --build-arg project="$PROJECT" \
+  --build-arg config_bucket="$CONFIG_BUCKET" \
+  --build-arg build_env="$BUILD_ENV" \
+  --tag="$TAG" .
+
+exit 0

--- a/scripts/push_docker_image_to_ecr.sh
+++ b/scripts/push_docker_image_to_ecr.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+# Push a Docker image to ECR and copy its release ID to our S3 bucket.
+
+set -o errexit
+set -o nounset
+
+$(aws ecr get-login)
+docker push "$TAG"
+echo "New container image is $RELEASE_ID"
+
+echo "$RELEASE_ID" | aws s3 cp - "s3://$CONFIG_BUCKET/releases/$PROJECT"
+
+exit 0

--- a/scripts/run_tests.sh
+++ b/scripts/run_tests.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+# Run all the tests.
+
+set -o nounset
+
+ALL_PROJECTS="api common id_minter ingestor miro_adapter reindexer transformer"
+
+
+function run_tests {
+  # Run the commands for the test.  Chaining them together means we don't
+  # have to pay the cost of starting the JVM three times.
+  # http://www.scala-sbt.org/0.12.2/docs/Howto/runningcommands.html
+  sbt "project $1" ";dockerComposeUp;test;dockerComposeStop"
+}
+
+
+PROJECT=${PROJECT:-""}
+if [[ -z "$PROJECT" ]]
+then
+  echo "=== No project specified; running tests for all projects ==="
+  for project in $ALL_PROJECTS
+  do
+    echo "=== Starting tests for $project ==="
+    run_tests "$project"
+    echo "=== Finished tests for $project ==="
+  done
+else
+  run_tests "$PROJECT"
+fi


### PR DESCRIPTION
## What is this PR trying to achieve?

Break out the build pieces from the Travis logic.

Resolves #297: it is now possible to run:

```console
$ PROJECT=api ./scripts/run_tests.sh
$ ./scripts/run_tests.sh
```

to run a subset or all of the tests.

## Who is this change for?

Developers who want it to be easier to run steps locally.

## Have the following been considered/are they needed?

- [ ] Tests?
- [ ] Docs?
- [ ] Spoken to the right people?
