### PR TITLE
Fill in the Reindex* fields in the Miro adapter

### DIFF
--- a/miro_adapter/miro_adapter.py
+++ b/miro_adapter/miro_adapter.py
@@ -62,6 +62,8 @@ def push_to_dynamodb(table_name, collection_name, image_data):
                 Item={
                     'MiroID': image['image_no_calc'],
                     'MiroCollection': collection_name,
+                    'ReindexShard': 'default',
+                    'ReindexVersion': 0,
                     'data': json.dumps(image, separators=(',', ':'))
                 }
             )


### PR DESCRIPTION
### What is this PR trying to achieve?

When we run the Miro adapter, fill in the reindex-related fields so the row becomes visible to the reindexer.

### Who is this change for?

Folks working on the ingest pipeline.

---

Follow-on Qs:

- [ ] We'll need to do this for the Calm adapter when we turn it back on
- [ ] If we reingest certain records, we'll reset their ReindexVersion. Is that a problem? (I've been thinking about putting stronger de-dupe checks on the Miro adapter as-is, could do those at the same time.)