### PR TITLE
Utilise metrics sender to report on time taken for reindex to take place

### DIFF
--- a/common/src/test/scala/uk/ac/wellcome/test/utils/MetricsSender.scala
+++ b/common/src/test/scala/uk/ac/wellcome/test/utils/MetricsSender.scala
@@ -1,0 +1,11 @@
+package uk.ac.wellcome.test.utils
+
+import com.amazonaws.services.cloudwatch.AmazonCloudWatch
+import org.scalatest.mockito.MockitoSugar
+import uk.ac.wellcome.metrics.MetricsSender
+
+trait MetricsSenderLocal extends MockitoSugar {
+  val metricsSender: MetricsSender = new MetricsSender(
+    namespace = "reindex-service-test",
+    mock[AmazonCloudWatch])
+}

--- a/reindexer/src/main/scala/uk/ac/wellcome/platform/reindexer/Server.scala
+++ b/reindexer/src/main/scala/uk/ac/wellcome/platform/reindexer/Server.scala
@@ -25,6 +25,8 @@ class Server extends HttpServer {
                              ReindexModule,
                              AkkaModule)
 
+  flag[String]("aws.metrics.namespace", "", "Namespace for cloudwatch metrics")
+
   override def configureHttp(router: HttpRouter) {
     router
       .filter[CommonFilters]

--- a/reindexer/src/main/scala/uk/ac/wellcome/platform/reindexer/services/ReindexService.scala
+++ b/reindexer/src/main/scala/uk/ac/wellcome/platform/reindexer/services/ReindexService.scala
@@ -4,6 +4,7 @@ import javax.inject.Inject
 
 import com.amazonaws.services.dynamodbv2.model.PutItemResult
 import com.twitter.inject.Logging
+import uk.ac.wellcome.metrics.MetricsSender
 import uk.ac.wellcome.models.Reindexable
 import uk.ac.wellcome.platform.reindexer.models.ReindexAttempt
 import uk.ac.wellcome.utils.GlobalExecutionContext.context
@@ -12,22 +13,25 @@ import scala.concurrent.Future
 
 class ReindexService[T <: Reindexable[String]] @Inject()(
   reindexTrackerService: ReindexTrackerService,
-  reindexTargetService: ReindexTargetService[T])
+  reindexTargetService: ReindexTargetService[T],
+  metricsSender: MetricsSender)
     extends Logging {
 
   def run: Future[PutItemResult] = {
     info("ReindexService started.")
 
-    val result = for {
-      indices <- reindexTrackerService.getIndexForReindex
-      attempt = indices.map(ReindexAttempt(_, Nil, 0))
-      _ <- attempt.map(processReindexAttempt).getOrElse(Future.successful())
-      updates <- reindexTrackerService.updateReindex(attempt.get)
-    } yield updates
+    metricsSender.timeAndCount("reindex-total-time", () => {
+      val result = for {
+        indices <- reindexTrackerService.getIndexForReindex
+        attempt = indices.map(ReindexAttempt(_, Nil, 0))
+        _ <- attempt.map(processReindexAttempt).getOrElse(Future.successful((): Unit))
+        updates <- reindexTrackerService.updateReindex(attempt.get)
+      } yield updates
 
-    info("ReindexService finished.")
+      info("ReindexService finished.")
 
-    result
+      result
+    })
   }
 
   private def processReindexAttempt(

--- a/reindexer/src/test/scala/uk/ac/wellcome/platform/reindexer/ReindexerFeatureTest.scala
+++ b/reindexer/src/test/scala/uk/ac/wellcome/platform/reindexer/ReindexerFeatureTest.scala
@@ -6,13 +6,15 @@ import com.twitter.finagle.http.Status._
 import com.twitter.finatra.http.EmbeddedHttpServer
 import org.scalatest.concurrent.Eventually
 import org.scalatest.{FunSpec, Matchers}
+import uk.ac.wellcome.metrics.MetricsSender
 import uk.ac.wellcome.models.{CalmTransformable, Reindex}
-import uk.ac.wellcome.test.utils.{DynamoDBLocal, ExtendedPatience}
+import uk.ac.wellcome.test.utils.{DynamoDBLocal, ExtendedPatience, MetricsSenderLocal}
 
 class ReindexerFeatureTest
     extends FunSpec
     with DynamoDBLocal
     with Matchers
+    with MetricsSenderLocal
     with Eventually
     with ExtendedPatience {
 
@@ -25,6 +27,7 @@ class ReindexerFeatureTest
         "reindex.target.tableName" -> "CalmData"
       )
     ).bind[AmazonDynamoDB](dynamoDbClient)
+      .bind[MetricsSender](metricsSender)
 
   it(
     "should increment the reindexVersion to the value requested on all items of a table in need of reindex"
@@ -62,8 +65,8 @@ class ReindexerFeatureTest
       Scanamo.scan[CalmTransformable](dynamoDbClient)(calmDataTableName) shouldBe expectedCalmTransformableList
 
       server.httpGet(path = "/management/healthcheck",
-        andExpect = Created,
-        withJsonBody = """{"message": "success"}""")
+                     andExpect = Created,
+                     withJsonBody = """{"message": "success"}""")
     }
   }
 }

