### PR TITLE
Add creation dates to records transformed in Miro V

### DIFF
--- a/common/src/main/scala/uk/ac/wellcome/models/MiroTransformable.scala
+++ b/common/src/main/scala/uk/ac/wellcome/models/MiroTransformable.scala
@@ -10,7 +10,8 @@ case class MiroTransformableData(
   @JsonProperty("image_title") title: Option[String],
   @JsonProperty("image_creator") creator: Option[List[String]],
   @JsonProperty("image_image_desc") description: Option[String],
-  @JsonProperty("image_secondary_creator") secondaryCreator: Option[List[String]]
+  @JsonProperty("image_secondary_creator") secondaryCreator: Option[List[String]],
+  @JsonProperty("image_artwork_date") artworkDate: Option[String]
 )
 
 case class MiroTransformable(MiroID: String,
@@ -46,10 +47,18 @@ case class MiroTransformable(MiroID: String,
         case None => List()
       }
 
+      // Determining the creation date depends on several factors, so we do
+      // it on a per-collection basis.
+      val createdDate: Option[Period] = MiroCollection match {
+        case "Images-V" => miroData.artworkDate.map { Period(_) }
+        case _ => None
+      }
+
       Work(
         identifiers = identifiers,
         label = label,
         description = description,
+        hasCreatedDate = createdDate,
         hasCreator = creators ++ secondaryCreators
       )
     }

--- a/common/src/test/scala/uk/ac/wellcome/models/MiroTransformableTest.scala
+++ b/common/src/test/scala/uk/ac/wellcome/models/MiroTransformableTest.scala
@@ -61,6 +61,24 @@ class MiroTransformableTest extends FunSpec with Matchers {
     work.description shouldBe Some(description)
   }
 
+  it("should pass through the value of the creation date on V records") {
+    val date = "1820-1848"
+    val work = transformMiroRecord(
+      data = s"""{"image_title": "A description of a dalmation", "image_artwork_date": "$date"}""",
+      miroCollection = "Images-V"
+    )
+    work.hasCreatedDate shouldBe Some(Period(date))
+  }
+
+  it("should not pass through the value of the creation date on non-V records") {
+    val date = "1820-1848"
+    val work = transformMiroRecord(
+      data = s"""{"image_title": "A diary about a dodo", "image_artwork_date": "$date"}""",
+      miroCollection = "Images-A"
+    )
+    work.hasCreatedDate shouldBe None
+  }
+
   it("should use the image_creator_secondary field if image_creator is not present") {
     val secondaryCreator = "Scientist Sarah"
     val work = transformMiroRecord(


### PR DESCRIPTION
### What is this PR trying to achieve?

Add a creation date value to any records transformed that come from the Images-V collection.

Related: #311.

### Who is this change for?

API users who want to know when something was created.

### Have the following been considered/are they needed?

- [ ] Deployed new versions
