### PR TITLE
Fix a silly syntax error in the Travis check scripts

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ before_install:
   - |
     if [[ "$TRAVIS_EVENT_TYPE" == "pull_request" ]]
     then
-      if ! python ./scripts/should_rerun_tests.py
+      if python ./scripts/should_rerun_tests.py
       then
         echo "No changes that require us to re-run tests, skipping to the end"
         exit 0
@@ -31,7 +31,7 @@ before_install:
   - |
     if [[ "$TRAVIS_EVENT_TYPE" == "push" ]]
     then
-      if ! python ./scripts/should_rebuild_master.py
+      if python ./scripts/should_rebuild_master.py
       then
         echo "No changes that require us to re-build, skipping to the end"
         exit 0

--- a/scripts/should_rebuild_master.py
+++ b/scripts/should_rebuild_master.py
@@ -3,7 +3,7 @@
 """
 Decide whether we should re-build tests for a project on master.
 
-Exits with code 0 if there are changes that require a rebuild, 1 if not.
+Exits with code 1 if there are changes that require a rebuild, 0 if not.
 """
 
 import os
@@ -27,7 +27,7 @@ def should_rebuild_project(changed_files, project):
 
     elif 'run.sh' in changed_files:
         print("*** Changes to run.sh mean we should rebuild")
-        retrun True
+        return True
 
     elif any(f.startswith('scripts/') for f in changed_files):
         print("*** Changes to the scripts directory mean we should rebuild")
@@ -49,6 +49,6 @@ if __name__ == '__main__':
         project=os.environ['PROJECT']
     )
     if should_rebuild:
-        sys.exit(0)
-    else:
         sys.exit(1)
+    else:
+        sys.exit(0)

--- a/scripts/should_rerun_tests.py
+++ b/scripts/should_rerun_tests.py
@@ -3,7 +3,7 @@
 """
 Decide whether we should re-run tests for a project on a pull request.
 
-Exits with code 0 if there are changes that require a retest, 1 if not.
+Exits with code 1 if there are changes that require a retest, 0 if not.
 """
 
 import os
@@ -40,6 +40,6 @@ if __name__ == '__main__':
         project=os.environ['PROJECT']
     )
     if should_retest:
-        sys.exit(0)
-    else:
         sys.exit(1)
+    else:
+        sys.exit(0)


### PR DESCRIPTION
Also change it so that an error in the scripts (= exit code 1)
means everything should be rebuilt, so a failure in the scripts
mean we just rebuild everything.

### What is this PR trying to achieve?

Get the master builds running again.

### Who is this change for?

Developers who like working builds.