### PR TITLE
Setting up alarms when DLQs are not empty

### DIFF
--- a/terraform/sqs/alarms.tf
+++ b/terraform/sqs/alarms.tf
@@ -1,0 +1,20 @@
+resource "aws_sns_topic" "topic" {
+  name = "${aws_sqs_queue.dlq.name}_alarm"
+}
+
+resource "aws_cloudwatch_metric_alarm" "dlq_not_empty" {
+  alarm_name          = "${aws_sqs_queue.dlq.name}_not_empty"
+  comparison_operator = "GreaterThanThreshold"
+  evaluation_periods  = 1
+  metric_name         = "ApproximateNumberOfMessagesVisible"
+  namespace           = "AWS/SQS"
+  period              = 60
+  threshold           = 0
+  statistic           = "Average"
+
+  dimensions {
+    QueueName = "${aws_sqs_queue.dlq.name}"
+  }
+
+  alarm_actions = ["${aws_sns_topic.topic.arn}"]
+}

--- a/terraform/sqs/sqs.tf
+++ b/terraform/sqs/sqs.tf
@@ -7,18 +7,3 @@ resource "aws_sqs_queue" "q" {
 resource "aws_sqs_queue" "dlq" {
   name = "${var.queue_name}_dlq"
 }
-
-resource "aws_cloudwatch_metric_alarm" "dlq_not_empty" {
-  alarm_name          = "${aws_sqs_queue.dlq.name}_not_empty"
-  comparison_operator = "GreaterThanThreshold"
-  evaluation_periods  = 1
-  metric_name         = "NumberOfMessagesSent"
-  namespace           = "SQS"
-  period              = 60
-  threshold           = 0
-  statistic           = "SampleCount"
-
-  dimensions {
-    QueueName = "${aws_sqs_queue.dlq.name}"
-  }
-}

--- a/terraform/sqs/sqs.tf
+++ b/terraform/sqs/sqs.tf
@@ -9,14 +9,14 @@ resource "aws_sqs_queue" "dlq" {
 }
 
 resource "aws_cloudwatch_metric_alarm" "dlq_not_empty" {
-  alarm_name = "${aws_sqs_queue.dlq.name}_not_empty"
-  comparison_operator = "GreaterThanOrEqualToThreshold"
-  evaluation_periods = 1
-  metric_name = "NumberOfMessagesSent"
-  namespace = "SQS"
-  period = 60
-  threshold = 1
-  statistic = "SampleCount"
+  alarm_name          = "${aws_sqs_queue.dlq.name}_not_empty"
+  comparison_operator = "GreaterThanThreshold"
+  evaluation_periods  = 1
+  metric_name         = "NumberOfMessagesSent"
+  namespace           = "SQS"
+  period              = 60
+  threshold           = 0
+  statistic           = "SampleCount"
 
   dimensions {
     QueueName = "${aws_sqs_queue.dlq.name}"

--- a/terraform/sqs/sqs.tf
+++ b/terraform/sqs/sqs.tf
@@ -7,3 +7,18 @@ resource "aws_sqs_queue" "q" {
 resource "aws_sqs_queue" "dlq" {
   name = "${var.queue_name}_dlq"
 }
+
+resource "aws_cloudwatch_metric_alarm" "dlq_not_empty" {
+  alarm_name = "${aws_sqs_queue.dlq.name}_not_empty"
+  comparison_operator = "GreaterThanOrEqualToThreshold"
+  evaluation_periods = 1
+  metric_name = "NumberOfMessagesSent"
+  namespace = "SQS"
+  period = 60
+  threshold = 1
+  statistic = "SampleCount"
+
+  dimensions {
+    QueueName = "${aws_sqs_queue.dlq.name}"
+  }
+}


### PR DESCRIPTION
### What is this PR trying to achieve?
Be notified when there is stuff in the dlqs
### Who is this change for?
Devs
### Have the following been considered/are they needed?

<!-- Remove this section if you don't have Terraform changes -->
- [x] Run `terraform apply`.
