### PR TITLE
Adds a query util for Scanamo to prevent OOM ...

### DIFF
--- a/common/src/main/scala/uk/ac/wellcome/utils/DynamoUtils.scala
+++ b/common/src/main/scala/uk/ac/wellcome/utils/DynamoUtils.scala
@@ -1,10 +1,10 @@
 package uk.ac.wellcome.utils
 
-import scala.collection.JavaConversions._
-
 import com.amazonaws.services.dynamodbv2._
 import com.amazonaws.services.dynamodbv2.document._
 import com.amazonaws.services.dynamodbv2.model.ProvisionedThroughput
+
+import scala.collection.JavaConversions._
 
 trait DynamoUpdateWriteCapacityCapable {
   val client: AmazonDynamoDB
@@ -34,3 +34,4 @@ trait DynamoUpdateWriteCapacityCapable {
     table.updateTable(newThroughput)
   }
 }
+

--- a/common/src/main/scala/uk/ac/wellcome/utils/ScanamoUtils.scala
+++ b/common/src/main/scala/uk/ac/wellcome/utils/ScanamoUtils.scala
@@ -1,6 +1,16 @@
 package uk.ac.wellcome.utils
 
+import java.util
+
+import cats.free.Free
+import com.amazonaws.services.dynamodbv2.model.{AttributeValue, QueryResult}
+import com.gu.scanamo.{DynamoFormat, ScanamoFree}
 import com.gu.scanamo.error.DynamoReadError
+import com.gu.scanamo.ops.{ScanamoOps, ScanamoOpsA}
+import com.gu.scanamo.request.ScanamoQueryRequest
+
+import scala.collection.JavaConverters._
+
 
 object ScanamoUtils {
   def logAndFilterLeft[Y](rows: List[Either[DynamoReadError, Y]]) = {
@@ -15,5 +25,46 @@ object ScanamoUtils {
         case Left(_) => false
       }
       .flatMap(_.right.toOption)
+  }
+}
+
+object ScanamoQueryStream {
+  type EvaluationKey = java.util.Map[String, AttributeValue]
+
+  private def items(
+                     res: QueryResult): util.List[util.Map[String, AttributeValue]] =
+    res.getItems
+  private def lastEvaluatedKey(
+                                res: QueryResult): util.Map[String, AttributeValue] =
+    res.getLastEvaluatedKey
+  private def withExclusiveStartKey(
+                                     req: ScanamoQueryRequest,
+                                     key: util.Map[String, AttributeValue]): ScanamoQueryRequest =
+    req.copy(options =
+      req.options.copy(exclusiveStartKey = Some(key.asScala.toMap)))
+
+  private def exec(req: ScanamoQueryRequest): ScanamoOps[QueryResult] =
+    ScanamoOps.query(req)
+
+  def run[T: DynamoFormat, Y](
+                               req: ScanamoQueryRequest,
+                               f: (List[Either[DynamoReadError, T]]) => List[Y])
+  : ScanamoOps[List[Y]] = {
+    def runMore(lastKey: Option[EvaluationKey]): ScanamoOps[List[Y]] = {
+      for {
+        queryResult <- exec(
+          lastKey.foldLeft(req)(withExclusiveStartKey(_, _)))
+        results = items(queryResult).asScala.map(ScanamoFree.read[T]).toList
+        processedResults = f(results)
+        resultList <- Option(lastEvaluatedKey(queryResult)).foldLeft(
+          Free.pure[ScanamoOpsA, List[Y]](processedResults)
+        )((rs, k) =>
+          for {
+            items <- rs
+            more <- runMore(Some(k))
+          } yield items ::: more)
+      } yield resultList
+    }
+    runMore(None)
   }
 }

