### PR TITLE
Ensures reindexer doesn't retry when successful

### DIFF
--- a/common/src/main/scala/uk/ac/wellcome/utils/TryBackoff.scala
+++ b/common/src/main/scala/uk/ac/wellcome/utils/TryBackoff.scala
@@ -44,8 +44,8 @@ import scala.util.{Failure, Success, Try}
   */
 trait TryBackoff extends Logging {
   lazy val continuous = true
-  lazy val baseWait = 100 millis
-  lazy val totalWait = 12 seconds
+  lazy val baseWait: Duration = 100 millis
+  lazy val totalWait: Duration = 12 seconds
 
   // This value is cached to save us repeating the calculation.
   private val maxAttempts = maximumAttemptsToTry()
@@ -56,7 +56,7 @@ trait TryBackoff extends Logging {
 
     Future.successful().flatMap(_ => f()).onComplete { tried =>
       val attempted = tried match {
-        case Success(_) => Right()
+        case Success(_) => Right((): Unit)
         case Failure(e) =>
           error(s"Failed to run (attempt: $attempt)", e)
           Left(e)

--- a/common/src/test/scala/uk/ac/wellcome/utils/TryBackoffTest.scala
+++ b/common/src/test/scala/uk/ac/wellcome/utils/TryBackoffTest.scala
@@ -3,9 +3,9 @@ package uk.ac.wellcome.utils
 import akka.actor.ActorSystem
 import org.scalatest.concurrent.{Eventually, IntegrationPatience}
 import org.scalatest.{BeforeAndAfterEach, FunSpec, Matchers}
+
+import scala.concurrent.Future
 import scala.concurrent.duration._
-import uk.ac.wellcome.utils.GlobalExecutionContext.context
-import uk.ac.wellcome.utils.TryBackoff
 
 class TryBackoffTest
     extends FunSpec
@@ -94,21 +94,23 @@ class TryBackoffTest
 
   // Methods passed to the TryBackoff.
 
-  def alwaysSucceeds(): Unit = {
+  def alwaysSucceeds(): Future[Unit] = {
     calls = 0 :: calls
+    Future.successful(())
   }
 
-  def alwaysFails(): Unit = {
+  def alwaysFails(): Future[Unit] = {
     calls = System.currentTimeMillis().toInt :: calls
-    throw new Exception("I will always fail")
+    Future.failed(new Exception("I will always fail"))
   }
 
-  def succeedsOnThirdAttempt(): Unit = {
+  def succeedsOnThirdAttempt(): Future[Unit] = {
     if (calls.length < 2) {
       calls = 0 :: calls
-      throw new Exception("Not ready yet")
+      Future.failed(new Exception("Not ready yet"))
     } else {
       calls = 1 :: calls
+      Future.successful(())
     }
   }
 }

--- a/common/src/test/scala/uk/ac/wellcome/utils/TryBackoffTest.scala
+++ b/common/src/test/scala/uk/ac/wellcome/utils/TryBackoffTest.scala
@@ -15,7 +15,7 @@ class TryBackoffTest
     with Matchers {
   val system = ActorSystem.create("TestActorSystem")
 
-  var calls = List[Int]()
+  private var calls = List[Int]()
 
   val tryBackoff = new TryBackoff {
     override lazy val totalWait = 6 seconds
@@ -50,7 +50,10 @@ class TryBackoffTest
 
     Thread.sleep(10000)
     val finalLength = calls.length
+    println(finalLength)
+    println(calls.length)
     Thread.sleep(5000)
+    println(calls.length)
     calls.length shouldBe finalLength
   }
 

--- a/id_minter/src/main/scala/uk/ac/wellcome/platform/idminter/modules/IdMinterModule.scala
+++ b/id_minter/src/main/scala/uk/ac/wellcome/platform/idminter/modules/IdMinterModule.scala
@@ -3,14 +3,13 @@ package uk.ac.wellcome.platform.idminter.modules
 import akka.actor.ActorSystem
 import com.twitter.inject.{Injector, TwitterModule}
 import uk.ac.wellcome.models.{IdentifiedWork, Work}
-import uk.ac.wellcome.platform.idminter.steps.{
-  IdentifierGenerator,
-  WorkExtractor
-}
+import uk.ac.wellcome.platform.idminter.steps.{IdentifierGenerator, WorkExtractor}
 import uk.ac.wellcome.sns.SNSWriter
 import uk.ac.wellcome.sqs.SQSReader
 import uk.ac.wellcome.utils.{JsonUtil, TryBackoff}
 import uk.ac.wellcome.utils.GlobalExecutionContext.context
+
+import scala.concurrent.Future
 
 object IdMinterModule extends TwitterModule with TryBackoff {
   val snsSubject = "identified-item"
@@ -27,7 +26,7 @@ object IdMinterModule extends TwitterModule with TryBackoff {
 
   private def start(sqsReader: SQSReader,
                     idGenerator: IdentifierGenerator,
-                    snsWriter: SNSWriter) = {
+                    snsWriter: SNSWriter): Future[Unit] = {
 
     sqsReader.retrieveAndDeleteMessages { message =>
       for {

--- a/ingestor/src/main/scala/uk/ac/wellcome/platform/ingestor/modules/SQSWorker.scala
+++ b/ingestor/src/main/scala/uk/ac/wellcome/platform/ingestor/modules/SQSWorker.scala
@@ -28,7 +28,7 @@ object SQSWorker extends TwitterModule with TryBackoff {
 
   private def processMessages(
     sqsReader: SQSReader,
-    indexer: IdentifiedWorkIndexer): Unit = {
+    indexer: IdentifiedWorkIndexer): Future[Unit] = {
     sqsReader.retrieveAndDeleteMessages { message =>
       Future.fromTry(extractMessage(message)).flatMap { sqsMessage =>
         indexer.indexIdentifiedWork(sqsMessage.body).map(_=>())

--- a/reindexer/src/main/scala/uk/ac/wellcome/platform/reindexer/modules/ReindexModule.scala
+++ b/reindexer/src/main/scala/uk/ac/wellcome/platform/reindexer/modules/ReindexModule.scala
@@ -57,7 +57,8 @@ object ReindexModule extends TwitterModule with TryBackoff {
     }
 
     val reindexJob = () => {
-      reindexService.run.onComplete {
+      val future = reindexService.run
+      future.onComplete {
         case Success(_) =>
           info(s"ReindexModule job completed successfully.")
           ReindexStatus.succeed()
@@ -65,6 +66,7 @@ object ReindexModule extends TwitterModule with TryBackoff {
           error(s"ReindexModule job failed!", e)
           ReindexStatus.fail()
       }
+      future
     }
 
     run(() => reindexJob(), actorSystem)

--- a/reindexer/src/main/scala/uk/ac/wellcome/platform/reindexer/modules/ReindexModule.scala
+++ b/reindexer/src/main/scala/uk/ac/wellcome/platform/reindexer/modules/ReindexModule.scala
@@ -14,10 +14,11 @@ import uk.ac.wellcome.platform.reindexer.services._
 import uk.ac.wellcome.utils.GlobalExecutionContext.context
 import uk.ac.wellcome.utils.TryBackoff
 
-import scala.concurrent.duration._
 import scala.util.{Failure, Success}
 
 object ReindexModule extends TwitterModule with TryBackoff {
+
+  override lazy val continuous: Boolean = false
 
   val targetTableName: Flag[String] = flag[String](
     name = "reindex.target.tableName",

--- a/reindexer/src/test/scala/uk/ac/wellcome/platform/reindexer/modules/ReindexModuleTest.scala
+++ b/reindexer/src/test/scala/uk/ac/wellcome/platform/reindexer/modules/ReindexModuleTest.scala
@@ -3,21 +3,20 @@ package uk.ac.wellcome.platform.reindexer.modules
 import com.gu.scanamo.Scanamo
 import com.gu.scanamo.syntax._
 import com.twitter.finatra.http.EmbeddedHttpServer
-import org.mockito.Mockito.when
-import org.scalatest.concurrent.{Eventually, IntegrationPatience}
+import org.scalatest.concurrent.Eventually
 import org.scalatest.mockito.MockitoSugar
 import org.scalatest.{FunSpec, Matchers}
 import uk.ac.wellcome.models.aws.DynamoConfig
 import uk.ac.wellcome.models.{CalmTransformable, Reindex}
 import uk.ac.wellcome.platform.reindexer.Server
 import uk.ac.wellcome.platform.reindexer.models.ReindexAttempt
-import uk.ac.wellcome.platform.reindexer.services.{CalmReindexTargetService, ReindexTargetService}
+import uk.ac.wellcome.platform.reindexer.services.{CalmReindexTargetService, ReindexService, ReindexTargetService}
 import uk.ac.wellcome.test.utils.{AmazonCloudWatchFlag, DynamoDBLocal, ExtendedPatience}
 
 import scala.concurrent.Future
 
 class ReindexModuleTest
-    extends FunSpec
+  extends FunSpec
     with MockitoSugar
     with DynamoDBLocal
     with Eventually
@@ -25,28 +24,30 @@ class ReindexModuleTest
     with AmazonCloudWatchFlag
     with Matchers {
 
-  val reindexTargetService = mock[CalmReindexTargetService]
-  val server: EmbeddedHttpServer =
-    new EmbeddedHttpServer(
-      new Server(),
-      flags = Map(
-        "aws.dynamo.reindexTracker.tableName" -> "ReindexTracker",
-        "aws.dynamo.calmData.tableName" -> "CalmData",
-        "reindex.target.tableName" -> "CalmData"
-      ) ++ cloudWatchLocalEndpointFlag ++ dynamoDbLocalEndpointFlags
-    ).bind[ReindexTargetService[CalmTransformable]](reindexTargetService)
+  import org.mockito.Mockito._
 
   val currentVersion = 1
   val requestedVersion = 2
 
   val dynamoConfigs = Map(
     "reindex" -> DynamoConfig("applicationName",
-                              "streamArn",
-                              reindexTableName),
+      "streamArn",
+      reindexTableName),
     "calm" -> DynamoConfig("applicationName", "streamArn", calmDataTableName)
   )
 
   it("should retry if the target service returns a failed future") {
+    val reindexTargetService = mock[CalmReindexTargetService]
+    val server: EmbeddedHttpServer =
+      new EmbeddedHttpServer(
+        new Server(),
+        flags = Map(
+          "aws.dynamo.reindexTracker.tableName" -> "ReindexTracker",
+          "aws.dynamo.calmData.tableName" -> "CalmData",
+          "reindex.target.tableName" -> "CalmData"
+        ) ++ cloudWatchLocalEndpointFlag ++ dynamoDbLocalEndpointFlags
+      ).bind[ReindexTargetService[CalmTransformable]](reindexTargetService)
+
     val reindex = Reindex(calmDataTableName, requestedVersion, currentVersion)
     Scanamo.put(dynamoDbClient)(reindexTableName)(reindex)
 
@@ -62,6 +63,34 @@ class ReindexModuleTest
       Scanamo.get[Reindex](dynamoDbClient)(reindexTableName)(
         'TableName -> "CalmData") shouldBe Some(
         Right(reindex.copy(CurrentVersion = requestedVersion)))
+    }
+
+    server.close()
+  }
+
+  it("should call reindexService.run only once if successful") {
+    val reindexService = mock[ReindexService[CalmTransformable]]
+    val server: EmbeddedHttpServer =
+      new EmbeddedHttpServer(
+        new Server(),
+        flags = Map(
+          "aws.dynamo.reindexTracker.tableName" -> "ReindexTracker",
+          "aws.dynamo.calmData.tableName" -> "CalmData",
+          "reindex.target.tableName" -> "CalmData"
+        ) ++ cloudWatchLocalEndpointFlag ++ dynamoDbLocalEndpointFlags
+      ).bind[ReindexService[CalmTransformable]](reindexService)
+
+    val reindex = Reindex(calmDataTableName, requestedVersion, currentVersion)
+    val reindexAttempt = ReindexAttempt(reindex, Nil, 0)
+
+    Scanamo.put(dynamoDbClient)(reindexTableName)(reindex)
+
+    when(reindexService.run).thenReturn(Future.successful(()))
+
+    server.start()
+
+    eventually {
+      verify(reindexService, times(1)).run
     }
 
     server.close()

--- a/reindexer/src/test/scala/uk/ac/wellcome/platform/reindexer/modules/ReindexModuleTest.scala
+++ b/reindexer/src/test/scala/uk/ac/wellcome/platform/reindexer/modules/ReindexModuleTest.scala
@@ -80,11 +80,6 @@ class ReindexModuleTest
         ) ++ cloudWatchLocalEndpointFlag ++ dynamoDbLocalEndpointFlags
       ).bind[ReindexService[CalmTransformable]](reindexService)
 
-    val reindex = Reindex(calmDataTableName, requestedVersion, currentVersion)
-    val reindexAttempt = ReindexAttempt(reindex, Nil, 0)
-
-    Scanamo.put(dynamoDbClient)(reindexTableName)(reindex)
-
     when(reindexService.run).thenReturn(Future.successful(()))
 
     server.start()

--- a/reindexer/src/test/scala/uk/ac/wellcome/platform/reindexer/modules/ReindexModuleTest.scala
+++ b/reindexer/src/test/scala/uk/ac/wellcome/platform/reindexer/modules/ReindexModuleTest.scala
@@ -3,50 +3,57 @@ package uk.ac.wellcome.platform.reindexer.modules
 import com.gu.scanamo.Scanamo
 import com.gu.scanamo.syntax._
 import com.twitter.finatra.http.EmbeddedHttpServer
+import org.mockito.Mockito._
 import org.scalatest.concurrent.Eventually
 import org.scalatest.mockito.MockitoSugar
-import org.scalatest.{FunSpec, Matchers}
+import org.scalatest.{BeforeAndAfterEach, FunSpec, Matchers}
 import uk.ac.wellcome.models.aws.DynamoConfig
 import uk.ac.wellcome.models.{CalmTransformable, Reindex}
 import uk.ac.wellcome.platform.reindexer.Server
 import uk.ac.wellcome.platform.reindexer.models.ReindexAttempt
-import uk.ac.wellcome.platform.reindexer.services.{CalmReindexTargetService, ReindexService, ReindexTargetService}
-import uk.ac.wellcome.test.utils.{AmazonCloudWatchFlag, DynamoDBLocal, ExtendedPatience}
+import uk.ac.wellcome.platform.reindexer.services.{
+  CalmReindexTargetService,
+  ReindexService,
+  ReindexTargetService
+}
+import uk.ac.wellcome.test.utils.{
+  AmazonCloudWatchFlag,
+  DynamoDBLocal,
+  ExtendedPatience
+}
 
 import scala.concurrent.Future
 
 class ReindexModuleTest
-  extends FunSpec
+    extends FunSpec
     with MockitoSugar
     with DynamoDBLocal
     with Eventually
     with ExtendedPatience
     with AmazonCloudWatchFlag
-    with Matchers {
-
-  import org.mockito.Mockito._
+    with Matchers
+    with BeforeAndAfterEach {
 
   val currentVersion = 1
   val requestedVersion = 2
 
   val dynamoConfigs = Map(
     "reindex" -> DynamoConfig("applicationName",
-      "streamArn",
-      reindexTableName),
+                              "streamArn",
+                              reindexTableName),
     "calm" -> DynamoConfig("applicationName", "streamArn", calmDataTableName)
   )
+
+  var maybeServer: Option[EmbeddedHttpServer] = None
+
+  override def afterEach(): Unit = maybeServer.foreach(_.close())
 
   it("should retry if the target service returns a failed future") {
     val reindexTargetService = mock[CalmReindexTargetService]
     val server: EmbeddedHttpServer =
-      new EmbeddedHttpServer(
-        new Server(),
-        flags = Map(
-          "aws.dynamo.reindexTracker.tableName" -> "ReindexTracker",
-          "aws.dynamo.calmData.tableName" -> "CalmData",
-          "reindex.target.tableName" -> "CalmData"
-        ) ++ cloudWatchLocalEndpointFlag ++ dynamoDbLocalEndpointFlags
-      ).bind[ReindexTargetService[CalmTransformable]](reindexTargetService)
+      defineServer.bind[ReindexTargetService[CalmTransformable]](
+        reindexTargetService)
+    maybeServer = Some(server)
 
     val reindex = Reindex(calmDataTableName, requestedVersion, currentVersion)
     Scanamo.put(dynamoDbClient)(reindexTableName)(reindex)
@@ -64,21 +71,13 @@ class ReindexModuleTest
         'TableName -> "CalmData") shouldBe Some(
         Right(reindex.copy(CurrentVersion = requestedVersion)))
     }
-
-    server.close()
   }
 
   it("should call reindexService.run only once if successful") {
     val reindexService = mock[ReindexService[CalmTransformable]]
     val server: EmbeddedHttpServer =
-      new EmbeddedHttpServer(
-        new Server(),
-        flags = Map(
-          "aws.dynamo.reindexTracker.tableName" -> "ReindexTracker",
-          "aws.dynamo.calmData.tableName" -> "CalmData",
-          "reindex.target.tableName" -> "CalmData"
-        ) ++ cloudWatchLocalEndpointFlag ++ dynamoDbLocalEndpointFlags
-      ).bind[ReindexService[CalmTransformable]](reindexService)
+      defineServer.bind[ReindexService[CalmTransformable]](reindexService)
+    maybeServer = Some(server)
 
     when(reindexService.run).thenReturn(Future.successful(()))
 
@@ -87,7 +86,16 @@ class ReindexModuleTest
     eventually {
       verify(reindexService, times(1)).run
     }
+  }
 
-    server.close()
+  private def defineServer = {
+    new EmbeddedHttpServer(
+      new Server(),
+      flags = Map(
+        "aws.dynamo.reindexTracker.tableName" -> "ReindexTracker",
+        "aws.dynamo.calmData.tableName" -> "CalmData",
+        "reindex.target.tableName" -> "CalmData"
+      ) ++ cloudWatchLocalEndpointFlag ++ dynamoDbLocalEndpointFlags
+    )
   }
 }


### PR DESCRIPTION
### What is this PR trying to achieve?
Prevents winning too much
### Who is this change for?
Devs who want to use `TryBackoff` without repeating the operation on success.

### Have the following been considered/are they needed?

<!-- Delete bullets if they don't apply to this patch -->

<!-- If you're making application changes -->
- [ ] Deployed new versions
