### PR TITLE
Support searching against a different index in the API

### DIFF
--- a/api/src/main/scala/uk/ac/wellcome/platform/api/controllers/WorksController.scala
+++ b/api/src/main/scala/uk/ac/wellcome/platform/api/controllers/WorksController.scala
@@ -21,10 +21,15 @@ case class MultipleResultsRequest(
   @Min(1) @Max(100) @QueryParam pageSize: Option[Int],
   @QueryParam includes: Option[String],
   @RouteParam id: Option[String],
-  @QueryParam query: Option[String])
+  @QueryParam query: Option[String],
+  @QueryParam index: Option[String]
+)
 
-case class SingleWorkRequest(@RouteParam id: String,
-                             @QueryParam includes: Option[String])
+case class SingleWorkRequest(
+  @RouteParam id: String,
+  @QueryParam includes: Option[String],
+  @QueryParam index: Option[String]
+)
 
 @Singleton
 class WorksController @Inject()(@Flag("api.prefix") apiPrefix: String,
@@ -61,6 +66,11 @@ class WorksController @Inject()(@Flag("api.prefix") apiPrefix: String,
           "includes",
           "A comma-separated list of extra fields to include",
           required = false)
+        // Deliberately undocumented: we have an 'index' query param that
+        // allows the user to pick which Elasticsearch index to use.  This is
+        // useful for us to try out transformer changes, different index
+        // weighting, etc., but we don't want to advertise its existence
+        // in the public docs.
     } { request: MultipleResultsRequest =>
       val pageSize = request.pageSize.getOrElse((defaultPageSize))
       val includes = request.includes.getOrElse("").split(",").toList
@@ -71,13 +81,15 @@ class WorksController @Inject()(@Flag("api.prefix") apiPrefix: String,
             queryString,
             pageSize = pageSize,
             pageNumber = request.page,
-            includes = includes
+            includes = includes,
+            index = request.index
           )
         case None =>
           worksService.listWorks(
             pageSize = pageSize,
             pageNumber = request.page,
-            includes = includes
+            includes = includes,
+            index = request.index
           )
       }
 
@@ -107,10 +119,12 @@ class WorksController @Inject()(@Flag("api.prefix") apiPrefix: String,
           "includes",
           "A comma-separated list of extra fields to include",
           required = false)
