### PR TITLE
Don't require explicit ontologyType parameters

### DIFF
--- a/api/src/main/scala/uk/ac/wellcome/platform/api/models/DisplayWork.scala
+++ b/api/src/main/scala/uk/ac/wellcome/platform/api/models/DisplayWork.scala
@@ -8,14 +8,16 @@ import uk.ac.wellcome.utils.JsonUtil
 
 
 case class DisplayWork(
-  @JsonProperty("type") ontologyType: String = "Work",
   id: String,
   label: String,
   description: Option[String] = None,
   lettering: Option[String] = None,
   hasCreatedDate: Option[Period] = None,
   hasCreator: List[Agent] = List()
-)
+) {
+  @JsonProperty("type") val ontologyType: String = "Work"
+}
+
 case object DisplayWork {
   def apply(hit: RichSearchHit): DisplayWork = {
     toRecord(hit.sourceAsString)

--- a/api/src/main/scala/uk/ac/wellcome/platform/api/responses/Responses.scala
+++ b/api/src/main/scala/uk/ac/wellcome/platform/api/responses/Responses.scala
@@ -11,9 +11,10 @@ case class ResultResponse(
 
 case class ResultListResponse(
   @JsonProperty("@context") context: String,
-  @JsonProperty("type") ontologyType: String = "ResultList",
   pageSize: Int = 10,
   totalPages: Int = 10,
   totalResults: Int = 100,
   results: Array[_ <: Any]
-)
+) {
+  @JsonProperty("type") val ontologyType: String = "ResultList"
+}

--- a/api/src/main/scala/uk/ac/wellcome/platform/api/services/WorksService.scala
+++ b/api/src/main/scala/uk/ac/wellcome/platform/api/services/WorksService.scala
@@ -6,7 +6,6 @@ import com.sksamuel.elastic4s.searches.RichSearchResponse
 import com.twitter.inject.Logging
 import com.twitter.inject.annotations.Flag
 import uk.ac.wellcome.platform.api.models.{DisplaySearch, DisplayWork}
-import uk.ac.wellcome.platform.api.responses.ResultListResponse
 import uk.ac.wellcome.utils.GlobalExecutionContext.context
 
 import scala.concurrent.Future

--- a/api/src/test/scala/uk/ac/wellcome/platform/api/WorksUtil.scala
+++ b/api/src/test/scala/uk/ac/wellcome/platform/api/WorksUtil.scala
@@ -15,7 +15,6 @@ trait WorksUtil {
 
 
   def convertWorkToDisplayWork(work: IdentifiedWork) = DisplayWork(
-    "Work",
     work.canonicalId,
     work.work.label,
     work.work.description,

--- a/api/src/test/scala/uk/ac/wellcome/platform/api/services/ElasticsearchServiceTest.scala
+++ b/api/src/test/scala/uk/ac/wellcome/platform/api/services/ElasticsearchServiceTest.scala
@@ -40,8 +40,8 @@ class ElasticsearchServiceTest
     )
     whenReady(sortedSearchResultByCanonicalId) { result =>
       val works = result.hits.map { DisplayWork(_) }
-      works.head shouldBe DisplayWork("Work", work3.canonicalId, work3.work.label)
-      works.last shouldBe DisplayWork("Work", work1.canonicalId, work1.work.label)
+      works.head shouldBe DisplayWork(work3.canonicalId, work3.work.label)
+      works.last shouldBe DisplayWork(work1.canonicalId, work1.work.label)
     }
 
     // TODO: canonicalID is the only user-defined field that we can sort on.

--- a/api/src/test/scala/uk/ac/wellcome/platform/api/services/WorksServiceTest.scala
+++ b/api/src/test/scala/uk/ac/wellcome/platform/api/services/WorksServiceTest.scala
@@ -31,11 +31,9 @@ class WorksServiceTest
 
     displayWorksFuture map { displayWork =>
       displayWork.results should have size 2
-      displayWork.results.head shouldBe DisplayWork("Work",
-                                                    works(0).canonicalId,
+      displayWork.results.head shouldBe DisplayWork(works(0).canonicalId,
                                                     works(0).work.label)
-      displayWork.results.tail.head shouldBe DisplayWork("Work",
-                                                         works(1).canonicalId,
+      displayWork.results.tail.head shouldBe DisplayWork(works(1).canonicalId,
                                                          works(1).work.label)
     }
   }
@@ -74,13 +72,12 @@ class WorksServiceTest
     val searchForDodo = worksService.searchWorks("dodo")
     whenReady(searchForDodo) { works =>
       works.results should have size 1
-      works.results.head shouldBe DisplayWork("Work",
-                                              workDodo.canonicalId,
+      works.results.head shouldBe DisplayWork(workDodo.canonicalId,
                                               workDodo.work.label)
     }
   }
 
-  it("should return a future of None if it cannot get arecord by id") {
+  it("should return a future of None if it cannot get a record by id") {
     val recordsFuture = worksService.findWorkById("1234")
 
     whenReady(recordsFuture) { record =>
@@ -159,8 +156,7 @@ class WorksServiceTest
 
     whenReady(searchForEmu) { works =>
       works.results should have size 1
-      works.results.head shouldBe DisplayWork("Work",
-                                              workEmu.canonicalId,
+      works.results.head shouldBe DisplayWork(workEmu.canonicalId,
                                               workEmu.work.label)
     }
   }


### PR DESCRIPTION
### What is this PR trying to achieve?

A small code tidy that means you don't need to specify an explicit `type` parameter. Refactored out of #323.

### Who is this change for?

Developers who are lazy and want to type as little as possible.

### Have the following been considered/are they needed?

- [ ] Deployed new versions
