### PR TITLE
Use config location variables provided by Terraform

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,5 @@
 FROM anapsix/alpine-java
 
-ARG build_env=dev
-ARG config_bucket
 ARG project
 
 RUN apk update && apk add python3 && pip3 install awscli && rm -rf /var/cache/apk
@@ -14,8 +12,6 @@ COPY run.sh /run.sh
 
 EXPOSE 8888
 
-ENV BUILD_ENV $build_env
-ENV CONFIG_BUCKET $config_bucket
 ENV PROJECT $project
 
 CMD ["/run.sh"]

--- a/run.sh
+++ b/run.sh
@@ -2,12 +2,13 @@
 
 set -o errexit
 set -o nounset
+set -o xtrace
 
 echo "Running project $PROJECT"
 
 echo "Fetching config from AWS..."
-aws s3 ls s3://$CONFIG_BUCKET/config/$BUILD_ENV/$PROJECT.ini
-aws s3 cp s3://$CONFIG_BUCKET/config/$BUILD_ENV/$PROJECT.ini /opt/docker/conf/application.ini
+aws s3 ls s3://$INFRA_BUCKET/$CONFIG_KEY
+aws s3 cp s3://$INFRA_BUCKET/$CONFIG_KEY /opt/docker/conf/application.ini
 
 echo "=== config ==="
 cat /opt/docker/conf/application.ini

--- a/scripts/build_docker_image.sh
+++ b/scripts/build_docker_image.sh
@@ -3,13 +3,10 @@
 
 set -o errexit
 set -o nounset
+set -o xtrace
 
 sbt "project $PROJECT" stage
 
-docker build \
-  --build-arg project="$PROJECT" \
-  --build-arg config_bucket="$CONFIG_BUCKET" \
-  --build-arg build_env="$BUILD_ENV" \
-  --tag="$TAG" .
+docker build --build-arg project="$PROJECT" --tag="$TAG" .
 
 exit 0


### PR DESCRIPTION
### What is this PR trying to achieve?

Use config location variables provided in https://github.com/wellcometrust/platform-infra/pull/97

```
In order to have multiple instances of the same service running with different configurations.

So we can run multiple reindexers and transformers.

We need to parameterise the config key used for each service.
```

### Who is this change for?

Users of the ingestion pipeline.

### Have the following been considered/are they needed?

- [ ] Deployed new versions