--- a/common/src/test/scala/uk/ac/wellcome/utils/ScanamoQueryStreamTest.scala
+++ b/common/src/test/scala/uk/ac/wellcome/utils/ScanamoQueryStreamTest.scala
@@ -1,0 +1,92 @@
+package uk.ac.wellcome.utils
+
+import com.gu.scanamo.Scanamo
+import com.gu.scanamo.error.DynamoReadError
+import com.gu.scanamo.query._
+import com.gu.scanamo.request.{ScanamoQueryOptions, ScanamoQueryRequest}
+import com.gu.scanamo.syntax._
+import org.scalatest.concurrent.{Eventually, IntegrationPatience}
+import org.scalatest.{BeforeAndAfterEach, FunSpec, Matchers}
+import uk.ac.wellcome.models.MiroTransformable
+import uk.ac.wellcome.test.utils.DynamoDBLocal
+
+class ScanamoQueryStreamTest
+    extends FunSpec
+    with BeforeAndAfterEach
+    with Eventually
+    with IntegrationPatience
+    with DynamoDBLocal
+    with Matchers {
+
+
+  // TODO: Find a better way of doing this!!
+  val bigString = (1 to 400).map(_ => "a").foldLeft("")(_ + _)
+
+  it("run a given function for each row") {
+
+    (1 to 10)
+      .map(
+        i =>
+          MiroTransformable(
+            MiroID = s"Image$i",
+            MiroCollection = "Collection",
+            data = bigString,
+            ReindexVersion = 1
+        ))
+      .par.foreach(
+        Scanamo.put(dynamoDbClient)(miroDataTableName)
+      )
+
+    val result = run
+
+    val currentState = Scanamo.scan[MiroTransformable](dynamoDbClient)("MiroData")
+
+    println(result)
+    println(currentState)
+
+    true shouldBe false
+  }
+
+
+
+  def run: List[Either[DynamoReadError, MiroTransformable]] = {
+
+    val scanamoQueryRequest = ScanamoQueryRequest(
+      miroDataTableName,
+      Some("ReindexTracker"),
+      Query(
+        AndQueryCondition(
+          KeyEquals('ReindexShard, "default"),
+          KeyIs('ReindexVersion, LT, 10)
+        )),
+      ScanamoQueryOptions.default
+    )
+
+    def updateVersion(
+      resultGroup: List[Either[DynamoReadError, MiroTransformable]])
+      : List[Either[DynamoReadError, MiroTransformable]] = {
+
+      resultGroup.map {
+        case Left(e) => Left(e)
+        case Right(miroTransformable) => {
+          val reindexItem = miroTransformable.getReindexItem
+
+          Scanamo.update[MiroTransformable](dynamoDbClient)("MiroData")(
+            reindexItem.hashKey and reindexItem.rangeKey,
+            set('ReindexVersion -> (reindexItem.ReindexVersion + 1)))
+
+          Right(miroTransformable)
+        }
+      }
+
+    }
+
+    val ops = ScanamoQueryStream
+      .run[MiroTransformable, Either[DynamoReadError, MiroTransformable]](
+        scanamoQueryRequest,
+        updateVersion)
+
+    Scanamo.exec(dynamoDbClient)(ops)
+  }
+
+}

--- a/common/src/test/scala/uk/ac/wellcome/utils/ScanamoQueryStreamTest.scala
+++ b/common/src/test/scala/uk/ac/wellcome/utils/ScanamoQueryStreamTest.scala
@@ -24,10 +24,10 @@ class ScanamoQueryStreamTest
 
   val bigString = "_" * maxDynamoItemSizeinKb
 
-  it("run a given function for each batch from the query provided") {
+  it("should run a given function for each batch from the query provided") {
 
     type ResultGroup = List[Either[DynamoReadError, MiroTransformable]]
-    var resultGroups: ListBuffer[ResultGroup] = new ListBuffer[ResultGroup]()
+    val resultGroups: ListBuffer[ResultGroup] = new ListBuffer[ResultGroup]()
 
     val expectedBatchCount = 4
     val numberofRequiredPuts = (expectedBatchCount * maxDynamoQueryResultSizeInKb) / maxDynamoItemSizeinKb
@@ -42,7 +42,7 @@ class ScanamoQueryStreamTest
             ReindexVersion = 1
         ))
 
-    itemsToPut.par.foreach(
+    itemsToPut.foreach(
       Scanamo.put(dynamoDbClient)(miroDataTableName)
     )
 
@@ -59,17 +59,10 @@ class ScanamoQueryStreamTest
       ScanamoQueryOptions.default
     )
 
-    def updateVersion(
-      resultGroup: List[Either[DynamoReadError, MiroTransformable]])
-      : List[Either[DynamoReadError, MiroTransformable]] = {
-
+    def updateVersion(resultGroup: ResultGroup): ResultGroup = {
       resultGroups += resultGroup
-
       resultGroup
     }
-
-    val currentState =
-      Scanamo.scan[MiroTransformable](dynamoDbClient)("MiroData")
 
     val ops = ScanamoQueryStream
       .run[MiroTransformable, Either[DynamoReadError, MiroTransformable]](

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -1,5 +1,4 @@
 import sbt._
-import Keys._
 
 object Dependencies {
 
@@ -15,7 +14,7 @@ object Dependencies {
     val scalatest = "3.0.1"
     val junitInterface = "0.11"
     val elastic4s = "5.4.1"
-    val scanamo = "0.9.1"
+    val scanamo = "0.9.4"
     val jacksonYamlVersion = "2.8.8"
   }
 


### PR DESCRIPTION
... when performing transformations on large datasets.

### What is this PR trying to achieve?

Provide a better way to work on large queries from Scanamo to prevent OOM error.

### Who is this change for?

Developers

### Have the following been considered/are they needed?

- [ ] Deployed new versions
