### PR TITLE
Serialisation changes for the API

### DIFF
--- a/api/src/main/resources/context.json
+++ b/api/src/main/resources/context.json
@@ -5,7 +5,15 @@
       "@vocab": "http://wellcomecollection.org/ontologies/works/",
       "id": "@id",
       "type": "@type",
-      "hasCreator": {
+      "creators": {
+        "@type": "wa:agent",
+        "@container": "@list"
+      },
+      "createdDate": {
+        "@type": "wa:period"
+      },
+      "identifiers": {
+        "@type": "wa:identifier",
         "@container": "@list"
       }
     },

--- a/api/src/main/resources/context.json
+++ b/api/src/main/resources/context.json
@@ -6,14 +6,11 @@
       "id": "@id",
       "type": "@type",
       "creators": {
-        "@type": "wa:agent",
+        "@id": "hasCreator",
         "@container": "@list"
       },
-      "createdDate": {
-        "@type": "wa:period"
-      },
       "identifiers": {
-        "@type": "wa:identifier",
+        "@id": "hasIdentifier",
         "@container": "@list"
       }
     },

--- a/api/src/main/scala/uk/ac/wellcome/platform/api/models/DisplayWork.scala
+++ b/api/src/main/scala/uk/ac/wellcome/platform/api/models/DisplayWork.scala
@@ -10,9 +10,9 @@ case class DisplayWork(id: String,
                        label: String,
                        description: Option[String] = None,
                        lettering: Option[String] = None,
-                       hasCreatedDate: Option[Period] = None,
-                       hasCreator: List[Agent] = List(),
-                       hasIdentifier: Option[List[DisplayIdentifier]] = None) {
+                       createdDate: Option[Period] = None,
+                       creators: List[Agent] = List(),
+                       identifiers: Option[List[DisplayIdentifier]] = None) {
   @JsonProperty("type") val ontologyType: String = "Work"
 }
 
@@ -37,11 +37,11 @@ case object DisplayWork {
       label = identifiedWork.work.label,
       description = identifiedWork.work.description,
       lettering = identifiedWork.work.lettering,
-      hasCreatedDate = identifiedWork.work.hasCreatedDate,
+      createdDate = identifiedWork.work.createdDate,
       // Wrapping this in Option to catch null value from Jackson
-      hasCreator = Option(identifiedWork.work.hasCreator).getOrElse(Nil),
-      hasIdentifier =
-        if (includes.contains("hasIdentifier"))
+      creators = Option(identifiedWork.work.creators).getOrElse(Nil),
+      identifiers =
+        if (includes.contains("identifiers"))
           Some(identifiedWork.work.identifiers.map(DisplayIdentifier(_)))
         else None
     )

--- a/api/src/test/scala/uk/ac/wellcome/platform/api/ApiWorksTest.scala
+++ b/api/src/test/scala/uk/ac/wellcome/platform/api/ApiWorksTest.scala
@@ -64,13 +64,13 @@ class ApiWorksTest
             |     "label": "${works(0).work.label}",
             |     "description": "${works(0).work.description.get}",
             |     "lettering": "${works(0).work.lettering.get}",
