### PR TITLE
Ensures reindexer doesn't retry when successful

### DIFF
--- a/common/src/main/scala/uk/ac/wellcome/utils/DynamoUtils.scala
+++ b/common/src/main/scala/uk/ac/wellcome/utils/DynamoUtils.scala
@@ -34,4 +34,3 @@ trait DynamoUpdateWriteCapacityCapable {
     table.updateTable(newThroughput)
   }
 }
-

--- a/common/src/main/scala/uk/ac/wellcome/utils/TryBackoff.scala
+++ b/common/src/main/scala/uk/ac/wellcome/utils/TryBackoff.scala
@@ -44,7 +44,7 @@ import scala.util.{Failure, Success, Try}
 trait TryBackoff extends Logging {
   def baseWait = 100 millis
   def totalWait = 12 seconds
-  def continuous = true
+  val continuous = true
 
   // This value is cached to save us repeating the calculation.
   private val maxAttempts = maximumAttemptsToTry()

--- a/common/src/main/scala/uk/ac/wellcome/utils/TryBackoff.scala
+++ b/common/src/main/scala/uk/ac/wellcome/utils/TryBackoff.scala
@@ -5,42 +5,43 @@ import com.twitter.inject.Logging
 import uk.ac.wellcome.utils.GlobalExecutionContext.context
 
 import scala.annotation.tailrec
+import scala.concurrent.Future
 import scala.concurrent.duration._
 import scala.math.pow
 import scala.util.{Failure, Success, Try}
 
 /** This trait implements an exponential backoff algorithm.  This is useful
- *  for wrapping an operation that is known to be flakey/unreliable.
- *
- *  If the operation fails, we try again, but we wait an increasing amount
- *  of time between failed attempts.  This means we don't:
- *
- *    - Overwhelm an underlying service which might be overwhelmed -- and
- *      thus make the problem worse
- *    - Waste our own resources trying to repeat an operation that is likely
- *      to fail
- *
- *  How quickly we back off is controlled by two attributes:
- *
- *      @param baseWait   how long should we wait after the first failure
- *      @param totalWait  how long should we wait before giving up
- *
- *  Additionally, the operation can run again after it succeeds (reverting
- *  to the base wait time), or give up after the first success.  This is
- *  controlled by a third attribute:
- *
- *      @param continuous      true if the operation should repeat, false
- *                             if it should return after the first success
- *
- *  For example, to wait 1 second after the first failure and give up after
- *  five minutes, we would set
- *
- *      baseWait = 1 second
- *      totalWait = 5 minutes
- *
- *  Reference: https://en.wikipedia.org/wiki/Exponential_backoff
- *
- */
+  *  for wrapping an operation that is known to be flakey/unreliable.
+  *
+  *  If the operation fails, we try again, but we wait an increasing amount
+  *  of time between failed attempts.  This means we don't:
+  *
+  *    - Overwhelm an underlying service which might be overwhelmed -- and
+  *      thus make the problem worse
+  *    - Waste our own resources trying to repeat an operation that is likely
+  *      to fail
+  *
+  *  How quickly we back off is controlled by two attributes:
+  *
+  *      @param baseWait   how long should we wait after the first failure
+  *      @param totalWait  how long should we wait before giving up
+  *
+  *  Additionally, the operation can run again after it succeeds (reverting
+  *  to the base wait time), or give up after the first success.  This is
+  *  controlled by a third attribute:
+  *
+  *      @param continuous      true if the operation should repeat, false
+  *                             if it should return after the first success
+  *
+  *  For example, to wait 1 second after the first failure and give up after
+  *  five minutes, we would set
+  *
+  *      baseWait = 1 second
+  *      totalWait = 5 minutes
+  *
+  *  Reference: https://en.wikipedia.org/wiki/Exponential_backoff
+  *
+  */
 trait TryBackoff extends Logging {
   def baseWait = 100 millis
   def totalWait = 12 seconds
@@ -51,30 +52,34 @@ trait TryBackoff extends Logging {
 
   private var maybeCancellable: Option[Cancellable] = None
 
-  def run(f: (() => Unit), system: ActorSystem, attempt: Int = 0): Unit = {
+  def run(f: (() => Future[Unit]),
+          system: ActorSystem,
+          attempt: Int = 0): Unit = {
 
-    val attempted = Try { f() } match {
-      case Success(_) => Right()
-      case Failure(e) =>
-        error(s"Failed to run (attempt: $attempt)", e)
-        Left(e)
-    }
+    Future.successful(()).flatMap(_ => f()).onComplete { triedUnit =>
+      val attempted = triedUnit match {
+        case Success(_) => Right()
+        case Failure(e) =>
+          error(s"Failed to run (attempt: $attempt)", e)
+          Left(e)
+      }
 
-    val numberOfAttempts = attempted.fold(
-      left => attempt + 1,
-      right => 0
-    )
+      val numberOfAttempts = attempted.fold(
+        left => attempt + 1,
+        right => 0
+      )
 
-    if (numberOfAttempts > maxAttempts) {
-      throw new RuntimeException("Max retry attempts exceeded")
-    }
+      if (numberOfAttempts > maxAttempts) {
+        throw new RuntimeException("Max retry attempts exceeded")
+      }
 
-    val waitTime = timeToWaitOnAttempt(attempt)
+      val waitTime = timeToWaitOnAttempt(attempt)
 
-    if (continuous || attempted.isLeft) {
-      val cancellable = system.scheduler.scheduleOnce(waitTime milliseconds)(
-        run(f, system, attempt = numberOfAttempts))
-      maybeCancellable = Some(cancellable)
+      if (continuous || attempted.isLeft) {
+        val cancellable = system.scheduler.scheduleOnce(waitTime milliseconds)(
+          run(f, system, attempt = numberOfAttempts))
+        maybeCancellable = Some(cancellable)
+      }
     }
   }
 
@@ -83,12 +88,12 @@ trait TryBackoff extends Logging {
   }
 
   /** Returns the maximum number of attempts we should try.
-   *
-   *  In general, the exact number of attempts is less important than how
-   *  long we should wait before writing the operation off as failed.  We need
-   *  to know how many attempts to try for internal bookkeeping, but the
-   *  calculation is abstracted away from the caller.
-   */
+    *
+    *  In general, the exact number of attempts is less important than how
+    *  long we should wait before writing the operation off as failed.  We need
+    *  to know how many attempts to try for internal bookkeeping, but the
+    *  calculation is abstracted away from the caller.
+    */
   private def maximumAttemptsToTry(): Int = {
     @tailrec
     def go(attempt: Int, totalMillis: Long): Int = {
@@ -100,9 +105,9 @@ trait TryBackoff extends Logging {
   }
 
   /** Returns the time to wait after the nth failure.
-   *
-   *  @param attempt which attempt has just failed (zero-indexed)
-   */
+    *
+    *  @param attempt which attempt has just failed (zero-indexed)
+    */
   private def timeToWaitOnAttempt(attempt: Int): Long = {
     // This choice of exponent is somewhat arbitrary.  All we require is
     // that later attempts wait longer than earlier attempts.

--- a/common/src/main/scala/uk/ac/wellcome/utils/TryBackoff.scala
+++ b/common/src/main/scala/uk/ac/wellcome/utils/TryBackoff.scala
@@ -4,45 +4,109 @@ import akka.actor.{ActorSystem, Cancellable}
 import com.twitter.inject.Logging
 import uk.ac.wellcome.utils.GlobalExecutionContext.context
 
+import scala.annotation.tailrec
 import scala.concurrent.duration._
 import scala.math.pow
 import scala.util.{Failure, Success, Try}
 
+/** This trait implements an exponential backoff algorithm.  This is useful
+ *  for wrapping an operation that is known to be flakey/unreliable.
+ *
+ *  If the operation fails, we try again, but we wait an increasing amount
+ *  of time between failed attempts.  This means we don't:
+ *
+ *    - Overwhelm an underlying service which might be overwhelmed -- and
+ *      thus make the problem worse
+ *    - Waste our own resources trying to repeat an operation that is likely
+ *      to fail
+ *
+ *  How quickly we back off is controlled by two attributes:
+ *
+ *      @param baseWait   how long should we wait after the first failure
+ *      @param totalWait  how long should we wait before giving up
+ *
+ *  Additionally, the operation can run again after it succeeds (reverting
+ *  to the base wait time), or give up after the first success.  This is
+ *  controlled by a third attribute:
+ *
+ *      @param continuous      true if the operation should repeat, false
+ *                             if it should return after the first success
+ *
+ *  For example, to wait 1 second after the first failure and give up after
+ *  five minutes, we would set
+ *
+ *      baseWait = 1 second
+ *      totalWait = 5 minutes
+ *
+ *  Reference: https://en.wikipedia.org/wiki/Exponential_backoff
+ *
+ */
 trait TryBackoff extends Logging {
-  val baseWaitMillis = 100
-  val maxAttempts = 75
+  def baseWait = 100 millis
+  def totalWait = 12 seconds
+  def continuous = true
+
+  // This value is cached to save us repeating the calculation.
+  private val maxAttempts = maximumAttemptsToTry()
+
   private var maybeCancellable: Option[Cancellable] = None
 
   def run(f: (() => Unit), system: ActorSystem, attempt: Int = 0): Unit = {
 
-    val numberOfAttempts = Try {
-      f()
-    } match {
-      case Success(_) => 0
-      case Failure(_) =>
-        error(s"Failed to run (attempt: $attempt)")
-        attempt + 1
+    val attempted = Try { f() } match {
+      case Success(_) => Right()
+      case Failure(e) =>
+        error(s"Failed to run (attempt: $attempt)", e)
+        Left(e)
     }
 
-    if (numberOfAttempts > maxAttempts)
+    val numberOfAttempts = attempted.fold(
+      left => attempt + 1,
+      right => 0
+    )
+
+    if (numberOfAttempts > maxAttempts) {
       throw new RuntimeException("Max retry attempts exceeded")
+    }
 
-    val waitTime =
-      //if there are failures, we want to retry increasing the amount of time we wait each time
-      if (attempt > 0) increaseWaitTimeExponentially(attempt)
-      else baseWaitMillis
+    val waitTime = timeToWaitOnAttempt(attempt)
 
-    val cancellable = system.scheduler.scheduleOnce(waitTime milliseconds)(
-      run(f, system, numberOfAttempts))
-    maybeCancellable = Some(cancellable)
+    if (continuous || attempted.isLeft) {
+      val cancellable = system.scheduler.scheduleOnce(waitTime milliseconds)(
+        run(f, system, attempt = numberOfAttempts))
+      maybeCancellable = Some(cancellable)
+    }
   }
 
   def cancelRun(): Unit = {
     maybeCancellable.fold(())(cancellable => cancellable.cancel())
   }
 
-  private def increaseWaitTimeExponentially(attempt: Int) = {
-    val exponent = attempt / (baseWaitMillis / 4)
-    pow(baseWaitMillis, exponent).toLong
+  /** Returns the maximum number of attempts we should try.
+   *
+   *  In general, the exact number of attempts is less important than how
+   *  long we should wait before writing the operation off as failed.  We need
+   *  to know how many attempts to try for internal bookkeeping, but the
+   *  calculation is abstracted away from the caller.
+   */
+  private def maximumAttemptsToTry(): Int = {
+    @tailrec
+    def go(attempt: Int, totalMillis: Long): Int = {
+      val newTotalMillis = totalMillis + timeToWaitOnAttempt(attempt)
+      if (newTotalMillis > totalWait.toMillis) attempt
+      else go(attempt + 1, newTotalMillis)
+    }
+    go(attempt = 0, totalMillis = 0)
+  }
+
+  /** Returns the time to wait after the nth failure.
+   *
+   *  @param attempt which attempt has just failed (zero-indexed)
+   */
+  private def timeToWaitOnAttempt(attempt: Int): Long = {
+    // This choice of exponent is somewhat arbitrary.  All we require is
+    // that later attempts wait longer than earlier attempts.
+    val exponent = attempt.toFloat / (baseWait.toMillis / 4)
+    pow(baseWait.toMillis, 1 + exponent).toLong
   }
 }

--- a/common/src/main/scala/uk/ac/wellcome/utils/TryBackoff.scala
+++ b/common/src/main/scala/uk/ac/wellcome/utils/TryBackoff.scala
@@ -54,9 +54,9 @@ trait TryBackoff extends Logging {
 
   def run(f: (() => Future[Unit]), system: ActorSystem, attempt: Int = 0): Unit = {
 
-    Future.successful(()).flatMap(_ => f()).onComplete { tryied =>
-      val attempted = tryied match {
-        case Success(_) => Right()
+    Future.successful(()).flatMap(_ => f()).onComplete { tried =>
+      val attempted = tried match {
+        case Success(_) => Right((): Unit)
         case Failure(e) =>
           error(s"Failed to run (attempt: $attempt)", e)
           Left(e)

--- a/common/src/main/scala/uk/ac/wellcome/utils/TryBackoff.scala
+++ b/common/src/main/scala/uk/ac/wellcome/utils/TryBackoff.scala
@@ -54,8 +54,7 @@ trait TryBackoff extends Logging {
 
   def run(f: (() => Future[Unit]), system: ActorSystem, attempt: Int = 0): Unit = {
 
-    val eventualUnit = Future.successful(()).flatMap(_ => f())
-    eventualUnit.onComplete { tryied =>
+    Future.successful(()).flatMap(_ => f()).onComplete { tryied =>
       val attempted = tryied match {
         case Success(_) => Right()
         case Failure(e) =>

--- a/common/src/main/scala/uk/ac/wellcome/utils/TryBackoff.scala
+++ b/common/src/main/scala/uk/ac/wellcome/utils/TryBackoff.scala
@@ -45,7 +45,7 @@ import scala.util.{Failure, Success, Try}
 trait TryBackoff extends Logging {
   def baseWait = 100 millis
   def totalWait = 12 seconds
-  val continuous = true
+  def continuous = true
 
   // This value is cached to save us repeating the calculation.
   private val maxAttempts = maximumAttemptsToTry()

--- a/common/src/test/scala/uk/ac/wellcome/utils/TryBackoffTest.scala
+++ b/common/src/test/scala/uk/ac/wellcome/utils/TryBackoffTest.scala
@@ -1,0 +1,111 @@
+package uk.ac.wellcome.utils
+
+import akka.actor.ActorSystem
+import org.scalatest.concurrent.{Eventually, IntegrationPatience}
+import org.scalatest.{BeforeAndAfterEach, FunSpec, Matchers}
+import scala.concurrent.duration._
+import uk.ac.wellcome.utils.GlobalExecutionContext.context
+import uk.ac.wellcome.utils.TryBackoff
+
+
+class TryBackoffTest extends FunSpec with BeforeAndAfterEach with Eventually with IntegrationPatience with Matchers {
+  val system = ActorSystem.create("TestActorSystem")
+
+  var calls = List[Int]()
+
+  val tryBackoff = new TryBackoff {
+    override def totalWait = 6 seconds
+  }
+
+  val discontinuousTryBackoff = new TryBackoff {
+    override def continuous = false
+  }
+
+  override def afterEach(): Unit = {
+    calls = List()
+    tryBackoff.cancelRun()
+    discontinuousTryBackoff.cancelRun()
+  }
+
+  it("should always call a function that succeeds") {
+    def alwaysSucceeds(): Unit = {
+      calls = 0 :: calls
+    }
+
+    tryBackoff.run(alwaysSucceeds, system)
+    eventually {
+      calls shouldBe List(0)
+    }
+  }
+
+  it("should recall a function after it fails on the first attempt") {
+    def succeedsOnThirdAttempt(): Unit = {
+      if (calls.length < 2) {
+        calls = 0 :: calls
+        throw new Exception("Not ready yet")
+      } else {
+        calls = 1 :: calls
+      }
+    }
+
+    tryBackoff.run(succeedsOnThirdAttempt, system)
+    eventually {
+      calls.length should be > 1
+    }
+  }
+
+  it("should eventually give up on a function that always fails") {
+    def alwaysFails(): Unit = {
+      calls = 0 :: calls
+      throw new Exception("I will always fail")
+    }
+
+    tryBackoff.run(alwaysFails, system)
+
+    Thread.sleep(10000)
+    val finalLength = calls.length
+    Thread.sleep(5000)
+    calls.length shouldBe finalLength
+  }
+
+  it("should stop after the first success if continuous is false") {
+    def alwaysSucceeds(): Unit = {
+      calls = 0 :: calls
+    }
+
+    discontinuousTryBackoff.run(alwaysSucceeds, system)
+    eventually {
+      calls.length shouldBe 1
+    }
+    Thread.sleep(1000)
+    calls.length shouldBe 1
+  }
+
+  it("should wait progressively longer between failed attempts") {
+    def alwaysFails(): Unit = {
+      calls = System.currentTimeMillis().toInt :: calls
+      throw new Exception("Failure is inevitable")
+    }
+
+    system.scheduler.scheduleOnce(5 milliseconds)(println("hello world"))
+    Thread.sleep(25)
+
+    tryBackoff.run(alwaysFails, system)
+    Thread.sleep(10000)
+    calls = calls.reverse
+
+    val differences = calls.sliding(2).toList.map(ts => ts(1) - ts(0))
+
+    // When we run this test in isolation in IntelliJ, there's a warmup
+    // penalty -- the second invocation takes an unusually long time to run.
+    // We see differences of the form:
+    //
+    //     244, 112, 144, 158, ...
+    //
+    // We don't see the warmup penalty if we run the whole suite.
+    //
+    // For now, we just drop the first difference -- the patttern is more
+    // important than an individual element.
+    differences.tail shouldBe sorted
+  }
+}

--- a/common/src/test/scala/uk/ac/wellcome/utils/TryBackoffTest.scala
+++ b/common/src/test/scala/uk/ac/wellcome/utils/TryBackoffTest.scala
@@ -3,13 +3,9 @@ package uk.ac.wellcome.utils
 import akka.actor.ActorSystem
 import org.scalatest.concurrent.{Eventually, IntegrationPatience}
 import org.scalatest.{BeforeAndAfterEach, FunSpec, Matchers}
-import uk.ac.wellcome.utils.GlobalExecutionContext.context
 
 import scala.concurrent.Future
 import scala.concurrent.duration._
-import scala.concurrent.duration._
-import uk.ac.wellcome.utils.GlobalExecutionContext.context
-import uk.ac.wellcome.utils.TryBackoff
 
 
 class TryBackoffTest extends FunSpec with BeforeAndAfterEach with Eventually with IntegrationPatience with Matchers {

--- a/common/src/test/scala/uk/ac/wellcome/utils/TryBackoffTest.scala
+++ b/common/src/test/scala/uk/ac/wellcome/utils/TryBackoffTest.scala
@@ -81,6 +81,22 @@ class TryBackoffTest extends FunSpec with BeforeAndAfterEach with Eventually wit
     calls.length shouldBe 1
   }
 
+  it("should recall a failing function function if continuous is false") {
+    def succeedsOnThirdAttempt(): Unit = {
+      if (calls.length < 2) {
+        calls = 0 :: calls
+        throw new Exception("Not ready yet")
+      } else {
+        calls = 1 :: calls
+      }
+    }
+
+    discontinuousTryBackoff.run(succeedsOnThirdAttempt, system)
+
+    Thread.sleep(2000)
+    calls.length shouldBe 3
+  }
+
   it("should wait progressively longer between failed attempts") {
     def alwaysFails(): Unit = {
       calls = System.currentTimeMillis().toInt :: calls

--- a/common/src/test/scala/uk/ac/wellcome/utils/TryBackoffTest.scala
+++ b/common/src/test/scala/uk/ac/wellcome/utils/TryBackoffTest.scala
@@ -3,9 +3,9 @@ package uk.ac.wellcome.utils
 import akka.actor.ActorSystem
 import org.scalatest.concurrent.{Eventually, IntegrationPatience}
 import org.scalatest.{BeforeAndAfterEach, FunSpec, Matchers}
-import scala.concurrent.duration._
 import uk.ac.wellcome.utils.GlobalExecutionContext.context
-import uk.ac.wellcome.utils.TryBackoff
+
+import scala.concurrent.duration._
 
 
 class TryBackoffTest extends FunSpec with BeforeAndAfterEach with Eventually with IntegrationPatience with Matchers {
@@ -18,7 +18,7 @@ class TryBackoffTest extends FunSpec with BeforeAndAfterEach with Eventually wit
   }
 
   val discontinuousTryBackoff = new TryBackoff {
-    override def continuous = false
+    override val continuous = false
   }
 
   override def afterEach(): Unit = {

--- a/common/src/test/scala/uk/ac/wellcome/utils/TryBackoffTest.scala
+++ b/common/src/test/scala/uk/ac/wellcome/utils/TryBackoffTest.scala
@@ -3,9 +3,8 @@ package uk.ac.wellcome.utils
 import akka.actor.ActorSystem
 import org.scalatest.concurrent.{Eventually, IntegrationPatience}
 import org.scalatest.{BeforeAndAfterEach, FunSpec, Matchers}
+import scala.concurrent.Future
 import scala.concurrent.duration._
-import uk.ac.wellcome.utils.GlobalExecutionContext.context
-import uk.ac.wellcome.utils.TryBackoff
 
 class TryBackoffTest
     extends FunSpec
@@ -14,17 +13,12 @@ class TryBackoffTest
     with IntegrationPatience
     with Matchers {
 
-import scala.concurrent.Future
-import scala.concurrent.duration._
+  val system: ActorSystem = ActorSystem.create("TestActorSystem")
 
-
-class TryBackoffTest extends FunSpec with BeforeAndAfterEach with Eventually with IntegrationPatience with Matchers {
-  val system = ActorSystem.create("TestActorSystem")
-
-  var calls = List[Int]()
+  var calls: List[Int] = List[Int]()
 
   val tryBackoff = new TryBackoff {
-    override lazy val totalWait = 6 seconds
+    override lazy val totalWait: Duration = 6 seconds
   }
 
   val discontinuousTryBackoff = new TryBackoff {
@@ -83,7 +77,7 @@ class TryBackoffTest extends FunSpec with BeforeAndAfterEach with Eventually wit
     val differences = calls.reverse
       .sliding(2)
       .toList
-      .map(ts => ts(1) - ts(0))
+      .map(ts => ts(1) - ts.head)
 
     // When we run this test in isolation in IntelliJ, there's a warmup
     // penalty -- the second invocation takes an unusually long time to run.

--- a/id_minter/src/main/scala/uk/ac/wellcome/platform/idminter/modules/IdMinterModule.scala
+++ b/id_minter/src/main/scala/uk/ac/wellcome/platform/idminter/modules/IdMinterModule.scala
@@ -3,14 +3,13 @@ package uk.ac.wellcome.platform.idminter.modules
 import akka.actor.ActorSystem
 import com.twitter.inject.{Injector, TwitterModule}
 import uk.ac.wellcome.models.{IdentifiedWork, Work}
-import uk.ac.wellcome.platform.idminter.steps.{
-  IdentifierGenerator,
-  WorkExtractor
-}
+import uk.ac.wellcome.platform.idminter.steps.{IdentifierGenerator, WorkExtractor}
 import uk.ac.wellcome.sns.SNSWriter
 import uk.ac.wellcome.sqs.SQSReader
 import uk.ac.wellcome.utils.{JsonUtil, TryBackoff}
 import uk.ac.wellcome.utils.GlobalExecutionContext.context
+
+import scala.concurrent.Future
 
 object IdMinterModule extends TwitterModule with TryBackoff {
   val snsSubject = "identified-item"
@@ -27,7 +26,7 @@ object IdMinterModule extends TwitterModule with TryBackoff {
 
   private def start(sqsReader: SQSReader,
                     idGenerator: IdentifierGenerator,
-                    snsWriter: SNSWriter) = {
+                    snsWriter: SNSWriter): Future[Unit] = {
 
     sqsReader.retrieveAndDeleteMessages { message =>
       for {

--- a/ingestor/src/main/scala/uk/ac/wellcome/platform/ingestor/modules/SQSWorker.scala
+++ b/ingestor/src/main/scala/uk/ac/wellcome/platform/ingestor/modules/SQSWorker.scala
@@ -28,7 +28,7 @@ object SQSWorker extends TwitterModule with TryBackoff {
 
   private def processMessages(
     sqsReader: SQSReader,
-    indexer: IdentifiedWorkIndexer): Unit = {
+    indexer: IdentifiedWorkIndexer): Future[Unit] = {
     sqsReader.retrieveAndDeleteMessages { message =>
       Future.fromTry(extractMessage(message)).flatMap { sqsMessage =>
         indexer.indexIdentifiedWork(sqsMessage.body).map(_=>())

--- a/reindexer/src/main/scala/uk/ac/wellcome/platform/reindexer/modules/ReindexModule.scala
+++ b/reindexer/src/main/scala/uk/ac/wellcome/platform/reindexer/modules/ReindexModule.scala
@@ -57,7 +57,8 @@ object ReindexModule extends TwitterModule with TryBackoff {
     }
 
     val reindexJob = () => {
-      reindexService.run.onComplete {
+      val future = reindexService.run
+      future.onComplete {
         case Success(_) =>
           info(s"ReindexModule job completed successfully.")
           ReindexStatus.succeed()
@@ -65,6 +66,7 @@ object ReindexModule extends TwitterModule with TryBackoff {
           error(s"ReindexModule job failed!", e)
           ReindexStatus.fail()
       }
+      future
     }
 
     run(() => reindexJob(), actorSystem)

--- a/reindexer/src/main/scala/uk/ac/wellcome/platform/reindexer/modules/ReindexModule.scala
+++ b/reindexer/src/main/scala/uk/ac/wellcome/platform/reindexer/modules/ReindexModule.scala
@@ -14,10 +14,11 @@ import uk.ac.wellcome.platform.reindexer.services._
 import uk.ac.wellcome.utils.GlobalExecutionContext.context
 import uk.ac.wellcome.utils.TryBackoff
 
-import scala.concurrent.duration._
 import scala.util.{Failure, Success}
 
 object ReindexModule extends TwitterModule with TryBackoff {
+
+  override val continuous: Boolean = false
 
   val targetTableName: Flag[String] = flag[String](
     name = "reindex.target.tableName",

--- a/reindexer/src/main/scala/uk/ac/wellcome/platform/reindexer/modules/ReindexModule.scala
+++ b/reindexer/src/main/scala/uk/ac/wellcome/platform/reindexer/modules/ReindexModule.scala
@@ -18,7 +18,7 @@ import scala.util.{Failure, Success}
 
 object ReindexModule extends TwitterModule with TryBackoff {
 
-  override val continuous: Boolean = false
+  override lazy val continuous: Boolean = false
 
   val targetTableName: Flag[String] = flag[String](
     name = "reindex.target.tableName",

--- a/reindexer/src/main/scala/uk/ac/wellcome/platform/reindexer/services/ReindexService.scala
+++ b/reindexer/src/main/scala/uk/ac/wellcome/platform/reindexer/services/ReindexService.scala
@@ -23,8 +23,8 @@ class ReindexService[T <: Reindexable[String]] @Inject()(
     metricsSender.timeAndCount("reindex-total-time", () => {
       val attempt: Future[Option[ReindexAttempt]] = for {
         indices <- reindexTrackerService.getIndexForReindex
-        attempt = indices.map(ReindexAttempt(_, Nil, 0))
-        _ <- attempt.map(processReindexAttempt).getOrElse(Future.successful((): Unit))
+        attempt: Option[ReindexAttempt] = indices.map(ReindexAttempt(_, Nil, 0))
+        _ <- attempt.map(processReindexAttempt).getOrElse(Future.successful(()))
       } yield attempt
 
       attempt.map {

--- a/reindexer/src/main/scala/uk/ac/wellcome/platform/reindexer/services/ReindexService.scala
+++ b/reindexer/src/main/scala/uk/ac/wellcome/platform/reindexer/services/ReindexService.scala
@@ -23,7 +23,7 @@ class ReindexService[T <: Reindexable[String]] @Inject()(
     metricsSender.timeAndCount("reindex-total-time", () => {
       val attempt: Future[Option[ReindexAttempt]] = for {
         indices <- reindexTrackerService.getIndexForReindex
-        attempt: Option[ReindexAttempt] = indices.map(ReindexAttempt(_, Nil, 0))
+        attempt = indices.map(ReindexAttempt(_, Nil, 0))
         _ <- attempt.map(processReindexAttempt).getOrElse(Future.successful(()))
       } yield attempt
 

--- a/reindexer/src/test/scala/uk/ac/wellcome/platform/reindexer/modules/ReindexModuleTest.scala
+++ b/reindexer/src/test/scala/uk/ac/wellcome/platform/reindexer/modules/ReindexModuleTest.scala
@@ -81,11 +81,6 @@ class ReindexModuleTest
         ) ++ cloudWatchLocalEndpointFlag ++ dynamoDbLocalEndpointFlags
       ).bind[ReindexService[CalmTransformable]](reindexService)
 
-    val reindex = Reindex(calmDataTableName, requestedVersion, currentVersion)
-    val reindexAttempt = ReindexAttempt(reindex, Nil, 0)
-
-    Scanamo.put(dynamoDbClient)(reindexTableName)(reindex)
-
     when(reindexService.run).thenReturn(Future.successful(()))
 
     server.start()

--- a/reindexer/src/test/scala/uk/ac/wellcome/platform/reindexer/modules/ReindexModuleTest.scala
+++ b/reindexer/src/test/scala/uk/ac/wellcome/platform/reindexer/modules/ReindexModuleTest.scala
@@ -3,21 +3,20 @@ package uk.ac.wellcome.platform.reindexer.modules
 import com.gu.scanamo.Scanamo
 import com.gu.scanamo.syntax._
 import com.twitter.finatra.http.EmbeddedHttpServer
-import org.mockito.Mockito.when
-import org.scalatest.concurrent.{Eventually, IntegrationPatience}
+import org.scalatest.concurrent.Eventually
 import org.scalatest.mockito.MockitoSugar
 import org.scalatest.{FunSpec, Matchers}
 import uk.ac.wellcome.models.aws.DynamoConfig
 import uk.ac.wellcome.models.{CalmTransformable, Reindex}
 import uk.ac.wellcome.platform.reindexer.Server
 import uk.ac.wellcome.platform.reindexer.models.ReindexAttempt
-import uk.ac.wellcome.platform.reindexer.services.{CalmReindexTargetService, ReindexTargetService}
+import uk.ac.wellcome.platform.reindexer.services.{CalmReindexTargetService, ReindexService, ReindexTargetService}
 import uk.ac.wellcome.test.utils.{AmazonCloudWatchFlag, DynamoDBLocal, ExtendedPatience}
 
 import scala.concurrent.Future
 
 class ReindexModuleTest
-    extends FunSpec
+  extends FunSpec
     with MockitoSugar
     with DynamoDBLocal
     with Eventually
@@ -25,28 +24,30 @@ class ReindexModuleTest
     with AmazonCloudWatchFlag
     with Matchers {
 
-  val reindexTargetService = mock[CalmReindexTargetService]
-  val server: EmbeddedHttpServer =
-    new EmbeddedHttpServer(
-      new Server(),
-      flags = Map(
-        "aws.dynamo.reindexTracker.tableName" -> "ReindexTracker",
-        "aws.dynamo.calmData.tableName" -> "CalmData",
-        "reindex.target.tableName" -> "CalmData"
-      ) ++ cloudWatchLocalEndpointFlag ++ dynamoDbLocalEndpointFlags
-    ).bind[ReindexTargetService[CalmTransformable]](reindexTargetService)
+  import org.mockito.Mockito._
 
   val currentVersion = 1
   val requestedVersion = 2
 
   val dynamoConfigs = Map(
     "reindex" -> DynamoConfig("applicationName",
-                              "streamArn",
-                              reindexTableName),
+      "streamArn",
+      reindexTableName),
     "calm" -> DynamoConfig("applicationName", "streamArn", calmDataTableName)
   )
 
   it("should retry if the target service returns a failed future") {
+    val reindexTargetService = mock[CalmReindexTargetService]
+    val server: EmbeddedHttpServer =
+      new EmbeddedHttpServer(
+        new Server(),
+        flags = Map(
+          "aws.dynamo.reindexTracker.tableName" -> "ReindexTracker",
+          "aws.dynamo.calmData.tableName" -> "CalmData",
+          "reindex.target.tableName" -> "CalmData"
+        ) ++ cloudWatchLocalEndpointFlag ++ dynamoDbLocalEndpointFlags
+      ).bind[ReindexTargetService[CalmTransformable]](reindexTargetService)
+
     val reindex = Reindex(calmDataTableName, requestedVersion, currentVersion)
     Scanamo.put(dynamoDbClient)(reindexTableName)(reindex)
 
@@ -62,6 +63,34 @@ class ReindexModuleTest
       Scanamo.get[Reindex](dynamoDbClient)(reindexTableName)(
         'TableName -> "CalmData") shouldBe Some(
         Right(reindex.copy(CurrentVersion = requestedVersion)))
+    }
+
+    server.close()
+  }
+
+  it("should call reindexService.run only once if successful") {
+    val reindexService = mock[ReindexService[CalmTransformable]]
+    val server: EmbeddedHttpServer =
+      new EmbeddedHttpServer(
+        new Server(),
+        flags = Map(
+          "aws.dynamo.reindexTracker.tableName" -> "ReindexTracker",
+          "aws.dynamo.calmData.tableName" -> "CalmData",
+          "reindex.target.tableName" -> "CalmData"
+        ) ++ cloudWatchLocalEndpointFlag ++ dynamoDbLocalEndpointFlags
+      ).bind[ReindexService[CalmTransformable]](reindexService)
+
+    val reindex = Reindex(calmDataTableName, requestedVersion, currentVersion)
+    val reindexAttempt = ReindexAttempt(reindex, Nil, 0)
+
+    Scanamo.put(dynamoDbClient)(reindexTableName)(reindex)
+
+    when(reindexService.run).thenReturn(Future.successful(()))
+
+    server.start()
+
+    eventually {
+      verify(reindexService, times(1)).run
     }
 
     server.close()

--- a/reindexer/src/test/scala/uk/ac/wellcome/platform/reindexer/modules/ReindexModuleTest.scala
+++ b/reindexer/src/test/scala/uk/ac/wellcome/platform/reindexer/modules/ReindexModuleTest.scala
@@ -37,6 +37,7 @@ class ReindexModuleTest
   )
 
   it("should retry if the target service returns a failed future") {
+
     val reindexTargetService = mock[CalmReindexTargetService]
     val server: EmbeddedHttpServer =
       new EmbeddedHttpServer(


### PR DESCRIPTION
### What is this PR trying to achieve?

Prevents winning _too much_

### Who is this change for?

Devs who want to use `TryBackoff` without repeating the operation on success.

### Have the following been considered/are they needed?

- [ ] Deployed new versions
