### PR TITLE
Adds _even better_ reporting to the reindexer service

### DIFF
--- a/reindexer/src/main/scala/uk/ac/wellcome/platform/reindexer/models/JobStatus.scala
+++ b/reindexer/src/main/scala/uk/ac/wellcome/platform/reindexer/models/JobStatus.scala
@@ -15,7 +15,8 @@ object JobStatus extends Enumeration {
 case class ReindexStatus(state: JobStatus.Value,
                          percentComplete: Option[Float]) {
   def toMap =
-    Map("state" -> state.toString, "percent" -> percentComplete.getOrElse(0F))
+    Map("state" -> state.toString,
+        "percent" -> percentComplete.getOrElse(0F).toString)
 
 }
 object ReindexStatus {

--- a/reindexer/src/main/scala/uk/ac/wellcome/platform/reindexer/models/JobStatus.scala
+++ b/reindexer/src/main/scala/uk/ac/wellcome/platform/reindexer/models/JobStatus.scala
@@ -21,8 +21,7 @@ case class ReindexStatus(state: JobStatus.Value,
 }
 object ReindexStatus {
   private val initState = ReindexStatus(JobStatus.Init, None)
-
-  val agent: Agent[ReindexStatus] = Agent[ReindexStatus](initState)
+  private val agent: Agent[ReindexStatus] = Agent[ReindexStatus](initState)
 
   def currentStatus: ReindexStatus = agent.get()
 

--- a/reindexer/src/main/scala/uk/ac/wellcome/platform/reindexer/models/JobStatus.scala
+++ b/reindexer/src/main/scala/uk/ac/wellcome/platform/reindexer/models/JobStatus.scala
@@ -1,0 +1,38 @@
+package uk.ac.wellcome.platform.reindexer.models
+
+import akka.agent.Agent
+import uk.ac.wellcome.utils.GlobalExecutionContext.context
+
+object JobStatus extends Enumeration {
+  type JobStatus = Value
+
+  val Init = Value("initialised")
+  val Working = Value("working")
+  val Success = Value("success")
+  val Failure = Value("failure")
+}
+
+case class ReindexStatus(state: JobStatus.Value,
+                         percentComplete: Option[Float]) {
+  def toMap =
+    Map("state" -> state.toString, "percent" -> percentComplete.getOrElse(0F))
+
+}
+object ReindexStatus {
+  private val initState = ReindexStatus(JobStatus.Init, None)
+
+  val agent: Agent[ReindexStatus] = Agent[ReindexStatus](initState)
+
+  def currentStatus: ReindexStatus = agent.get()
+
+  def init(): Unit = agent.send(ReindexStatus(JobStatus.Init, None))
+
+  def work(percent: Float): Unit =
+    agent.send(ReindexStatus(JobStatus.Working, Some(percent)))
+
+  def succeed(): Unit =
+    agent.send(ReindexStatus(JobStatus.Success, currentStatus.percentComplete))
+
+  def fail(): Unit =
+    agent.send(ReindexStatus(JobStatus.Failure, currentStatus.percentComplete))
+}

--- a/reindexer/src/main/scala/uk/ac/wellcome/platform/reindexer/services/ReindexTargetService.scala
+++ b/reindexer/src/main/scala/uk/ac/wellcome/platform/reindexer/services/ReindexTargetService.scala
@@ -8,7 +8,7 @@ import com.gu.scanamo.{Scanamo, Table}
 import com.twitter.inject.Logging
 import uk.ac.wellcome.metrics.MetricsSender
 import uk.ac.wellcome.models.{Reindex, ReindexItem, Reindexable}
-import uk.ac.wellcome.platform.reindexer.models.ReindexAttempt
+import uk.ac.wellcome.platform.reindexer.models.{ReindexAttempt, ReindexStatus}
 import uk.ac.wellcome.utils.GlobalExecutionContext.context
 
 import scala.concurrent.Future
@@ -71,11 +71,12 @@ abstract class ReindexTargetService[T <: Reindexable[String]](
           val result = groupOps.map(Scanamo.exec(dynamoDBClient)(_))
 
           val updateCount = groupOps.length * (i + 1)
-          val percentComplete =
-            "%1.0f".format((updateCount.toFloat / rows.length.toFloat) * 100)
+          val percentComplete = (updateCount.toFloat / rows.length.toFloat) * 100
+
+          ReindexStatus.work(percentComplete)
 
           info(
-            s"ReindexTargetService completed ${updateCount} updates: ${percentComplete}% complete")
+            s"ReindexTargetService completed $updateCount updates: ${"%1.0f".format(percentComplete)}% complete")
 
           metricsSender.incrementCount("reindex-updated-items", updateCount.toDouble)
 

--- a/reindexer/src/test/scala/uk/ac/wellcome/platform/reindexer/ReindexerFeatureTest.scala
+++ b/reindexer/src/test/scala/uk/ac/wellcome/platform/reindexer/ReindexerFeatureTest.scala
@@ -63,7 +63,8 @@ class ReindexerFeatureTest
 
       server.httpGet(path = "/management/healthcheck",
                      andExpect = Created,
-                     withJsonBody = """{"message": "success"}""")
+                     withJsonBody =
+                       """{"percent" : 100.0,"state" : "success"}""")
     }
   }
 }


### PR DESCRIPTION
### What is this PR trying to achieve?

Even more visibility on the internal state of the reindexer!

Depends:
- https://github.com/wellcometrust/platform-api/pull/355/files

### Who is this change for?

Devs trying to understand reindexer behaviour

### Have the following been considered/are they needed?

- [ ] Deployed new versions
