### PR TITLE
Adds continuous param to TryBackoff so that we can stop after success

### DIFF
--- a/reindexer/src/main/scala/uk/ac/wellcome/platform/reindexer/modules/ReindexModule.scala
+++ b/reindexer/src/main/scala/uk/ac/wellcome/platform/reindexer/modules/ReindexModule.scala
@@ -14,7 +14,6 @@ import uk.ac.wellcome.platform.reindexer.services._
 import uk.ac.wellcome.utils.GlobalExecutionContext.context
 import uk.ac.wellcome.utils.TryBackoff
 
-import scala.concurrent.duration._
 import scala.util.{Failure, Success}
 
 object ReindexModule extends TwitterModule with TryBackoff {


### PR DESCRIPTION
### What is this PR trying to achieve?

Prevents winning _too much_

### Who is this change for?

Devs who want to use `TryBackoff` without repeating the operation on success.

### Have the following been considered/are they needed?

- [ ] Deployed new versions