-            |     "hasCreatedDate": {
+            |     "createdDate": {
             |       "type": "Period",
-            |       "label": "${works(0).work.hasCreatedDate.get.label}"
+            |       "label": "${works(0).work.createdDate.get.label}"
             |     },
-            |     "hasCreator": [{
+            |     "creators": [{
             |       "type": "Agent",
-            |       "label": "${works(0).work.hasCreator(0).label}"
+            |       "label": "${works(0).work.creators(0).label}"
             |     }]
             |   },
             |   {
@@ -79,13 +79,13 @@ class ApiWorksTest
             |     "label": "${works(1).work.label}",
             |     "description": "${works(1).work.description.get}",
             |     "lettering": "${works(1).work.lettering.get}",
-            |     "hasCreatedDate": {
+            |     "createdDate": {
             |       "type": "Period",
-            |       "label": "${works(1).work.hasCreatedDate.get.label}"
+            |       "label": "${works(1).work.createdDate.get.label}"
             |     },
-            |     "hasCreator": [{
+            |     "creators": [{
             |       "type": "Agent",
-            |       "label": "${works(1).work.hasCreator(0).label}"
+            |       "label": "${works(1).work.creators(0).label}"
             |     }]
             |   },
             |   {
@@ -94,13 +94,13 @@ class ApiWorksTest
             |     "label": "${works(2).work.label}",
             |     "description": "${works(2).work.description.get}",
             |     "lettering": "${works(2).work.lettering.get}",
-            |     "hasCreatedDate": {
+            |     "createdDate": {
             |       "type": "Period",
-            |       "label": "${works(2).work.hasCreatedDate.get.label}"
+            |       "label": "${works(2).work.createdDate.get.label}"
             |     },
-            |     "hasCreator": [{
+            |     "creators": [{
             |       "type": "Agent",
-            |       "label": "${works(2).work.hasCreator(0).label}"
+            |       "label": "${works(2).work.creators(0).label}"
             |     }]
             |   }
             |  ]
@@ -134,11 +134,11 @@ class ApiWorksTest
             | "label": "$label",
             | "description": "$description",
             | "lettering": "$lettering",
-            | "hasCreatedDate": {
+            | "createdDate": {
             |   "type": "Period",
             |   "label": "${period.label}"
             | },
-            | "hasCreator": [{
+            | "creators": [{
             |   "type": "Agent",
             |   "label": "${agent.label}"
             | }]
@@ -171,14 +171,14 @@ class ApiWorksTest
                           |     "label": "${works(1).work.label}",
                           |     "description": "${works(1).work.description.get}",
                           |     "lettering": "${works(1).work.lettering.get}",
-                          |     "hasCreatedDate": {
+                          |     "createdDate": {
                           |       "type": "Period",
-                          |       "label": "${works(1).work.hasCreatedDate.get.label}"
+                          |       "label": "${works(1).work.createdDate.get.label}"
                           |     },
-                          |     "hasCreator": [{
+                          |     "creators": [{
                           |       "type": "Agent",
                           |       "label": "${works(1).work
-                            .hasCreator(0)
+                            .creators(0)
                             .label}"
                           |     }]
                           |   }]
@@ -314,7 +314,7 @@ class ApiWorksTest
              |     "type": "Work",
              |     "id": "${work1.canonicalId}",
              |     "label": "${work1.work.label}",
-             |     "hasCreator": []
+             |     "creators": []
              |   }
              |  ]
              |}""".stripMargin
@@ -322,7 +322,7 @@ class ApiWorksTest
     }
   }
 
-  it("should include a list of identifiers on a list endpoint if we pass ?includes=hasIdentifier") {
+  it("should include a list of identifiers on a list endpoint if we pass ?includes=identifiers") {
     val identifier1 = SourceIdentifier(
       source = "TestSource",
       sourceId = "The ID field within the TestSource",
@@ -351,7 +351,7 @@ class ApiWorksTest
 
     eventually {
       server.httpGet(
-        path = s"/$apiPrefix/works?includes=hasIdentifier",
+        path = s"/$apiPrefix/works?includes=identifiers",
         andExpect = Status.Ok,
         withJsonBody = s"""
                           |{
@@ -365,8 +365,8 @@ class ApiWorksTest
                           |     "type": "Work",
                           |     "id": "${work1.canonicalId}",
                           |     "label": "${work1.work.label}",
-                          |     "hasCreator": [ ],
-                          |     "hasIdentifier": [
+                          |     "creators": [ ],
+                          |     "identifiers": [
                           |       {
                           |         "type": "Identifier",
                           |         "source": "${identifier1.source}",
@@ -379,8 +379,8 @@ class ApiWorksTest
                           |     "type": "Work",
                           |     "id": "${work2.canonicalId}",
                           |     "label": "${work2.work.label}",
-                          |     "hasCreator": [ ],
-                          |     "hasIdentifier": [
+                          |     "creators": [ ],
+                          |     "identifiers": [
                           |       {
                           |         "type": "Identifier",
                           |         "source": "${identifier2.source}",
@@ -397,7 +397,7 @@ class ApiWorksTest
   }
 
 
-  it("should include a list of identifiers on a single work endpoint if we pass ?includes=hasIdentifier") {
+  it("should include a list of identifiers on a single work endpoint if we pass ?includes=identifiers") {
     val identifier = SourceIdentifier(
       source = "TestSource",
       sourceId = "The ID field within the TestSource",
@@ -412,7 +412,7 @@ class ApiWorksTest
 
     eventually {
       server.httpGet(
-        path = s"/$apiPrefix/works/${work.canonicalId}?includes=hasIdentifier",
+        path = s"/$apiPrefix/works/${work.canonicalId}?includes=identifiers",
         andExpect = Status.Ok,
         withJsonBody = s"""
                           |{
@@ -420,8 +420,8 @@ class ApiWorksTest
                           | "type": "Work",
                           | "id": "${work.canonicalId}",
                           | "label": "${work.work.label}",
-                          | "hasCreator": [ ],
-                          | "hasIdentifier": [
+                          | "creators": [ ],
+                          | "identifiers": [
                           |   {
                           |     "type": "Identifier",
                           |     "source": "${identifier.source}",

--- a/api/src/test/scala/uk/ac/wellcome/platform/api/ApiWorksTest.scala
+++ b/api/src/test/scala/uk/ac/wellcome/platform/api/ApiWorksTest.scala
@@ -177,9 +177,7 @@ class ApiWorksTest
                           |     },
                           |     "creators": [{
                           |       "type": "Agent",
-                          |       "label": "${works(1).work
-                            .creators(0)
-                            .label}"
+                          |       "label": "${works(1).work.creators(0).label}"
                           |     }]
                           |   }]
                           |   }

--- a/api/src/test/scala/uk/ac/wellcome/platform/api/WorksUtil.scala
+++ b/api/src/test/scala/uk/ac/wellcome/platform/api/WorksUtil.scala
@@ -18,8 +18,8 @@ trait WorksUtil {
     work.work.label,
     work.work.description,
     work.work.lettering,
-    work.work.hasCreatedDate,
-    work.work.hasCreator
+    work.work.createdDate,
+    work.work.creators
   )
 
   def createIdentifiedWorks(count: Int): Seq[IdentifiedWork] =
@@ -57,8 +57,8 @@ trait WorksUtil {
       label = label,
       description = Some(description),
       lettering = Some(lettering),
-      hasCreatedDate = Some(createdDate),
-      hasCreator = List(creator)
+      createdDate = Some(createdDate),
+      creators = List(creator)
     )
   )
 }

--- a/api/src/test/scala/uk/ac/wellcome/platform/api/services/WorksServiceTest.scala
+++ b/api/src/test/scala/uk/ac/wellcome/platform/api/services/WorksServiceTest.scala
@@ -184,12 +184,12 @@ class WorksServiceTest
     insertIntoElasticSearch(work)
 
     val getByIdResult =
-      worksService.findWorkById(canonicalId, includes = List("hasIdentifier"))
+      worksService.findWorkById(canonicalId, includes = List("identifiers"))
 
     whenReady(getByIdResult) { maybeDisplayWork =>
       maybeDisplayWork.isDefined shouldBe true
-      maybeDisplayWork.get.hasIdentifier.isDefined shouldBe true
-      maybeDisplayWork.get.hasIdentifier.get shouldBe List(
+      maybeDisplayWork.get.identifiers.isDefined shouldBe true
+      maybeDisplayWork.get.identifiers.get shouldBe List(
         DisplayIdentifier(source = sourceName,
                           name = sourceId,
                           value = miroId))
@@ -213,10 +213,10 @@ class WorksServiceTest
     insertIntoElasticSearch(work)
 
     val listWorksResult =
-      worksService.listWorks(includes = List("hasIdentifier"))
+      worksService.listWorks(includes = List("identifiers"))
 
     whenReady(listWorksResult) { (displayWork: DisplaySearch) =>
-      displayWork.results.head.hasIdentifier.get shouldBe List(
+      displayWork.results.head.identifiers.get shouldBe List(
         DisplayIdentifier(source = sourceName,
                           name = sourceId,
                           value = miroId))
@@ -241,10 +241,10 @@ class WorksServiceTest
 
     val searchWorksResult = worksService.searchWorks(query = "snail",
                                                      includes =
-                                                       List("hasIdentifier"))
+                                                       List("identifiers"))
 
     whenReady(searchWorksResult) { (displayWork: DisplaySearch) =>
-      displayWork.results.head.hasIdentifier.get shouldBe List(
+      displayWork.results.head.identifiers.get shouldBe List(
         DisplayIdentifier(source = sourceName,
                           name = sourceId,
                           value = miroId))

--- a/common/src/main/scala/uk/ac/wellcome/elasticsearch/mappings/WorksIndex.scala
+++ b/common/src/main/scala/uk/ac/wellcome/elasticsearch/mappings/WorksIndex.scala
@@ -34,11 +34,11 @@ class WorksIndex @Inject()(client: TcpClient,
           textField("english").analyzer(EnglishLanguageAnalyzer)),
         textField("lettering").fields(
           textField("english").analyzer(EnglishLanguageAnalyzer)),
-        objectField("hasCreatedDate").fields(
+        objectField("createdDate").fields(
           textField("label"),
           keywordField("type")
         ),
-        objectField("hasCreator").fields(
+        objectField("creators").fields(
           textField("label"),
           keywordField("type")
         )

--- a/common/src/main/scala/uk/ac/wellcome/models/MiroTransformable.scala
+++ b/common/src/main/scala/uk/ac/wellcome/models/MiroTransformable.scala
@@ -67,8 +67,8 @@ case class MiroTransformable(MiroID: String,
         identifiers = identifiers,
         label = label,
         description = description,
-        hasCreatedDate = createdDate,
-        hasCreator = creators ++ secondaryCreators
+        createdDate = createdDate,
+        creators = creators ++ secondaryCreators
       )
     }
 }

--- a/common/src/main/scala/uk/ac/wellcome/models/Work.scala
+++ b/common/src/main/scala/uk/ac/wellcome/models/Work.scala
@@ -20,8 +20,8 @@ case class Work(
   label: String,
   description: Option[String] = None,
   lettering: Option[String] = None,
-  hasCreatedDate: Option[Period] = None,
-  hasCreator: List[Agent] = List()
+  createdDate: Option[Period] = None,
+  creators: List[Agent] = List()
 ) {
   @JsonProperty("type") val ldType: String = "Work"
 }

--- a/common/src/test/scala/uk/ac/wellcome/models/MiroTransformableTest.scala
+++ b/common/src/test/scala/uk/ac/wellcome/models/MiroTransformableTest.scala
@@ -22,12 +22,12 @@ class MiroTransformableTest extends FunSpec with Matchers {
 
   it("should have an empty list if no image_creator field is present") {
     val work = transformMiroRecord(data = s"""{"image_title": "A guide to giraffes"}""")
-    work.hasCreator shouldBe List[Agent]()
+    work.creators shouldBe List[Agent]()
   }
 
   it("should have an empty list if the image_creator field is empty") {
     val work = transformMiroRecord(data = s"""{"image_title": "A box of beavers", "image_creator": []}""")
-    work.hasCreator shouldBe List[Agent]()
+    work.creators shouldBe List[Agent]()
   }
 
   it("should pass through a single value in the image_creator field") {
@@ -35,7 +35,7 @@ class MiroTransformableTest extends FunSpec with Matchers {
     val work = transformMiroRecord(
       data = s"""{"image_title": "A radio for a racoon", "image_creator": ["$creator"]}"""
     )
-    work.hasCreator shouldBe List(Agent(creator))
+    work.creators shouldBe List(Agent(creator))
   }
 
   it("should pass through multiple values in the image_creator field") {
@@ -45,7 +45,7 @@ class MiroTransformableTest extends FunSpec with Matchers {
     val work = transformMiroRecord(
       data = s"""{"image_title": "A book about badgers", "image_creator": ["$creator1", "$creator2", "$creator3"]}"""
     )
-    work.hasCreator shouldBe List(Agent(creator1), Agent(creator2), Agent(creator3))
+    work.creators shouldBe List(Agent(creator1), Agent(creator2), Agent(creator3))
   }
 
   it("should have no description if no image_image_desc field is present") {
@@ -67,7 +67,7 @@ class MiroTransformableTest extends FunSpec with Matchers {
       data = s"""{"image_title": "A description of a dalmation", "image_artwork_date": "$date"}""",
       miroCollection = "Images-V"
     )
-    work.hasCreatedDate shouldBe Some(Period(date))
+    work.createdDate shouldBe Some(Period(date))
   }
 
   it("should not pass through the value of the creation date on non-V records") {
@@ -76,7 +76,7 @@ class MiroTransformableTest extends FunSpec with Matchers {
       data = s"""{"image_title": "A diary about a dodo", "image_artwork_date": "$date"}""",
       miroCollection = "Images-A"
     )
-    work.hasCreatedDate shouldBe None
+    work.createdDate shouldBe None
   }
 
   it("should use the image_creator_secondary field if image_creator is not present") {
@@ -84,7 +84,7 @@ class MiroTransformableTest extends FunSpec with Matchers {
     val work = transformMiroRecord(
       data = s"""{"image_title": "Samples of a shark", "image_secondary_creator": ["$secondaryCreator"]}"""
     )
-    work.hasCreator shouldBe List(Agent(secondaryCreator))
+    work.creators shouldBe List(Agent(secondaryCreator))
   }
 
   it("should use all the values in the image_creator_secondary field if image_creator is not present") {
@@ -93,7 +93,7 @@ class MiroTransformableTest extends FunSpec with Matchers {
     val work = transformMiroRecord(
       data = s"""{"image_title": "Verdant and vivid", "image_secondary_creator": ["$secondaryCreator1", "$secondaryCreator2"]}"""
     )
-    work.hasCreator shouldBe List(Agent(secondaryCreator1), Agent(secondaryCreator2))
+    work.creators shouldBe List(Agent(secondaryCreator1), Agent(secondaryCreator2))
   }
 
   it("should combine the values in the image_creator and image_secondary_creator fields if both present") {
@@ -102,7 +102,7 @@ class MiroTransformableTest extends FunSpec with Matchers {
     val work = transformMiroRecord(
       data = s"""{"image_title": "Musings on mice", "image_creator": ["$creator"], "image_secondary_creator": ["$secondaryCreator"]}"""
     )
-    work.hasCreator shouldBe List(Agent(creator), Agent(secondaryCreator))
+    work.creators shouldBe List(Agent(creator), Agent(secondaryCreator))
   }
 
   private def assertTransformMiroRecordFails(


### PR DESCRIPTION
### What is this PR trying to achieve?

Drop the "hasFoo" naming style in favour of "foos", and update the JSON-LD context.

### Who is this change for?

Users of our API.

### Have the following been considered/are they needed?

- [x] Reviewed by @jtweed
- [ ] Updated the Swagger documentation
- [ ] Deployed new versions