### PR TITLE
Add the --no-include-email to our 'aws ecr get-login' call

### DIFF
--- a/scripts/push_docker_image_to_ecr.sh
+++ b/scripts/push_docker_image_to_ecr.sh
@@ -4,7 +4,7 @@
 set -o errexit
 set -o nounset
 
-$(aws ecr get-login)
+$(aws ecr get-login --no-include-email)
 docker push "$TAG"
 echo "New container image is $RELEASE_ID"
 


### PR DESCRIPTION
Based on advice from AWS Support (email, earlier this morning):

> If you are currently using ‘get-login’ to authenticate with ECR, Please take the following actions based on the Docker version you are running:
>
> * If you are running Docker v17.06 or higher, you must update the AWS CLI to version 1.11.91 or higher. Additionally, you must change any reference to 'get-login' to include the new --no-include-email option.
> * If you are running Docker v17.06 or lower, no action is required since these versions accept the email flags. By default, the 'get-login' command will continue to include the -e flag in the output to preserve backwards compatibility with older versions of Docker.
