### PR TITLE
Correctly name failure metric in timeAndCount

### DIFF
--- a/common/src/main/scala/uk/ac/wellcome/metrics/MetricsSender.scala
+++ b/common/src/main/scala/uk/ac/wellcome/metrics/MetricsSender.scala
@@ -30,7 +30,7 @@ class MetricsSender @Inject()(@Flag("aws.metrics.namespace") namespace: String,
       case Failure(_) =>
         val end = new Date()
         incrementCount("failure")
-        sendTime("ingest-time",
+        sendTime(metricName,
           (end.getTime - start.getTime) milliseconds,
           Map("success" -> "false"))
     }


### PR DESCRIPTION
### What is this PR trying to achieve?

Recording fail state correctly in metrics sender.

### Who is this change for?

Devs

### Have the following been considered/are they needed?

- [ ] Deployed new versions
