### PR TITLE
Reduce memory pressure in reindexer by using smaller objects

### DIFF
--- a/common/src/test/scala/uk/ac/wellcome/utils/ScanamoQueryStreamTest.scala
+++ b/common/src/test/scala/uk/ac/wellcome/utils/ScanamoQueryStreamTest.scala
@@ -50,11 +50,12 @@ class ScanamoQueryStreamTest
 
     def updateVersion(resultGroup: ResultGroup): ResultGroup = {
       resultGroups += resultGroup
+
       resultGroup
     }
 
     val ops = ScanamoQueryStream
-      .run[MiroTransformable, Either[DynamoReadError, MiroTransformable]](
+      .run[MiroTransformable, List[Either[DynamoReadError, MiroTransformable]]](
         scanamoQueryRequest,
         updateVersion)
 

--- a/reindexer/src/main/scala/uk/ac/wellcome/platform/reindexer/models/ReindexAttempt.scala
+++ b/reindexer/src/main/scala/uk/ac/wellcome/platform/reindexer/models/ReindexAttempt.scala
@@ -1,7 +1,7 @@
 package uk.ac.wellcome.platform.reindexer.models
 
-import uk.ac.wellcome.models.{Reindex, Reindexable}
+import uk.ac.wellcome.models.Reindex
 
 case class ReindexAttempt(reindex: Reindex,
-                          successful: List[Reindexable[String]] = Nil,
+                          successful: Boolean = false,
                           attempt: Int = 0)

--- a/reindexer/src/main/scala/uk/ac/wellcome/platform/reindexer/services/CalmReindexTargetService.scala
+++ b/reindexer/src/main/scala/uk/ac/wellcome/platform/reindexer/services/CalmReindexTargetService.scala
@@ -4,7 +4,6 @@ import javax.inject.Inject
 
 import com.amazonaws.services.dynamodbv2.AmazonDynamoDB
 import com.gu.scanamo.Scanamo
-import com.gu.scanamo.error.DynamoReadError
 import com.twitter.inject.annotations.Flag
 import uk.ac.wellcome.metrics.MetricsSender
 import uk.ac.wellcome.models.CalmTransformable
@@ -23,5 +22,5 @@ class CalmReindexTargetService @Inject()(
 
   protected val scanamoQueryStreamFunction: ScanamoQueryStreamFunction =
     ScanamoQueryStream
-      .run[CalmTransformable, Either[DynamoReadError, CalmTransformable]]
+      .run[CalmTransformable, Boolean]
 }

--- a/reindexer/src/main/scala/uk/ac/wellcome/platform/reindexer/services/MiroReindexTargetService.scala
+++ b/reindexer/src/main/scala/uk/ac/wellcome/platform/reindexer/services/MiroReindexTargetService.scala
@@ -4,7 +4,6 @@ import javax.inject.Inject
 
 import com.amazonaws.services.dynamodbv2.AmazonDynamoDB
 import com.gu.scanamo.Scanamo
-import com.gu.scanamo.error.DynamoReadError
 import com.twitter.inject.annotations.Flag
 import uk.ac.wellcome.metrics.MetricsSender
 import uk.ac.wellcome.models.MiroTransformable
@@ -23,6 +22,6 @@ class MiroReindexTargetService @Inject()(
 
   protected val scanamoQueryStreamFunction: ScanamoQueryStreamFunction =
     ScanamoQueryStream
-      .run[MiroTransformable, Either[DynamoReadError, MiroTransformable]]
+      .run[MiroTransformable, Boolean]
 
 }

--- a/reindexer/src/main/scala/uk/ac/wellcome/platform/reindexer/services/ReindexService.scala
+++ b/reindexer/src/main/scala/uk/ac/wellcome/platform/reindexer/services/ReindexService.scala
@@ -23,7 +23,7 @@ class ReindexService[T <: Reindexable[String]] @Inject()(
     metricsSender.timeAndCount("reindex-total-time", () => {
       val attempt: Future[Option[ReindexAttempt]] = for {
         indices <- reindexTrackerService.getIndexForReindex
-        attempt = indices.map(ReindexAttempt(_, Nil, 0))
+        attempt = indices.map(ReindexAttempt(_, false, 0))
         _ <- attempt.map(processReindexAttempt).getOrElse(Future.successful((): Unit))
       } yield attempt
 
@@ -37,9 +37,9 @@ class ReindexService[T <: Reindexable[String]] @Inject()(
   private def processReindexAttempt(
     reindexAttempt: ReindexAttempt): Future[ReindexAttempt] =
     reindexAttempt match {
-      case ReindexAttempt(reindex, Nil, attempt) if attempt != 0 => {
+      case ReindexAttempt(reindex, true, attempt) => {
         info(s"Finshed reindexing $reindex successfully.")
-        Future.successful(ReindexAttempt(reindex, Nil, attempt)) // Stop: done!
+        Future.successful(ReindexAttempt(reindex, true, attempt)) // Stop: done!
       }
       case _ => {
         info(s"ReindexService continuing at attempt ${reindexAttempt.attempt}, ")

--- a/reindexer/src/main/scala/uk/ac/wellcome/platform/reindexer/services/ReindexTargetService.scala
+++ b/reindexer/src/main/scala/uk/ac/wellcome/platform/reindexer/services/ReindexTargetService.scala
@@ -22,19 +22,17 @@ abstract class ReindexTargetService[T <: Reindexable[String]](
   targetTableName: String)
     extends Logging {
 
-  import uk.ac.wellcome.utils.ScanamoUtils._
-
   type ScanamoQueryResult = Either[DynamoReadError, T]
 
   type ScanamoUpdate =
     (UniqueKey[_], UpdateExpression) => Either[DynamoReadError, T]
 
   type ScanamoQueryResultFunction =
-    (List[ScanamoQueryResult]) => List[ScanamoQueryResult]
+    (List[ScanamoQueryResult]) => Boolean
 
   type ScanamoQueryStreamFunction = (
     ScanamoQueryRequest,
-    ScanamoQueryResultFunction) => ScanamoOps[List[ScanamoQueryResult]]
+    ScanamoQueryResultFunction) => ScanamoOps[List[Boolean]]
 
   private val gsiName = "ReindexTracker"
 
@@ -43,7 +41,7 @@ abstract class ReindexTargetService[T <: Reindexable[String]](
 
   protected val scanamoQueryStreamFunction: ScanamoQueryStreamFunction
 
-  private def updateVersion(resultGroup: List[ScanamoQueryResult]) = {
+  private def updateVersion(resultGroup: List[ScanamoQueryResult]): Boolean = {
     val updatedResults = resultGroup.map {
       case Left(e) => Left(e)
       case Right(miroTransformable) => {
@@ -54,12 +52,14 @@ abstract class ReindexTargetService[T <: Reindexable[String]](
       }
     }
 
-    if(updatedResults.length > 0) {
+    val performedUpdates = updatedResults.nonEmpty
+
+    if (performedUpdates) {
       info(s"ReindexTargetService completed batch of ${updatedResults.length}")
       ReindexStatus.progress(updatedResults.length, 1)
     }
 
-    updatedResults
+    performedUpdates
   }
 
   private def createScanamoQueryRequest(
@@ -83,11 +83,9 @@ abstract class ReindexTargetService[T <: Reindexable[String]](
 
     val ops = scanamoQueryStreamFunction(scanamoQueryRequest, updateVersion)
 
-    for {
-      result <- Future(Scanamo.exec(dynamoDBClient)(ops))
-      updatedRows = logAndFilterLeft(result)
-    } yield
-      reindexAttempt.copy(successful = updatedRows,
+    Future(Scanamo.exec(dynamoDBClient)(ops)).map(r => {
+      reindexAttempt.copy(successful = !r.contains(false),
                           attempt = reindexAttempt.attempt + 1)
+    })
   }
 }

--- a/reindexer/src/test/scala/uk/ac/wellcome/platform/reindexer/modules/ReindexModuleTest.scala
+++ b/reindexer/src/test/scala/uk/ac/wellcome/platform/reindexer/modules/ReindexModuleTest.scala
@@ -58,11 +58,11 @@ class ReindexModuleTest
     val reindex = Reindex(calmDataTableName, requestedVersion, currentVersion)
     Scanamo.put(dynamoDbClient)(reindexTableName)(reindex)
 
-    when(reindexTargetService.runReindex(ReindexAttempt(reindex, Nil, 0)))
+    when(reindexTargetService.runReindex(ReindexAttempt(reindex, false, 0)))
       .thenReturn(Future.failed(new Exception("boom!")))
       .thenReturn(Future.failed(new Exception("boom!")))
       .thenReturn(Future.failed(new Exception("boom!")))
-      .thenReturn(Future.successful(ReindexAttempt(reindex, Nil, 1)))
+      .thenReturn(Future.successful(ReindexAttempt(reindex, true, 1)))
 
     server.start()
 

--- a/reindexer/src/test/scala/uk/ac/wellcome/platform/reindexer/services/CalmReindexTargetServiceTest.scala
+++ b/reindexer/src/test/scala/uk/ac/wellcome/platform/reindexer/services/CalmReindexTargetServiceTest.scala
@@ -61,10 +61,11 @@ class CalmReindexTargetServiceTest
 
     val reindexTargetService =
       new CalmReindexTargetService(dynamoDbClient, "CalmData", metricsSender)
+
     val reindexAttempt = ReindexAttempt(reindex)
     val expectedReindexAttempt = reindexAttempt.copy(
       reindex = reindex,
-      successful = expectedCalmTransformableList,
+      successful = true,
       attempt = 1
     )
 

--- a/reindexer/src/test/scala/uk/ac/wellcome/platform/reindexer/services/MiroReindexTargetServiceTest.scala
+++ b/reindexer/src/test/scala/uk/ac/wellcome/platform/reindexer/services/MiroReindexTargetServiceTest.scala
@@ -50,7 +50,7 @@ class MiroReindexTargetServiceTest
     val reindexAttempt = ReindexAttempt(reindex)
     val expectedReindexAttempt = reindexAttempt.copy(
       reindex = reindex,
-      successful = expectedMiroTransformableList,
+      successful = true,
       attempt = 1
     )
 

--- a/reindexer/src/test/scala/uk/ac/wellcome/platform/reindexer/services/ReindexServiceTest.scala
+++ b/reindexer/src/test/scala/uk/ac/wellcome/platform/reindexer/services/ReindexServiceTest.scala
@@ -1,7 +1,6 @@
 package uk.ac.wellcome.platform.reindexer.services
 
 import com.amazonaws.services.cloudwatch.AmazonCloudWatch
-import com.amazonaws.services.dynamodbv2.model.PutItemResult
 import com.gu.scanamo.Scanamo
 import com.gu.scanamo.syntax._
 import org.mockito.Mockito._
@@ -99,20 +98,20 @@ class ReindexServiceTest
 
     when(calmReindexTargetService.runReindex(ReindexAttempt(reindex)))
       .thenReturn(
-        Future.successful(ReindexAttempt(reindex, calmTransformableList, 1)))
+        Future.successful(ReindexAttempt(reindex, true, 1)))
 
     (1 to 4).foreach { x =>
       when(
         calmReindexTargetService.runReindex(
-          ReindexAttempt(reindex, calmTransformableList, x)))
+          ReindexAttempt(reindex, true, x)))
         .thenReturn(Future.successful(
-          ReindexAttempt(reindex, calmTransformableList, x + 1)))
+          ReindexAttempt(reindex, false, x + 1)))
     }
 
     when(
       calmReindexTargetService.runReindex(
-        ReindexAttempt(reindex, calmTransformableList, 5)))
-      .thenReturn(Future.successful(ReindexAttempt(reindex, Nil, 6)))
+        ReindexAttempt(reindex, false, 5)))
+      .thenReturn(Future.successful(ReindexAttempt(reindex, true, 6)))
 
     val reindexService = new ReindexService(
       new ReindexTrackerService(


### PR DESCRIPTION
### What is this PR trying to achieve?

Reduce memory pressure in reindexer by using smaller objects

### Who is this change for?

Thrifty developers

### Have the following been considered/are they needed?

- [ ] Deployed new versions
