### PR TITLE
Set reindex version to the value set in ReindexTracker table

### DIFF
--- a/reindexer/src/main/scala/uk/ac/wellcome/platform/reindexer/services/ReindexTargetService.scala
+++ b/reindexer/src/main/scala/uk/ac/wellcome/platform/reindexer/services/ReindexTargetService.scala
@@ -41,7 +41,8 @@ abstract class ReindexTargetService[T <: Reindexable[String]](
 
   protected val scanamoQueryStreamFunction: ScanamoQueryStreamFunction
 
-  private def updateVersion(newReindexVersion: Int, resultGroup: List[ScanamoQueryResult]): Boolean = {
+  private def updateVersion(newReindexVersion: Int,
+                            resultGroup: List[ScanamoQueryResult]): Boolean = {
     val updatedResults = resultGroup.map {
       case Left(e) => Left(e)
       case Right(miroTransformable) => {
@@ -56,7 +57,8 @@ abstract class ReindexTargetService[T <: Reindexable[String]](
 
     if (performedUpdates) {
       info(s"ReindexTargetService completed batch of ${updatedResults.length}")
-      metricsSender.incrementCount("reindex-updated-items", updatedResults.length)
+      metricsSender.incrementCount("reindex-updated-items",
+                                   updatedResults.length)
       ReindexStatus.progress(updatedResults.length, 1)
     }
 
@@ -82,7 +84,9 @@ abstract class ReindexTargetService[T <: Reindexable[String]](
     val scanamoQueryRequest: ScanamoQueryRequest = createScanamoQueryRequest(
       reindexAttempt.reindex.RequestedVersion)
 
-    val ops = scanamoQueryStreamFunction(scanamoQueryRequest, updateVersion(reindexAttempt.reindex.RequestedVersion, _))
+    val ops = scanamoQueryStreamFunction(
+      scanamoQueryRequest,
+      updateVersion(reindexAttempt.reindex.RequestedVersion, _))
 
     Future(Scanamo.exec(dynamoDBClient)(ops)).map(r => {
       reindexAttempt.copy(successful = !r.contains(false),

--- a/reindexer/src/test/scala/uk/ac/wellcome/platform/reindexer/services/MiroReindexTargetServiceTest.scala
+++ b/reindexer/src/test/scala/uk/ac/wellcome/platform/reindexer/services/MiroReindexTargetServiceTest.scala
@@ -21,7 +21,7 @@ class MiroReindexTargetServiceTest
   it("should update the correct index to the requested version") {
 
     val currentVersion = 1
-    val requestedVersion = 2
+    val requestedVersion = 3
 
     val outOfdateMiroTransformableList = List(
       MiroTransformable(
@@ -37,14 +37,11 @@ class MiroReindexTargetServiceTest
         MiroID = "Image2",
         MiroCollection = "Images-A",
         data = s"""{"image_title": "title"}""",
-        ReindexVersion = 2
+        ReindexVersion = requestedVersion
       )
     )
 
     val miroTransformableList = outOfdateMiroTransformableList ++ inDateMiroTransferrableList
-
-    val expectedMiroTransformableList =
-      outOfdateMiroTransformableList.map(_.copy(ReindexVersion = 2))
 
     val reindex = Reindex(miroDataTableName, requestedVersion, currentVersion)
     val reindexAttempt = ReindexAttempt(reindex)
@@ -68,6 +65,11 @@ class MiroReindexTargetServiceTest
     whenReady(reindexTargetService.runReindex(reindexAttempt)) {
       reindexAttempt =>
         reindexAttempt shouldBe expectedReindexAttempt
+        Scanamo
+          .scan[MiroTransformable](dynamoDbClient)(miroDataTableName)
+          .map {
+            case Right(miroTranformable) => miroTranformable.ReindexVersion
+          } should contain only requestedVersion
     }
 
   }


### PR DESCRIPTION
### What is this PR trying to achieve?
avoid multiple runs if there are records that have an older reindex version (possible if we stop the reindexer halfway through)
### Who is this change for?
Devs
### Have the following been considered/are they needed?

<!-- Delete bullets if they don't apply to this patch -->

- [ ] Deployed new versions
