### PR TITLE
Make pull request builds go faster

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,23 @@ branches:
   only:
     - master
 
+before_install:
+  # If this is a pull request branch, we only do anything if there are
+  # interesting changes between this branch and master.
+  #
+  # Using 'exit' in a build step will terminate the rest of the build:
+  # https://docs.travis-ci.com/user/customizing-the-build/#How-does-this-work%3F-(Or%2C-why-you-should-not-use-exit-in-build-steps)
+  - |
+    if [[ "$TRAVIS_EVENT_TYPE" == "pull_request" ]]
+    then
+      git fetch origin
+      if ! python ./scripts/should_rerun_tests.py
+      then
+        echo "No changes that require us to re-run tests, skipping to the end"
+        exit 0
+      fi
+    fi
+
 install:
   - ./.travis/install.sh
 

--- a/scripts/should_rerun_tests.py
+++ b/scripts/should_rerun_tests.py
@@ -1,0 +1,62 @@
+#!/usr/bin/env python
+# -*- encoding: utf-8 -*-
+"""
+Decide whether we should re-run tests for a project on a pull request.
+
+Exits with code 0 if there are changes that require a retest, 1 if not.
+"""
+
+import os
+import subprocess
+import sys
+
+
+def modified_files(a, b):
+    """Returns a set of changed files between ``a`` and ``b``.
+
+    >>> modified_files('HEAD', '^HEAD')
+    >>> modified_files('ab27a1f', '8cae231')
+    >>> modified_files('master', 'feature-branch')
+
+    """
+    files = set()
+    command = ['git', 'diff', '--name-only', a, b]
+    diff_output = subprocess.check_output(command).decode('ascii')
+    for line in diff_output.splitlines():
+        filepath = line.strip()
+        if filepath:
+            files.add(filepath)
+    return files
+
+
+def should_retest_project(changed_files, project):
+    """
+    Given a set of changed files, return True/False if we should re-run
+    the tests for this project.
+    """
+    if 'build.sbt' in changed_files:
+        print("*** Changes to build.sbt mean we should rebuild")
+        return True
+
+    elif any(f.startswith(('common/', 'project/')) for f in changed_files):
+        print("*** Changes to common/project dirs mean we should rebuild")
+        return True
+
+    elif any(f.startswith('%s/' % project) for f in changed_files):
+        print("*** Changes to the project dir mean we should rebuild")
+        return True
+
+    else:
+        return False
+
+
+if __name__ == '__main__':
+    changed_files = modified_files('HEAD', 'master')
+    should_retest = should_retest_project(
+        changed_files=changed_files,
+        project=os.environ['PROJECT']
+    )
+    if should_retest:
+        sys.exit(0)
+    else:
+        sys.exit(1)


### PR DESCRIPTION
## What is this PR trying to achieve?

If we're on a pull request build, we can do a diff against master to check whether there are any file changes.  If there aren't any relevant changes, we can skip running the tests. A nice side-effect is that this will probably make non-PR builds go faster as well, because we have less contention for our share of Travis resources.

Doing this on master requires a little more care, so I haven't done that yet – this is just a proof-of-concept. Related to #203.

## Who is this change for?

Developers who want faster builds.

## Have the following been considered/are they needed?

- [x] Tests?
- [x] Docs?
- [x] Spoken to the right people?