### PR TITLE
Expose identifiers with includes=hasIdentifier

### DIFF
--- a/api/src/main/scala/uk/ac/wellcome/platform/api/controllers/WorksController.scala
+++ b/api/src/main/scala/uk/ac/wellcome/platform/api/controllers/WorksController.scala
@@ -13,10 +13,11 @@ import uk.ac.wellcome.platform.api.services.WorksService
 import uk.ac.wellcome.utils.GlobalExecutionContext.context
 import com.twitter.finatra.validation._
 
-case class UsersRequest(@Min(1) @QueryParam page: Int = 1,
-                        @Min(1) @Max(100) @QueryParam pageSize: Option[Int],
-                        @QueryParam includes: Option[String],
-                        @QueryParam query: Option[String])
+case class MultipleResultsRequest(@Min(1) @QueryParam page: Int = 1,
+                                  @Min(1) @Max(100) @QueryParam pageSize: Option[Int],
+                                  @QueryParam includes: Option[String],
+                                  @RouteParam id: Option[String],
+                                  @QueryParam query: Option[String])
 
 case class SingleWorkRequest(@RouteParam id: String,
                              @QueryParam includes: Option[String])
@@ -52,20 +53,23 @@ class WorksController @Inject()(@Flag("api.prefix") apiPrefix: String,
         .queryParam[String]("query",
                             "Full-text search query",
                             required = false)
-    } { request: UsersRequest =>
+    } { request: MultipleResultsRequest =>
       val pageSize = request.pageSize.getOrElse((defaultPageSize))
+      val includes = request.includes.getOrElse("").split(",").toList
 
       val works = request.query match {
         case Some(queryString) =>
           worksService.searchWorks(
             queryString,
             pageSize = pageSize,
-            pageNumber = request.page
+            pageNumber = request.page,
+            includes = includes
           )
         case None =>
           worksService.listWorks(
             pageSize = pageSize,
-            pageNumber = request.page
+            pageNumber = request.page,
+            includes = includes
           )
       }
 

--- a/api/src/main/scala/uk/ac/wellcome/platform/api/models/DisplaySearch.scala
+++ b/api/src/main/scala/uk/ac/wellcome/platform/api/models/DisplaySearch.scala
@@ -10,9 +10,9 @@ case class DisplaySearch(
   results: Array[DisplayWork]
 )
 case object DisplaySearch {
-  def apply(searchResponse: RichSearchResponse, pageSize: Int): DisplaySearch = {
+  def apply(searchResponse: RichSearchResponse, pageSize: Int, includes: List[String]): DisplaySearch = {
     DisplaySearch(
-      results = searchResponse.hits.map { DisplayWork(_) },
+      results = searchResponse.hits.map { DisplayWork(_, includes) },
       pageSize = pageSize,
       totalPages = Math.ceil(searchResponse.totalHits.toDouble / pageSize.toDouble).toInt,
       totalResults = searchResponse.totalHits.toInt

--- a/api/src/main/scala/uk/ac/wellcome/platform/api/models/DisplayWork.scala
+++ b/api/src/main/scala/uk/ac/wellcome/platform/api/models/DisplayWork.scala
@@ -1,31 +1,31 @@
 package uk.ac.wellcome.platform.api.models
 
 import com.fasterxml.jackson.annotation.JsonProperty
-import com.sksamuel.elastic4s.searches.{RichSearchHit, RichSearchResponse}
+import com.sksamuel.elastic4s.searches.RichSearchHit
 import org.elasticsearch.action.get.GetResponse
-import uk.ac.wellcome.models.{Agent, IdentifiedWork, Period, Work}
+import uk.ac.wellcome.models._
 import uk.ac.wellcome.utils.JsonUtil
 
-
-case class DisplayWork(
-  @JsonProperty("type") ontologyType: String = "Work",
-  id: String,
-  label: String,
-  description: Option[String] = None,
-  lettering: Option[String] = None,
-  hasCreatedDate: Option[Period] = None,
-  hasCreator: List[Agent] = List()
-)
+case class DisplayWork(id: String,
+                       label: String,
+                       description: Option[String] = None,
+                       lettering: Option[String] = None,
+                       hasCreatedDate: Option[Period] = None,
+                       hasCreator: List[Agent] = List(),
+                       hasIdentifier: Option[List[DisplayIdentifier]] = None) {
+  @JsonProperty("type")
+  val ontologyType: String = "Work"
+}
 case object DisplayWork {
   def apply(hit: RichSearchHit): DisplayWork = {
-    toRecord(hit.sourceAsString)
+    jsonToDisplayWork(hit.sourceAsString, Nil)
   }
 
-  def apply(got: GetResponse): DisplayWork = {
-    toRecord(got.getSourceAsString)
+  def apply(got: GetResponse, includes: List[String]): DisplayWork = {
+    jsonToDisplayWork(got.getSourceAsString, includes)
   }
 
-  private def toRecord(document: String) = {
+  private def jsonToDisplayWork(document: String, includes: List[String]) = {
     val identifiedWork =
       JsonUtil.fromJson[IdentifiedWork](document).get
 
@@ -36,7 +36,26 @@ case object DisplayWork {
       lettering = identifiedWork.work.lettering,
       hasCreatedDate = identifiedWork.work.hasCreatedDate,
       // Wrapping this in Option to catch null value from Jackson
-      hasCreator = Option(identifiedWork.work.hasCreator).getOrElse(Nil)
+      hasCreator = Option(identifiedWork.work.hasCreator).getOrElse(Nil),
+      hasIdentifier =
+        if (includes.contains("hasIdentifier"))
+          Some(identifiedWork.work.identifiers.map(DisplayIdentifier(_)))
+        else None
     )
   }
 }
+
+case class DisplayIdentifier(source: DisplaySource, value: String) {
+  @JsonProperty("type")
+  val ontologyType: String = "Identifier"
+}
+
+object DisplayIdentifier {
+  def apply(sourceIdentifier: SourceIdentifier): DisplayIdentifier =
+    DisplayIdentifier(source =
+                        DisplaySource(name = sourceIdentifier.source,
+                                      value = sourceIdentifier.sourceId),
+                      value = sourceIdentifier.value)
+}
+
+case class DisplaySource(name: String, value: String)

--- a/api/src/main/scala/uk/ac/wellcome/platform/api/models/DisplayWork.scala
+++ b/api/src/main/scala/uk/ac/wellcome/platform/api/models/DisplayWork.scala
@@ -17,8 +17,11 @@ case class DisplayWork(id: String,
   val ontologyType: String = "Work"
 }
 case object DisplayWork {
-  def apply(hit: RichSearchHit): DisplayWork = {
-    jsonToDisplayWork(hit.sourceAsString, Nil)
+
+  def apply(hit: RichSearchHit): DisplayWork = apply(hit, includes = List())
+
+  def apply(hit: RichSearchHit, includes: List[String]): DisplayWork = {
+    jsonToDisplayWork(hit.sourceAsString, includes)
   }
 
   def apply(got: GetResponse, includes: List[String]): DisplayWork = {

--- a/api/src/main/scala/uk/ac/wellcome/platform/api/services/WorksService.scala
+++ b/api/src/main/scala/uk/ac/wellcome/platform/api/services/WorksService.scala
@@ -24,24 +24,26 @@ class WorksService @Inject()(@Flag("api.pageSize") defaultPageSize: Int,
       }
 
   def listWorks(pageSize: Int = defaultPageSize,
-                pageNumber: Int = 1): Future[DisplaySearch] =
+                pageNumber: Int = 1,
+                includes: List[String] = Nil): Future[DisplaySearch] =
     searchService
       .listResults(
         sortByField = "canonicalId",
         limit = pageSize,
         from = (pageNumber - 1) * pageSize
       )
-      .map { DisplaySearch(_, pageSize) }
+      .map { DisplaySearch(_, pageSize, includes) }
 
   def searchWorks(query: String,
                   pageSize: Int = defaultPageSize,
-                  pageNumber: Int = 1): Future[DisplaySearch] =
+                  pageNumber: Int = 1,
+                  includes: List[String] = Nil): Future[DisplaySearch] =
     searchService
       .simpleStringQueryResults(
         query,
         limit = pageSize,
         from = (pageNumber - 1) * pageSize
       )
-      .map { DisplaySearch(_, pageSize) }
+      .map { DisplaySearch(_, pageSize, includes) }
 
 }

--- a/api/src/main/scala/uk/ac/wellcome/platform/api/services/WorksService.scala
+++ b/api/src/main/scala/uk/ac/wellcome/platform/api/services/WorksService.scala
@@ -12,16 +12,15 @@ import uk.ac.wellcome.utils.GlobalExecutionContext.context
 import scala.concurrent.Future
 
 @Singleton
-class WorksService @Inject()(
-  @Flag("api.pageSize") defaultPageSize: Int,
-  searchService: ElasticSearchService
-) {
+class WorksService @Inject()(@Flag("api.pageSize") defaultPageSize: Int,
+                             searchService: ElasticSearchService) {
 
-  def findWorkById(canonicalId: String): Future[Option[DisplayWork]] =
+  def findWorkById(canonicalId: String,
+                   includes: List[String] = Nil): Future[Option[DisplayWork]] =
     searchService
       .findResultById(canonicalId)
       .map { result =>
-        if (result.exists) Some(DisplayWork(result.original)) else None
+        if (result.exists) Some(DisplayWork(result.original, includes)) else None
       }
 
   def listWorks(pageSize: Int = defaultPageSize,

--- a/api/src/test/scala/uk/ac/wellcome/platform/api/ApiWorksTest.scala
+++ b/api/src/test/scala/uk/ac/wellcome/platform/api/ApiWorksTest.scala
@@ -322,7 +322,86 @@ class ApiWorksTest
     }
   }
 
-  it("should include a list of identifiers if we pass ?includes=hasIdentifier") {
+  it("should include a list of identifiers on a list endpoint if we pass ?includes=hasIdentifier") {
+    val identifier1 = SourceIdentifier(
+      source = "TestSource",
+      sourceId = "The ID field within the TestSource",
+      value = "Test1234"
+    )
+    val work1 = identifiedWorkWith(
+      canonicalId = "1234",
+      label = "An image of an iguana",
+      identifiers = List(identifier1)
+    )
+
+    val identifier2 = SourceIdentifier(
+      source = "DifferentTestSource",
+      sourceId = "The ID field within the DifferentTestSource",
+      value = "DTest5678"
+    )
+    val work2 = identifiedWorkWith(
+      canonicalId = "5678",
+      label = "An impression of an igloo",
+      identifiers = List(identifier2)
+    )
+
+    insertIntoElasticSearch(work1, work2)
+
+    val works = List(work1, work2)
+
+    eventually {
+      server.httpGet(
+        path = s"/$apiPrefix/works?includes=hasIdentifier",
+        andExpect = Status.Ok,
+        withJsonBody = s"""
+                          |{
+                          |  "@context": "https://localhost:8888/$apiPrefix/context.json",
+                          |  "type": "ResultList",
+                          |  "pageSize": 10,
+                          |  "totalPages": 1,
+                          |  "totalResults": 2,
+                          |  "results": [
+                          |   {
+                          |     "type": "Work",
+                          |     "id": "${work1.canonicalId}",
+                          |     "label": "${work1.work.label}",
+                          |     "hasCreator": [ ],
+                          |     "hasIdentifier": [
+                          |       {
+                          |         "type": "Identifier",
+                          |         "source": {
+                          |           "name": "${identifier1.source}",
+                          |           "value": "${identifier1.sourceId}"
+                          |         },
+                          |         "value": "${identifier1.value}"
+                          |       }
+                          |     ]
+                          |   },
+                          |   {
+                          |     "type": "Work",
+                          |     "id": "${work2.canonicalId}",
+                          |     "label": "${work2.work.label}",
+                          |     "hasCreator": [ ],
+                          |     "hasIdentifier": [
+                          |       {
+                          |         "type": "Identifier",
+                          |         "source": {
+                          |           "name": "${identifier2.source}",
+                          |           "value": "${identifier2.sourceId}"
+                          |         },
+                          |         "value": "${identifier2.value}"
+                          |       }
+                          |     ]
+                          |   }
+                          |  ]
+                          |}
+          """.stripMargin
+      )
+    }
+  }
+
+
+  it("should include a list of identifiers on a single work endpoint if we pass ?includes=hasIdentifier") {
     val identifier = SourceIdentifier(
       source = "TestSource",
       sourceId = "The ID field within the TestSource",

--- a/api/src/test/scala/uk/ac/wellcome/platform/api/ApiWorksTest.scala
+++ b/api/src/test/scala/uk/ac/wellcome/platform/api/ApiWorksTest.scala
@@ -213,8 +213,7 @@ class ApiWorksTest
     )
   }
 
-  it(
-    "should return a not found error when requesting a single work with a non existing id") {
+  it("should return a not found error when requesting a single work with a non existing id") {
     server.httpGet(
       path = s"/$apiPrefix/works/non-existing-id",
       andExpect = Status.NotFound,
@@ -227,7 +226,8 @@ class ApiWorksTest
     server.httpGet(
       path = s"/$apiPrefix/works?pageSize=$pageSize",
       andExpect = Status.BadRequest,
-      withJsonBody = s"""{"errors":["pageSize: [$pageSize] is not less than or equal to 100"]}"""
+      withJsonBody =
+        s"""{"errors":["pageSize: [$pageSize] is not less than or equal to 100"]}"""
     )
   }
 
@@ -236,7 +236,8 @@ class ApiWorksTest
     server.httpGet(
       path = s"/$apiPrefix/works?pageSize=$pageSize",
       andExpect = Status.BadRequest,
-      withJsonBody = s"""{"errors":["pageSize: [$pageSize] is not less than or equal to 100"]}"""
+      withJsonBody =
+        s"""{"errors":["pageSize: [$pageSize] is not less than or equal to 100"]}"""
     )
   }
 
@@ -244,15 +245,18 @@ class ApiWorksTest
     server.httpGet(
       path = s"/$apiPrefix/works?pageSize=0",
       andExpect = Status.BadRequest,
-      withJsonBody = s"""{"errors":["pageSize: [0] is not greater than or equal to 1"]}"""
+      withJsonBody =
+        s"""{"errors":["pageSize: [0] is not greater than or equal to 1"]}"""
     )
   }
 
-  it("should return an HTTP Bad Request error if the user asks for a negative page size") {
+  it(
+    "should return an HTTP Bad Request error if the user asks for a negative page size") {
     server.httpGet(
       path = s"/$apiPrefix/works?pageSize=-50",
       andExpect = Status.BadRequest,
-      withJsonBody = s"""{"errors":["pageSize: [-50] is not greater than or equal to 1"]}"""
+      withJsonBody =
+        s"""{"errors":["pageSize: [-50] is not greater than or equal to 1"]}"""
     )
   }
 
@@ -260,15 +264,18 @@ class ApiWorksTest
     server.httpGet(
       path = s"/$apiPrefix/works?page=0",
       andExpect = Status.BadRequest,
-      withJsonBody = s"""{"errors":["page: [0] is not greater than or equal to 1"]}"""
+      withJsonBody =
+        s"""{"errors":["page: [0] is not greater than or equal to 1"]}"""
     )
   }
 
-  it("should return an HTTP Bad Request error if the user asks for a page before 0") {
+  it(
+    "should return an HTTP Bad Request error if the user asks for a page before 0") {
     server.httpGet(
       path = s"/$apiPrefix/works?page=-50",
       andExpect = Status.BadRequest,
-      withJsonBody = s"""{"errors":["page: [-50] is not greater than or equal to 1"]}"""
+      withJsonBody =
+        s"""{"errors":["page: [-50] is not greater than or equal to 1"]}"""
     )
   }
 
@@ -311,6 +318,46 @@ class ApiWorksTest
              |   }
              |  ]
              |}""".stripMargin
+      )
+    }
+  }
+
+  it("should include a list of identifiers if we pass ?includes=hasIdentifier") {
+    val identifier = SourceIdentifier(
+      source = "TestSource",
+      sourceId = "The ID field within the TestSource",
+      value = "Test1234"
+    )
+    val work = identifiedWorkWith(
+      canonicalId = "1234",
+      label = "An image of an iguana",
+      identifiers = List(identifier)
+    )
+    insertIntoElasticSearch(work)
+
+    eventually {
+      server.httpGet(
+        path = s"/$apiPrefix/works/${work.canonicalId}?includes=hasIdentifier",
+        andExpect = Status.Ok,
+        withJsonBody = s"""
+                          |{
+                          | "@context": "https://localhost:8888/$apiPrefix/context.json",
+                          | "type": "Work",
+                          | "id": "${work.canonicalId}",
+                          | "label": "${work.work.label}",
+                          | "hasCreator": [ ],
+                          | "hasIdentifier": [
+                          |   {
+                          |     "type": "Identifier",
+                          |     "source": {
+                          |       "name": "${identifier.source}",
+                          |       "value": "${identifier.sourceId}"
+                          |     },
+                          |     "value": "${identifier.value}"
+                          |   }
+                          | ]
+                          |}
+          """.stripMargin
       )
     }
   }

--- a/api/src/test/scala/uk/ac/wellcome/platform/api/WorksUtil.scala
+++ b/api/src/test/scala/uk/ac/wellcome/platform/api/WorksUtil.scala
@@ -13,9 +13,7 @@ trait WorksUtil {
   val period = Period("the past")
   val agent = Agent("a person")
 
-
   def convertWorkToDisplayWork(work: IdentifiedWork) = DisplayWork(
-    "Work",
     work.canonicalId,
     work.work.label,
     work.work.description,
@@ -24,41 +22,43 @@ trait WorksUtil {
     work.work.hasCreator
   )
 
-  def createIdentifiedWorks(count: Int) = (1 to count).map(
-    (idx: Int) =>
-      identifiedWorkWith(
-        canonicalId = s"${idx}-${canonicalId}",
-        label = s"${idx}-${label}",
-        description = s"${idx}-${description}",
-        lettering = s"${idx}-${lettering}",
-        createdDate = period.copy(label = s"${idx}-${period.label}"),
-        creator = agent.copy(label = s"${idx}-${agent.label}")
+  def createIdentifiedWorks(count: Int): Seq[IdentifiedWork] =
+    (1 to count).map(
+      (idx: Int) =>
+        identifiedWorkWith(
+          canonicalId = s"${idx}-${canonicalId}",
+          label = s"${idx}-${label}",
+          description = s"${idx}-${description}",
+          lettering = s"${idx}-${lettering}",
+          createdDate = period.copy(label = s"${idx}-${period.label}"),
+          creator = agent.copy(label = s"${idx}-${agent.label}")
       ))
 
-  def identifiedWorkWith(canonicalId: String, label: String): IdentifiedWork = {
+  def identifiedWorkWith(canonicalId: String, label: String): IdentifiedWork =
     IdentifiedWork(canonicalId,
                    Work(identifiers =
                           List(SourceIdentifier("Miro", "MiroID", "5678")),
                         label = label))
 
-  }
+  def identifiedWorkWith(canonicalId: String,
+                         label: String,
+                         identifiers: List[SourceIdentifier]): IdentifiedWork =
+    IdentifiedWork(canonicalId, Work(identifiers = identifiers, label = label))
+
   def identifiedWorkWith(canonicalId: String,
                          label: String,
                          description: String,
                          lettering: String,
                          createdDate: Period,
-                         creator: Agent): IdentifiedWork = {
-
-    IdentifiedWork(
-      canonicalId = canonicalId,
-      work = Work(
-        identifiers = List(SourceIdentifier("Miro", "MiroID", "5678")),
-        label = label,
-        description = Some(description),
-        lettering = Some(lettering),
-        hasCreatedDate = Some(createdDate),
-        hasCreator = List(creator)
-      )
+                         creator: Agent): IdentifiedWork = IdentifiedWork(
+    canonicalId = canonicalId,
+    work = Work(
+      identifiers = List(SourceIdentifier("Miro", "MiroID", "5678")),
+      label = label,
+      description = Some(description),
+      lettering = Some(lettering),
+      hasCreatedDate = Some(createdDate),
+      hasCreator = List(creator)
     )
-  }
+  )
 }

--- a/api/src/test/scala/uk/ac/wellcome/platform/api/services/ElasticsearchServiceTest.scala
+++ b/api/src/test/scala/uk/ac/wellcome/platform/api/services/ElasticsearchServiceTest.scala
@@ -40,8 +40,8 @@ class ElasticsearchServiceTest
     )
     whenReady(sortedSearchResultByCanonicalId) { result =>
       val works = result.hits.map { DisplayWork(_) }
-      works.head shouldBe DisplayWork("Work", work3.canonicalId, work3.work.label)
-      works.last shouldBe DisplayWork("Work", work1.canonicalId, work1.work.label)
+      works.head shouldBe DisplayWork(work3.canonicalId, work3.work.label)
+      works.last shouldBe DisplayWork(work1.canonicalId, work1.work.label)
     }
 
     // TODO: canonicalID is the only user-defined field that we can sort on.


### PR DESCRIPTION
### What is this PR trying to achieve?
Expose the list of identifiers when the hasIdentifier include is specified. Closes #306 
### Who is this change for?
Clients of our api that want to know the external id of our resources
### Have the following been considered/are they needed?

<!-- Delete bullets if they don't apply to this patch -->

<!-- If you're making public API changes -->
- [ ] Reviewed by @jtweed
- [ ] Updated the Swagger documentation
<!-- If you're making application changes -->
- [ ] Deployed new versions
