### PR TITLE
Improve the design of the TryBackoff

### DIFF
--- a/common/src/main/scala/uk/ac/wellcome/utils/DynamoUtils.scala
+++ b/common/src/main/scala/uk/ac/wellcome/utils/DynamoUtils.scala
@@ -34,4 +34,3 @@ trait DynamoUpdateWriteCapacityCapable {
     table.updateTable(newThroughput)
   }
 }
-

--- a/common/src/main/scala/uk/ac/wellcome/utils/TryBackoff.scala
+++ b/common/src/main/scala/uk/ac/wellcome/utils/TryBackoff.scala
@@ -7,6 +7,7 @@ import uk.ac.wellcome.utils.GlobalExecutionContext.context
 import scala.concurrent.duration._
 import scala.math.pow
 import scala.util.{Failure, Success, Try}
+import scala.util.control.Breaks.break
 
 /** This trait implements an exponential backoff algorithm.  This is useful
   * for wrapping an operation that is known to be flakey/unreliable.
@@ -26,6 +27,13 @@ import scala.util.{Failure, Success, Try}
   *     @param totalWaitMillis how many milliseconds should we wait before
   *                            giving up on the operation
   *
+  * Additionally, the operation can run again after it succeeds (reverting
+  * to the base wait time), or give up after the first success.  This is
+  * controlled by a third attribute:
+  *
+  *     @param continuous      true if the operation should repeat, false
+  *                            if it should return after the first success
+  *
   * For example, to wait 1 second after the first failure and give up after
   * five minutes, we would set
   *
@@ -37,7 +45,8 @@ import scala.util.{Failure, Success, Try}
   */
 trait TryBackoff extends Logging {
   val baseWaitMillis = 100
-  val totalWaitMillis = 30 * 60 * 1000  // half an hour
+  val totalWaitMillis = 30 * 60 * 1000 // half an hour
+  val continuous = true
 
   // This value is cached to save us repeating the calculation.
   private val maxAttempts = maximumAttemptsToTry()
@@ -53,6 +62,12 @@ trait TryBackoff extends Logging {
       case Failure(e) =>
         error(s"Failed to run (attempt: $attempt)", e)
         attempt + 1
+    }
+
+    // If we're in non-continuous mode and the last attempt succeeded,
+    // we should return immediately.
+    if (numberOfAttempts == 0 && !continuous) {
+      return
     }
 
     if (numberOfAttempts > maxAttempts) {
@@ -77,24 +92,25 @@ trait TryBackoff extends Logging {
     * to know how many attempts to try for internal bookkeeping, but the
     * calculation is abstracted away from the caller.
     */
-  private def maximumAttemptsToTry() {
+  private def maximumAttemptsToTry(): Int = {
     var totalMillis: Long = 0
     var attempt = 0
-    while true {
-      totalMillis += timeToWaitOnAttempt(attempt)
-      if totalMillis > totalWaitMillis {
-        return attempt
+    while (true) {
+      totalMillis = totalMillis + timeToWaitOnAttempt(attempt)
+      if (totalMillis > totalWaitMillis) {
+        break
       } else {
         attempt += 1
       }
     }
+    attempt
   }
 
   /** Returns the time to wait after the nth failure.
     *
     * @param attempt which attempt has just failed (zero-indexed)
     */
-  private def timeToWaitOnAttempt(attempt: Int) {
+  private def timeToWaitOnAttempt(attempt: Int): Long = {
     // This choice of exponent is somewhat arbitrary.  All we require is
     // that later attempts wait longer than earlier attempts.
     val exponent = attempt / (baseWaitMillis / 4)

--- a/common/src/main/scala/uk/ac/wellcome/utils/TryBackoff.scala
+++ b/common/src/main/scala/uk/ac/wellcome/utils/TryBackoff.scala
@@ -50,8 +50,8 @@ trait TryBackoff extends Logging {
       f()
     } match {
       case Success(_) => 0
-      case Failure(_) =>
-        error(s"Failed to run (attempt: $attempt)")
+      case Failure(e) =>
+        error(s"Failed to run (attempt: $attempt)", e)
         attempt + 1
     }
 

--- a/common/src/main/scala/uk/ac/wellcome/utils/TryBackoff.scala
+++ b/common/src/main/scala/uk/ac/wellcome/utils/TryBackoff.scala
@@ -8,9 +8,40 @@ import scala.concurrent.duration._
 import scala.math.pow
 import scala.util.{Failure, Success, Try}
 
+/** This trait implements an exponential backoff algorithm.  This is useful
+  * for wrapping an operation that is known to be flakey/unreliable.
+  *
+  * If the operation fails, we try again, but we wait an increasing amount
+  * of time between failed attempts.  This means we don't:
+  *
+  *   - Overwhelm an underlying service which might be overwhelmed -- and
+  *     thus make the problem worse
+  *   - Waste our own resources trying to repeat an operation that is likely
+  *     to fail
+  *
+  * How quickly we back off is controlled by two attributes:
+  *
+  *     @param baseWaitMillis  how many milliseconds should we wait after
+  *                            the first failure
+  *     @param totalWaitMillis how many milliseconds should we wait before
+  *                            giving up on the operation
+  *
+  * For example, to wait 1 second after the first failure and give up after
+  * five minutes, we would set
+  *
+  *     baseWaitMillis = 1000
+  *     totalWaitMillis = 5 * 60 * 1000
+  *
+  * Reference: https://en.wikipedia.org/wiki/Exponential_backoff
+  *
+  */
 trait TryBackoff extends Logging {
   val baseWaitMillis = 100
-  val maxAttempts = 75
+  val totalWaitMillis = 30 * 60 * 1000  // half an hour
+
+  // This value is cached to save us repeating the calculation.
+  private val maxAttempts = maximumAttemptsToTry()
+
   private var maybeCancellable: Option[Cancellable] = None
 
   def run(f: (() => Unit), system: ActorSystem, attempt: Int = 0): Unit = {
@@ -24,16 +55,14 @@ trait TryBackoff extends Logging {
         attempt + 1
     }
 
-    if (numberOfAttempts > maxAttempts)
+    if (numberOfAttempts > maxAttempts) {
       throw new RuntimeException("Max retry attempts exceeded")
+    }
 
-    val waitTime =
-      //if there are failures, we want to retry increasing the amount of time we wait each time
-      if (attempt > 0) increaseWaitTimeExponentially(attempt)
-      else baseWaitMillis
+    val waitTime = timeToWaitOnAttempt(attempt)
 
     val cancellable = system.scheduler.scheduleOnce(waitTime milliseconds)(
-      run(f, system, numberOfAttempts))
+      run(f, system, attempt = numberOfAttempts))
     maybeCancellable = Some(cancellable)
   }
 
@@ -41,8 +70,34 @@ trait TryBackoff extends Logging {
     maybeCancellable.fold(())(cancellable => cancellable.cancel())
   }
 
-  private def increaseWaitTimeExponentially(attempt: Int) = {
+  /** Returns the maximum number of attempts we should try.
+    *
+    * In general, the exact number of attempts is less important than how
+    * long we should wait before writing the operation off as failed.  We need
+    * to know how many attempts to try for internal bookkeeping, but the
+    * calculation is abstracted away from the caller.
+    */
+  private def maximumAttemptsToTry() {
+    var totalMillis: Long = 0
+    var attempt = 0
+    while true {
+      totalMillis += timeToWaitOnAttempt(attempt)
+      if totalMillis > totalWaitMillis {
+        return attempt
+      } else {
+        attempt += 1
+      }
+    }
+  }
+
+  /** Returns the time to wait after the nth failure.
+    *
+    * @param attempt which attempt has just failed (zero-indexed)
+    */
+  private def timeToWaitOnAttempt(attempt: Int) {
+    // This choice of exponent is somewhat arbitrary.  All we require is
+    // that later attempts wait longer than earlier attempts.
     val exponent = attempt / (baseWaitMillis / 4)
-    pow(baseWaitMillis, exponent).toLong
+    pow(baseWaitMillis, 1 + exponent).toLong
   }
 }

--- a/common/src/main/scala/uk/ac/wellcome/utils/TryBackoff.scala
+++ b/common/src/main/scala/uk/ac/wellcome/utils/TryBackoff.scala
@@ -42,9 +42,9 @@ import scala.util.{Failure, Success, Try}
   *
   */
 trait TryBackoff extends Logging {
-  val baseWait = 100 millis
-  val totalWait = 30 minutes
-  val continuous = true
+  lazy val continuous = true
+  lazy val baseWait = 100 millis
+  lazy val totalWait = 12 seconds
 
   // This value is cached to save us repeating the calculation.
   private val maxAttempts = maximumAttemptsToTry()

--- a/common/src/main/scala/uk/ac/wellcome/utils/TryBackoff.scala
+++ b/common/src/main/scala/uk/ac/wellcome/utils/TryBackoff.scala
@@ -62,21 +62,17 @@ trait TryBackoff extends Logging {
         attempt + 1
     }
 
-    // If we're in non-continuous mode and the last attempt succeeded,
-    // we should return immediately.
-    if (numberOfAttempts == 0 && !continuous) {
-      return
-    }
-
     if (numberOfAttempts > maxAttempts) {
       throw new RuntimeException("Max retry attempts exceeded")
     }
 
     val waitTime = timeToWaitOnAttempt(attempt)
 
-    val cancellable = system.scheduler.scheduleOnce(waitTime milliseconds)(
-      run(f, system, attempt = numberOfAttempts))
-    maybeCancellable = Some(cancellable)
+    if (numberOfAttempts == 0 || continuous) {
+      val cancellable = system.scheduler.scheduleOnce(waitTime milliseconds)(
+        run(f, system, attempt = numberOfAttempts))
+      maybeCancellable = Some(cancellable)
+    }
   }
 
   def cancelRun(): Unit = {

--- a/common/src/main/scala/uk/ac/wellcome/utils/TryBackoff.scala
+++ b/common/src/main/scala/uk/ac/wellcome/utils/TryBackoff.scala
@@ -106,7 +106,7 @@ trait TryBackoff extends Logging {
   private def timeToWaitOnAttempt(attempt: Int): Long = {
     // This choice of exponent is somewhat arbitrary.  All we require is
     // that later attempts wait longer than earlier attempts.
-    val exponent = attempt / (baseWait.toMillis / 4)
+    val exponent = attempt.toFloat / (baseWait.toMillis / 4)
     pow(baseWait.toMillis, 1 + exponent).toLong
   }
 }

--- a/common/src/main/scala/uk/ac/wellcome/utils/TryBackoff.scala
+++ b/common/src/main/scala/uk/ac/wellcome/utils/TryBackoff.scala
@@ -22,10 +22,8 @@ import scala.util.control.Breaks.break
   *
   * How quickly we back off is controlled by two attributes:
   *
-  *     @param baseWaitMillis  how many milliseconds should we wait after
-  *                            the first failure
-  *     @param totalWaitMillis how many milliseconds should we wait before
-  *                            giving up on the operation
+  *     @param baseWait   how long should we wait after the first failure
+  *     @param totalWait  how long should we wait before giving up
   *
   * Additionally, the operation can run again after it succeeds (reverting
   * to the base wait time), or give up after the first success.  This is
@@ -37,15 +35,15 @@ import scala.util.control.Breaks.break
   * For example, to wait 1 second after the first failure and give up after
   * five minutes, we would set
   *
-  *     baseWaitMillis = 1000
-  *     totalWaitMillis = 5 * 60 * 1000
+  *     baseWait = 1 second
+  *     totalWait = 5 minutes
   *
   * Reference: https://en.wikipedia.org/wiki/Exponential_backoff
   *
   */
 trait TryBackoff extends Logging {
-  val baseWaitMillis = 100
-  val totalWaitMillis = 30 * 60 * 1000 // half an hour
+  val baseWait = 100 millis
+  val totalWait = 30 minutes
   val continuous = true
 
   // This value is cached to save us repeating the calculation.
@@ -97,7 +95,7 @@ trait TryBackoff extends Logging {
     var attempt = 0
     while (true) {
       totalMillis = totalMillis + timeToWaitOnAttempt(attempt)
-      if (totalMillis > totalWaitMillis) {
+      if (totalMillis > totalWait.toMillis) {
         break
       } else {
         attempt += 1
@@ -113,7 +111,7 @@ trait TryBackoff extends Logging {
   private def timeToWaitOnAttempt(attempt: Int): Long = {
     // This choice of exponent is somewhat arbitrary.  All we require is
     // that later attempts wait longer than earlier attempts.
-    val exponent = attempt / (baseWaitMillis / 4)
-    pow(baseWaitMillis, 1 + exponent).toLong
+    val exponent = attempt / (baseWait.toMillis / 4)
+    pow(baseWait.toMillis, 1 + exponent).toLong
   }
 }

--- a/common/src/test/scala/uk/ac/wellcome/utils/TryBackoffTest.scala
+++ b/common/src/test/scala/uk/ac/wellcome/utils/TryBackoffTest.scala
@@ -32,10 +32,6 @@ class TryBackoffTest
   }
 
   it("should always call a function that succeeds") {
-    def alwaysSucceeds(): Unit = {
-      calls = 0 :: calls
-    }
-
     tryBackoff.run(alwaysSucceeds, system)
     eventually {
       calls shouldBe List(0)
@@ -43,15 +39,6 @@ class TryBackoffTest
   }
 
   it("should recall a function after it fails on the first attempt") {
-    def succeedsOnThirdAttempt(): Unit = {
-      if (calls.length < 2) {
-        calls = 0 :: calls
-        throw new Exception("Not ready yet")
-      } else {
-        calls = 1 :: calls
-      }
-    }
-
     tryBackoff.run(succeedsOnThirdAttempt, system)
     eventually {
       calls.length should be > 1
@@ -59,11 +46,6 @@ class TryBackoffTest
   }
 
   it("should eventually give up on a function that always fails") {
-    def alwaysFails(): Unit = {
-      calls = 0 :: calls
-      throw new Exception("I will always fail")
-    }
-
     tryBackoff.run(alwaysFails, system)
 
     Thread.sleep(10000)
@@ -73,10 +55,6 @@ class TryBackoffTest
   }
 
   it("should stop after the first success if continuous is false") {
-    def alwaysSucceeds(): Unit = {
-      calls = 0 :: calls
-    }
-
     discontinuousTryBackoff.run(alwaysSucceeds, system)
     eventually {
       calls.length shouldBe 1
@@ -86,15 +64,6 @@ class TryBackoffTest
   }
 
   it("should recall a failing function function if continuous is false") {
-    def succeedsOnThirdAttempt(): Unit = {
-      if (calls.length < 2) {
-        calls = 0 :: calls
-        throw new Exception("Not ready yet")
-      } else {
-        calls = 1 :: calls
-      }
-    }
-
     discontinuousTryBackoff.run(succeedsOnThirdAttempt, system)
 
     Thread.sleep(2000)
@@ -102,19 +71,13 @@ class TryBackoffTest
   }
 
   it("should wait progressively longer between failed attempts") {
-    def alwaysFails(): Unit = {
-      calls = System.currentTimeMillis().toInt :: calls
-      throw new Exception("Failure is inevitable")
-    }
-
-    system.scheduler.scheduleOnce(5 milliseconds)(println("hello world"))
-    Thread.sleep(25)
-
     tryBackoff.run(alwaysFails, system)
     Thread.sleep(10000)
-    calls = calls.reverse
 
-    val differences = calls.sliding(2).toList.map(ts => ts(1) - ts(0))
+    val differences = calls.reverse
+      .sliding(2)
+      .toList
+      .map(ts => ts(1) - ts(0))
 
     // When we run this test in isolation in IntelliJ, there's a warmup
     // penalty -- the second invocation takes an unusually long time to run.
@@ -127,5 +90,25 @@ class TryBackoffTest
     // For now, we just drop the first difference -- the patttern is more
     // important than an individual element.
     differences.tail shouldBe sorted
+  }
+
+  // Methods passed to the TryBackoff.
+
+  def alwaysSucceeds(): Unit = {
+    calls = 0 :: calls
+  }
+
+  def alwaysFails(): Unit = {
+    calls = System.currentTimeMillis().toInt :: calls
+    throw new Exception("I will always fail")
+  }
+
+  def succeedsOnThirdAttempt(): Unit = {
+    if (calls.length < 2) {
+      calls = 0 :: calls
+      throw new Exception("Not ready yet")
+    } else {
+      calls = 1 :: calls
+    }
   }
 }

--- a/common/src/test/scala/uk/ac/wellcome/utils/TryBackoffTest.scala
+++ b/common/src/test/scala/uk/ac/wellcome/utils/TryBackoffTest.scala
@@ -85,6 +85,22 @@ class TryBackoffTest
     calls.length shouldBe 1
   }
 
+  it("should recall a failing function function if continuous is false") {
+    def succeedsOnThirdAttempt(): Unit = {
+      if (calls.length < 2) {
+        calls = 0 :: calls
+        throw new Exception("Not ready yet")
+      } else {
+        calls = 1 :: calls
+      }
+    }
+
+    discontinuousTryBackoff.run(succeedsOnThirdAttempt, system)
+
+    Thread.sleep(2000)
+    calls.length shouldBe 3
+  }
+
   it("should wait progressively longer between failed attempts") {
     def alwaysFails(): Unit = {
       calls = System.currentTimeMillis().toInt :: calls

--- a/common/src/test/scala/uk/ac/wellcome/utils/TryBackoffTest.scala
+++ b/common/src/test/scala/uk/ac/wellcome/utils/TryBackoffTest.scala
@@ -1,0 +1,68 @@
+package uk.ac.wellcome.utils
+
+import akka.actor.ActorSystem
+import org.scalatest.concurrent.{Eventually, IntegrationPatience}
+import org.scalatest.{BeforeAndAfterEach, FunSpec, Matchers}
+import scala.concurrent.duration._
+import uk.ac.wellcome.utils.TryBackoff
+
+class TryBackoffTest
+    extends FunSpec
+    with BeforeAndAfterEach
+    with Eventually
+    with IntegrationPatience
+    with Matchers {
+  val system = ActorSystem.create("TestActorSystem")
+
+  var calls = List[Int]()
+
+  val tryBackoff = new TryBackoff {
+    override lazy val totalWait = 6 seconds
+  }
+
+  override def afterEach(): Unit = {
+    calls = List()
+    tryBackoff.cancelRun()
+  }
+
+  it("should always call a function that succeeds") {
+    def alwaysSucceeds(): Unit = {
+      calls = 0 :: calls
+    }
+
+    tryBackoff.run(alwaysSucceeds, system)
+    eventually {
+      calls shouldBe List(0)
+    }
+  }
+
+  it("should recall a function after it fails on the first attempt") {
+    def succeedsOnThirdAttempt(): Unit = {
+      if (calls.length < 2) {
+        calls = 0 :: calls
+        throw new Exception("Not ready yet")
+      } else {
+        calls = 1 :: calls
+      }
+    }
+
+    tryBackoff.run(succeedsOnThirdAttempt, system)
+    eventually {
+      calls.length should be > 1
+    }
+  }
+
+  it("should eventually give up on a function that always fails") {
+    def alwaysFails(): Unit = {
+      calls = 0 :: calls
+      throw new Exception("I will always fail")
+    }
+
+    tryBackoff.run(alwaysFails, system)
+
+    Thread.sleep(10000)
+    val finalLength = calls.length
+    Thread.sleep(5000)
+    calls.length shouldBe finalLength
+  }
+}

--- a/common/src/test/scala/uk/ac/wellcome/utils/TryBackoffTest.scala
+++ b/common/src/test/scala/uk/ac/wellcome/utils/TryBackoffTest.scala
@@ -4,6 +4,7 @@ import akka.actor.ActorSystem
 import org.scalatest.concurrent.{Eventually, IntegrationPatience}
 import org.scalatest.{BeforeAndAfterEach, FunSpec, Matchers}
 import scala.concurrent.duration._
+import uk.ac.wellcome.utils.GlobalExecutionContext.context
 import uk.ac.wellcome.utils.TryBackoff
 
 class TryBackoffTest
@@ -82,5 +83,33 @@ class TryBackoffTest
     }
     Thread.sleep(1000)
     calls.length shouldBe 1
+  }
+
+  it("should wait progressively longer between failed attempts") {
+    def alwaysFails(): Unit = {
+      calls = System.currentTimeMillis().toInt :: calls
+      throw new Exception("Failure is inevitable")
+    }
+
+    system.scheduler.scheduleOnce(5 milliseconds)(println("hello world"))
+    Thread.sleep(25)
+
+    tryBackoff.run(alwaysFails, system)
+    Thread.sleep(10000)
+    calls = calls.reverse
+
+    val differences = calls.sliding(2).toList.map(ts => ts(1) - ts(0))
+
+    // When we run this test in isolation in IntelliJ, there's a warmup
+    // penalty -- the second invocation takes an unusually long time to run.
+    // We see differences of the form:
+    //
+    //     244, 112, 144, 158, ...
+    //
+    // We don't see the warmup penalty if we run the whole suite.
+    //
+    // For now, we just drop the first difference -- the patttern is more
+    // important than an individual element.
+    differences.tail shouldBe sorted
   }
 }


### PR DESCRIPTION
### What is this PR trying to achieve?

* Ensure that TryBackoff really does increase wait times between attempts
* Make it easier to change the outward behaviour (time to wait after first failure, total time to wait) without having to do any sums
* Add a `continuous` parameter so the TryBackoff can be stopped after the first success if necessary
* Log an error from the function wrapped by TryBackoff

### Who is this change for?

Devs who work with the TryBackoff code.

### Have the following been considered/are they needed?

- [ ] Deployed new versions