### PR TITLE
Fine-tuning works.ttl

### DIFF
--- a/ontologies/works.ttl
+++ b/ontologies/works.ttl
@@ -160,13 +160,6 @@ ww:hasFormat rdf:type owl:ObjectProperty ;
 	rdfs:domain ww:Work ;
 	rdfs:range ww:WorkType ;
 	rdf:isDefinedBy <http://www.wellcomecollection.org/ontologies/works> .
-					
-ww:hasShelfmark rdf:type owl:ObjectProperty ;
-	rdfs:label "hasShelfmark"@en ;
-	rdfs:comment "A shelfmark is a code that relates a work to a location within library storage, often but not always relating to a subject-based scheme of library classification and arrangement such as Dewey or Barnard."@en ;
-	rdfs:domain ww:Item ;
-	rdfs:range ww:Shelfmark ;
-	rdf:isDefinedBy <http://www.wellcomecollection.org/ontologies/works> .	
 	
 #######  Data properties #####  
 	


### PR DESCRIPTION
Further tidying-up following #381: removal of hasShelfmark property, since this will now occur in the Items ontology instead.

### What is this PR trying to achieve?
Preparing ground for Items ontology that will follow, by clarifying distinction between Work and Item properties
### Who is this change for?
All platform team