+        // Deliberately undocumented: the index flag.  See above.
     } { request: SingleWorkRequest =>
       worksService
         .findWorkById(request.id,
-                      request.includes.getOrElse("").split(",").toList)
+                      request.includes.getOrElse("").split(",").toList,
+                      index = request.index)
         .map {
           case Some(result) =>
             response.ok.json(

--- a/api/src/main/scala/uk/ac/wellcome/platform/api/controllers/WorksController.scala
+++ b/api/src/main/scala/uk/ac/wellcome/platform/api/controllers/WorksController.scala
@@ -24,7 +24,7 @@ case class MultipleResultsRequest(
 case class SingleWorkRequest(
   @RouteParam id: String,
   @QueryParam includes: Option[String],
-  @QueryParam index: Option[String]
+  @QueryParam _index: Option[String]
 )
 
 @Singleton
@@ -120,7 +120,7 @@ class WorksController @Inject()(@Flag("api.prefix") apiPrefix: String,
       worksService
         .findWorkById(request.id,
                       request.includes.getOrElse("").split(",").toList,
-                      index = request.index)
+                      index = request._index)
         .map {
           case Some(result) =>
             response.ok.json(

--- a/api/src/main/scala/uk/ac/wellcome/platform/api/finatra/modules/ElasticSearchServiceModule/ElasticSearchServiceModule.scala
+++ b/api/src/main/scala/uk/ac/wellcome/platform/api/finatra/modules/ElasticSearchServiceModule/ElasticSearchServiceModule.scala
@@ -9,17 +9,17 @@ import uk.ac.wellcome.platform.api.services.ElasticSearchService
 object ElasticSearchServiceModule extends TwitterModule {
   override val modules = Seq(ElasticClientModule)
 
-  private val indexName = flag[String](name = "es.index",
-                                       default = "records",
-                                       help = "ES index name")
+  private val defaultIndex = flag[String](name = "es.index",
+                                          default = "records",
+                                          help = "ES index name")
   private val documentType =
     flag[String](name = "es.type", default = "item", help = "ES document type")
 
   @Provides
   def providesElasticSearchService(
     elasticClient: TcpClient): ElasticSearchService =
-    new ElasticSearchService(index = indexName(),
-                             itemType = documentType(),
+    new ElasticSearchService(defaultIndex = defaultIndex(),
+                             defaultType = documentType(),
                              elasticClient = elasticClient)
 
 }

--- a/api/src/main/scala/uk/ac/wellcome/platform/api/finatra/modules/ElasticSearchServiceModule/ElasticSearchServiceModule.scala
+++ b/api/src/main/scala/uk/ac/wellcome/platform/api/finatra/modules/ElasticSearchServiceModule/ElasticSearchServiceModule.scala
@@ -19,7 +19,7 @@ object ElasticSearchServiceModule extends TwitterModule {
   def providesElasticSearchService(
     elasticClient: TcpClient): ElasticSearchService =
     new ElasticSearchService(defaultIndex = defaultIndex(),
-                             defaultType = documentType(),
+                             documentType = documentType(),
                              elasticClient = elasticClient)
 
 }

--- a/api/src/main/scala/uk/ac/wellcome/platform/api/services/ElasticSearchService.scala
+++ b/api/src/main/scala/uk/ac/wellcome/platform/api/services/ElasticSearchService.scala
@@ -14,38 +14,44 @@ import uk.ac.wellcome.utils.GlobalExecutionContext.context
 import scala.concurrent.Future
 
 @Singleton
-class ElasticSearchService @Inject()(@Flag("es.index") index: String,
-                                     @Flag("es.type") itemType: String,
+class ElasticSearchService @Inject()(@Flag("es.index") defaultIndex: String,
+                                     @Flag("es.type") defaultType: String,
                                      elasticClient: TcpClient) {
 
-  def findResultById(id: String): Future[RichGetResponse] =
+  def findResultById(id: String,
+                     index: String = defaultIndex,
+                     documentType: String = defaultType): Future[RichGetResponse] =
     elasticClient
       .execute {
-        get(id).from(s"$index/$itemType")
+        get(id).from(s"$index/$documentType")
       }
 
   def listResults(sortByField: String,
                   limit: Int = 10,
-                  from: Int = 0): Future[RichSearchResponse] =
+                  from: Int = 0,
+                  index: String = defaultIndex,
+                  documentType: String = defaultType): Future[RichSearchResponse] =
     elasticClient
       .execute {
-        search(s"$index/$itemType")
+        search(s"$index/$documentType")
           .matchAllQuery()
           .sortBy(fieldSort(sortByField))
           .limit(limit)
           .from(from)
       }
 
-  def simpleStringQueryResults(queryString: String,
-                               limit: Int = 10,
-                               from: Int = 0): Future[RichSearchResponse] =
+  def simpleStringQueryResults(
+    queryString: String,
+    limit: Int = 10,
+    from: Int = 0,
+    index: String = defaultIndex,
+    documentType: String = defaultType): Future[RichSearchResponse] =
     elasticClient
       .execute {
-        search(s"$index/$itemType")
+        search(s"$index/$documentType")
           .query(simpleStringQuery(queryString))
           .limit(limit)
           .from(from)
       }
 
 }
-

--- a/api/src/main/scala/uk/ac/wellcome/platform/api/services/ElasticSearchService.scala
+++ b/api/src/main/scala/uk/ac/wellcome/platform/api/services/ElasticSearchService.scala
@@ -15,12 +15,11 @@ import scala.concurrent.Future
 
 @Singleton
 class ElasticSearchService @Inject()(@Flag("es.index") defaultIndex: String,
-                                     @Flag("es.type") defaultType: String,
+                                     @Flag("es.type") documentType: String,
                                      elasticClient: TcpClient) {
 
   def findResultById(id: String,
-                     index: String = defaultIndex,
-                     documentType: String = defaultType): Future[RichGetResponse] =
+                     index: String = defaultIndex): Future[RichGetResponse] =
     elasticClient
       .execute {
         get(id).from(s"$index/$documentType")
@@ -29,8 +28,7 @@ class ElasticSearchService @Inject()(@Flag("es.index") defaultIndex: String,
   def listResults(sortByField: String,
                   limit: Int = 10,
                   from: Int = 0,
-                  index: String = defaultIndex,
-                  documentType: String = defaultType): Future[RichSearchResponse] =
+                  index: String = defaultIndex): Future[RichSearchResponse] =
     elasticClient
       .execute {
         search(s"$index/$documentType")
@@ -44,8 +42,7 @@ class ElasticSearchService @Inject()(@Flag("es.index") defaultIndex: String,
     queryString: String,
     limit: Int = 10,
     from: Int = 0,
-    index: String = defaultIndex,
-    documentType: String = defaultType): Future[RichSearchResponse] =
+    index: String = defaultIndex): Future[RichSearchResponse] =
     elasticClient
       .execute {
         search(s"$index/$documentType")

--- a/api/src/main/scala/uk/ac/wellcome/platform/api/services/ElasticSearchService.scala
+++ b/api/src/main/scala/uk/ac/wellcome/platform/api/services/ElasticSearchService.scala
@@ -18,20 +18,26 @@ class ElasticSearchService @Inject()(@Flag("es.index") defaultIndex: String,
                                      @Flag("es.type") documentType: String,
                                      elasticClient: TcpClient) {
 
+  private def getIndex(queryParam: Option[String]): String =
+    queryParam match {
+      case Some(index) => index
+      case None => defaultIndex
+    }
+
   def findResultById(id: String,
-                     index: String = defaultIndex): Future[RichGetResponse] =
+                     index: Option[String] = None): Future[RichGetResponse] =
     elasticClient
       .execute {
-        get(id).from(s"$index/$documentType")
+        get(id).from(s"${getIndex(index)}/$documentType")
       }
 
   def listResults(sortByField: String,
                   limit: Int = 10,
                   from: Int = 0,
-                  index: String = defaultIndex): Future[RichSearchResponse] =
+                  index: Option[String] = None): Future[RichSearchResponse] =
     elasticClient
       .execute {
-        search(s"$index/$documentType")
+        search(s"${getIndex(index)}/$documentType")
           .matchAllQuery()
           .sortBy(fieldSort(sortByField))
           .limit(limit)
@@ -42,10 +48,10 @@ class ElasticSearchService @Inject()(@Flag("es.index") defaultIndex: String,
     queryString: String,
     limit: Int = 10,
     from: Int = 0,
-    index: String = defaultIndex): Future[RichSearchResponse] =
+    index: Option[String] = None): Future[RichSearchResponse] =
     elasticClient
       .execute {
-        search(s"$index/$documentType")
+        search(s"${getIndex(index)}/$documentType")
           .query(simpleStringQuery(queryString))
           .limit(limit)
           .from(from)

--- a/api/src/main/scala/uk/ac/wellcome/platform/api/services/WorksService.scala
+++ b/api/src/main/scala/uk/ac/wellcome/platform/api/services/WorksService.scala
@@ -15,33 +15,38 @@ class WorksService @Inject()(@Flag("api.pageSize") defaultPageSize: Int,
                              searchService: ElasticSearchService) {
 
   def findWorkById(canonicalId: String,
-                   includes: List[String] = Nil): Future[Option[DisplayWork]] =
+                   includes: List[String] = Nil,
+                   index: Option[String] = None): Future[Option[DisplayWork]] =
     searchService
-      .findResultById(canonicalId)
+      .findResultById(canonicalId, index = index)
       .map { result =>
         if (result.exists) Some(DisplayWork(result.original, includes)) else None
       }
 
   def listWorks(pageSize: Int = defaultPageSize,
                 pageNumber: Int = 1,
-                includes: List[String] = Nil): Future[DisplaySearch] =
+                includes: List[String] = Nil,
+                index: Option[String] = None): Future[DisplaySearch] =
     searchService
       .listResults(
         sortByField = "canonicalId",
         limit = pageSize,
-        from = (pageNumber - 1) * pageSize
+        from = (pageNumber - 1) * pageSize,
+        index = index
       )
       .map { DisplaySearch(_, pageSize, includes) }
 
   def searchWorks(query: String,
                   pageSize: Int = defaultPageSize,
                   pageNumber: Int = 1,
-                  includes: List[String] = Nil): Future[DisplaySearch] =
+                  includes: List[String] = Nil,
+                  index: Option[String] = None): Future[DisplaySearch] =
     searchService
       .simpleStringQueryResults(
         query,
         limit = pageSize,
-        from = (pageNumber - 1) * pageSize
+        from = (pageNumber - 1) * pageSize,
+        index = index
       )
       .map { DisplaySearch(_, pageSize, includes) }
 

--- a/api/src/test/scala/uk/ac/wellcome/platform/api/ApiWorksTest.scala
+++ b/api/src/test/scala/uk/ac/wellcome/platform/api/ApiWorksTest.scala
@@ -485,4 +485,66 @@ class ApiWorksTest
     }
   }
 
+  it(
+    "should be able to search different Elasticsearch indices based on the ?index query parameter") {
+    val work = identifiedWorkWith(
+      canonicalId = "1234",
+      label = "A whale on a wave"
+    )
+    insertIntoElasticSearch(work)
+
+    val work_alt = identifiedWorkWith(
+      canonicalId = "5678",
+      label = "An impostor in an igloo"
+    )
+    insertIntoElasticSearchWithIndex("alt_records", work_alt)
+
+    eventually {
+      server.httpGet(
+        path = s"/$apiPrefix/works?query=whale",
+        andExpect = Status.Ok,
+        withJsonBody = s"""
+                          |{
+                          |  "@context": "https://localhost:8888/$apiPrefix/context.json",
+                          |  "type": "ResultList",
+                          |  "pageSize": 10,
+                          |  "totalPages": 1,
+                          |  "totalResults": 1,
+                          |  "results": [
+                          |   {
+                          |     "type": "Work",
+                          |     "id": "${work.canonicalId}",
+                          |     "label": "${work.work.label}",
+                          |     "creators": [ ]
+                          |   }
+                          |  ]
+                          |}
+          """.stripMargin
+      )
+    }
+
+    eventually {
+      server.httpGet(
+        path = s"/$apiPrefix/works?query=igloo&_index=alt_records",
+        andExpect = Status.Ok,
+        withJsonBody = s"""
+                          |{
+                          |  "@context": "https://localhost:8888/$apiPrefix/context.json",
+                          |  "type": "ResultList",
+                          |  "pageSize": 10,
+                          |  "totalPages": 1,
+                          |  "totalResults": 1,
+                          |  "results": [
+                          |   {
+                          |     "type": "Work",
+                          |     "id": "${work_alt.canonicalId}",
+                          |     "label": "${work_alt.work.label}",
+                          |     "creators": [ ]
+                          |   }
+                          |  ]
+                          |}
+          """.stripMargin
+      )
+    }
+  }
 }


### PR DESCRIPTION
### What is this PR trying to achieve?

Adds an `index` query parameter to API endpoints that allows us to search against a different Elasticsearch index.

Resolves #371.

### Who is this change for?

Developers who want to make Elasticsearch index changes without trashing the prod API.

### Have the following been considered/are they needed?

- [x] Reviewed by @jtweed
- [x] Updated the Swagger documentation – this is deliberately undocumented!
- [ ] Deployed new versions