--- a/reindexer/src/test/scala/uk/ac/wellcome/platform/reindexer/StartupTest.scala
+++ b/reindexer/src/test/scala/uk/ac/wellcome/platform/reindexer/StartupTest.scala
@@ -1,11 +1,17 @@
 package uk.ac.wellcome.platform.reindexer
 
+import com.amazonaws.services.dynamodbv2.AmazonDynamoDB
 import com.google.inject.Stage
 import com.twitter.finatra.http.EmbeddedHttpServer
 import com.twitter.inject.server.FeatureTest
-import uk.ac.wellcome.test.utils.StartupLogbackOverride
+import uk.ac.wellcome.metrics.MetricsSender
+import uk.ac.wellcome.test.utils.{DynamoDBLocal, MetricsSenderLocal, StartupLogbackOverride}
 
-class StartupTest extends FeatureTest with StartupLogbackOverride {
+class StartupTest
+    extends FeatureTest
+    with DynamoDBLocal
+    with StartupLogbackOverride
+    with MetricsSenderLocal {
 
   val server = new EmbeddedHttpServer(
     stage = Stage.PRODUCTION,
@@ -15,7 +21,8 @@ class StartupTest extends FeatureTest with StartupLogbackOverride {
       "aws.dynamo.miroData.tableName" -> "MiroData",
       "reindex.target.tableName" -> "MiroData"
     )
-  )
+  ).bind[AmazonDynamoDB](dynamoDbClient)
+    .bind[MetricsSender](metricsSender)
 
   test("server starts up correctly") {
     server.assertHealthy()

--- a/reindexer/src/test/scala/uk/ac/wellcome/platform/reindexer/services/ReindexServiceTest.scala
+++ b/reindexer/src/test/scala/uk/ac/wellcome/platform/reindexer/services/ReindexServiceTest.scala
@@ -3,14 +3,15 @@ package uk.ac.wellcome.platform.reindexer.services
 import com.gu.scanamo.Scanamo
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.{FunSpec, Matchers}
-import uk.ac.wellcome.models.{CalmTransformable, Reindex}
 import uk.ac.wellcome.models.aws.DynamoConfig
-import uk.ac.wellcome.test.utils.{DynamoDBLocal, ExtendedPatience}
+import uk.ac.wellcome.models.{CalmTransformable, Reindex}
+import uk.ac.wellcome.test.utils.{DynamoDBLocal, ExtendedPatience, MetricsSenderLocal}
 
 class ReindexServiceTest
     extends FunSpec
     with ScalaFutures
     with Matchers
+    with MetricsSenderLocal
     with DynamoDBLocal
     with ExtendedPatience {
 
@@ -28,7 +29,8 @@ class ReindexServiceTest
         dynamoConfigs,
         "CalmData"
       ),
-      new CalmReindexTargetService(dynamoDbClient, "CalmData")
+      new CalmReindexTargetService(dynamoDbClient, "CalmData"),
+      metricsSender
     )
 
   it(


### PR DESCRIPTION
### What is this PR trying to achieve?

Provide better reporting to the reindexing service

### Who is this change for?

Folks who want visibility into reindex processes

### Have the following been considered/are they needed?

- [ ] Deployed new versions
