### PR TITLE
A few Python health fixes

### DIFF
--- a/lambdas/common/dynamo_utils.py
+++ b/lambdas/common/dynamo_utils.py
@@ -1,0 +1,34 @@
+# -*- encoding: utf-8 -*-
+
+import boto3
+
+
+def change_dynamo_capacity(table_name, desired_capacity):
+    client = boto3.client('dynamodb')
+    response = client.describe_table(TableName=table_name)
+    gsi_names = [
+        idx['IndexName'] for idx in response['Table']['GlobalSecondaryIndexes']
+    ]
+    gsi_updates = [
+        {
+            'Update': {
+                'IndexName': index_name,
+                'ProvisionedThroughput': {
+                    'ReadCapacityUnits': desired_capacity,
+                    'WriteCapacityUnits': desired_capacity
+                }
+            }
+        }
+        for index_name in gsi_names
+    ]
+
+    resp = client.update_table(
+        TableName=table_name,
+        ProvisionedThroughput={
+            'ReadCapacityUnits': desired_capacity,
+            'WriteCapacityUnits':desired_capacity
+        },
+        GlobalSecondaryIndexUpdates=gsi_updates
+    )
+    print(f'DynamoDB response: {resp!r}')
+    assert resp['ResponseMetadata']['HTTPStatusCode'] == 200

--- a/lambdas/common/dynamo_utils.py
+++ b/lambdas/common/dynamo_utils.py
@@ -1,5 +1,7 @@
 # -*- encoding: utf-8 -*-
 
+import pprint
+
 import boto3
 
 
@@ -34,5 +36,5 @@ def change_dynamo_capacity(table_name, desired_capacity):
         },
         GlobalSecondaryIndexUpdates=gsi_updates
     )
-    print(f'DynamoDB response: {resp!r}')
+    print(f'DynamoDB response: {pprint.pformat(resp)}')
     assert resp['ResponseMetadata']['HTTPStatusCode'] == 200

--- a/lambdas/common/dynamo_utils.py
+++ b/lambdas/common/dynamo_utils.py
@@ -1,6 +1,13 @@
 # -*- encoding: utf-8 -*-
 
-import pprint
+import pprint{'MessageId': '648b4d2b-1dd1-580c-bdca-1c9f546e2a29',
+ 'ResponseMetadata': {'HTTPHeaders': {'content-length': '294',
+                                      'content-type': 'text/xml',
+                                      'date': 'Fri, 09 Jun 2017 07:00:14 GMT',
+                                      'x-amzn-requestid': '33719136-0980-51f3-81a3-c082403ff3d6'},
+                      'HTTPStatusCode': 200,
+                      'RequestId': '33719136-0980-51f3-81a3-c082403ff3d6',
+                      'RetryAttempts': 0}}
 
 import boto3
 
@@ -36,5 +43,5 @@ def change_dynamo_capacity(table_name, desired_capacity):
         },
         GlobalSecondaryIndexUpdates=gsi_updates
     )
-    print(f'DynamoDB response: {pprint.pformat(resp)}')
+    print(f'DynamoDB response:\n{pprint.pformat(resp)}')
     assert resp['ResponseMetadata']['HTTPStatusCode'] == 200

--- a/lambdas/common/dynamo_utils.py
+++ b/lambdas/common/dynamo_utils.py
@@ -4,6 +4,10 @@ import boto3
 
 
 def change_dynamo_capacity(table_name, desired_capacity):
+    """
+    Given the name of a DynamoDB table and a desired capacity, update the
+    read/write capacity of the table and every secondary index.
+    """
     client = boto3.client('dynamodb')
     response = client.describe_table(TableName=table_name)
     gsi_names = [

--- a/lambdas/common/sns_utils.py
+++ b/lambdas/common/sns_utils.py
@@ -1,6 +1,7 @@
 # -*- encoding: utf-8 -*-
 
 import json
+import pprint
 
 import boto3
 
@@ -18,5 +19,5 @@ def publish_sns_message(topic_arn, message):
             'default': json.dumps(message)
         })
     )
-    print(f'SNS response: {resp!r}')
+    print(f'SNS response: {pprint.pformat(resp)}')
     assert resp['ResponseMetadata']['HTTPStatusCode'] == 200

--- a/lambdas/common/sns_utils.py
+++ b/lambdas/common/sns_utils.py
@@ -19,5 +19,5 @@ def publish_sns_message(topic_arn, message):
             'default': json.dumps(message)
         })
     )
-    print(f'SNS response: {pprint.pformat(resp)}')
+    print(f'SNS response:\n{pprint.pformat(resp)}')
     assert resp['ResponseMetadata']['HTTPStatusCode'] == 200

--- a/lambdas/schedule_reindexer/schedule_reindexer.py
+++ b/lambdas/schedule_reindexer/schedule_reindexer.py
@@ -13,7 +13,7 @@ from sns_utils import publish_sns_message
 
 
 def main(event, _):
-    print(f'Received event: {pprint.pformat(event)}')
+    print(f'Received event:\n{pprint.pformat(event)}')
     new_image = event["Records"][0]["dynamodb"]["NewImage"]
     table_name = new_image["TableName"]["S"]
     current_version = new_image["CurrentVersion"]["N"]

--- a/lambdas/schedule_reindexer/schedule_reindexer.py
+++ b/lambdas/schedule_reindexer/schedule_reindexer.py
@@ -7,12 +7,13 @@ This script is triggered by updates to the reindexer DynamoDB table.
 """
 
 import os
+import pprint
 
 from sns_utils import publish_sns_message
 
 
 def main(event, _):
-    print(f'Received event: {event!r}')
+    print(f'Received event: {pprint.pformat(event)}')
     new_image = event["Records"][0]["dynamodb"]["NewImage"]
     table_name = new_image["TableName"]["S"]
     current_version = new_image["CurrentVersion"]["N"]

--- a/lambdas/service_scheduler/service_scheduler.py
+++ b/lambdas/service_scheduler/service_scheduler.py
@@ -4,13 +4,20 @@
 Publish a service scheduler to SNS.
 
 This script runs on a fixed schedule to send an SNS notification to start
-one of our adapters.
+one of our adapters.  It receives a blob of JSON from a CloudWatch timed
+event, and publishes that to the service scheduler topic.
 """
+
+import pprint
 
 from sns_utils import publish_sns_message
 
 
 def main(event, _):
-    print(f'Received event: {event!r}')
-    message = {'cluster': event['cluster'], 'service': event['service'], 'desired_count': event['desired_count']}
+    print(f'Received event: {pprint.pformat(event)}')
+    message = {
+        'cluster': event['cluster'],
+        'service': event['service'],
+        'desired_count': event['desired_count'],
+    }
     publish_sns_message(topic_arn=event['topic_arn'], message=message)

--- a/lambdas/service_scheduler/service_scheduler.py
+++ b/lambdas/service_scheduler/service_scheduler.py
@@ -14,7 +14,7 @@ from sns_utils import publish_sns_message
 
 
 def main(event, _):
-    print(f'Received event: {pprint.pformat(event)}')
+    print(f'Received event:\n{pprint.pformat(event)}')
     message = {
         'cluster': event['cluster'],
         'service': event['service'],

--- a/lambdas/update_dynamo_capacity/dynamo_utils.py
+++ b/lambdas/update_dynamo_capacity/dynamo_utils.py
@@ -1,0 +1,1 @@
+../common/dynamo_utils.py

--- a/lambdas/update_dynamo_capacity/update_dynamo_capacity.py
+++ b/lambdas/update_dynamo_capacity/update_dynamo_capacity.py
@@ -8,12 +8,13 @@ message should be a JSON string that includes "dynamo_table_name" and "desired_c
 """
 
 import json
+import pprint
 
 from dynamo_utils import change_dynamo_capacity
 
 
 def main(event, _):
-    print(f'Received event: {event!r}')
+    print(f'Received event:\n{pprint.pformat(event)}')
     message = event['Records'][0]['Sns']['Message']
     message_data = json.loads(message)
 

--- a/lambdas/update_dynamo_capacity/update_dynamo_capacity.py
+++ b/lambdas/update_dynamo_capacity/update_dynamo_capacity.py
@@ -9,21 +9,7 @@ message should be a JSON string that includes "dynamo_table_name" and "desired_c
 
 import json
 
-import boto3
-
-
-def change_dynamo_capacity(table_name, desired_capacity):
-    client = boto3.client('dynamodb')
-    response = client.describe_table(TableName=table_name)
-    gsi = [x['IndexName'] for x in response['Table']['GlobalSecondaryIndexes']]
-    gsi_updates = [
-        {'Update': {'IndexName': x, 'ProvisionedThroughput': {'ReadCapacityUnits': desired_capacity, 'WriteCapacityUnits': desired_capacity} }}
-        for x in gsi
-    ]
-
-    resp = client.update_table(TableName=table_name, GlobalSecondaryIndexUpdates=gsi_updates, ProvisionedThroughput={'ReadCapacityUnits':desired_capacity, 'WriteCapacityUnits':desired_capacity} )
-    print(f'DynamoDB response: {resp!r}')
-    assert resp['ResponseMetadata']['HTTPStatusCode'] == 200
+from dynamo_utils import change_dynamo_capacity
 
 
 def main(event, _):

--- a/lambdas/update_ecs_service_size/update_ecs_service_size.py
+++ b/lambdas/update_ecs_service_size/update_ecs_service_size.py
@@ -13,6 +13,7 @@ message should be a JSON string that includes "cluster", "service" and
 """
 
 import json
+import pprint
 
 import boto3
 
@@ -28,12 +29,12 @@ def change_desired_count(cluster, service, desired_count):
         service=service,
         desiredCount=desired_count
     )
-    print(f'ECS response: {resp!r}')
+    print(f'ECS response: {pprint.pformat(resp)}')
     assert resp['ResponseMetadata']['HTTPStatusCode'] == 200
 
 
 def main(event, _):
-    print(f'Received event: {event!r}')
+    print(f'Received event: {pprint.pformat(event)}')
     message = event['Records'][0]['Sns']['Message']
     message_data = json.loads(message)
 

--- a/lambdas/update_ecs_service_size/update_ecs_service_size.py
+++ b/lambdas/update_ecs_service_size/update_ecs_service_size.py
@@ -29,12 +29,12 @@ def change_desired_count(cluster, service, desired_count):
         service=service,
         desiredCount=desired_count
     )
-    print(f'ECS response: {pprint.pformat(resp)}')
+    print(f'ECS response:\n{pprint.pformat(resp)}')
     assert resp['ResponseMetadata']['HTTPStatusCode'] == 200
 
 
 def main(event, _):
-    print(f'Received event: {pprint.pformat(event)}')
+    print(f'Received event:\n{pprint.pformat(event)}')
     message = event['Records'][0]['Sns']['Message']
     message_data = json.loads(message)
 

--- a/lambdas/update_task_for_config_change/update_task_for_config_change.py
+++ b/lambdas/update_task_for_config_change/update_task_for_config_change.py
@@ -42,7 +42,7 @@ def clone_latest_task_definition(client, cluster, service):
         service=service,
         taskDefinition=cloned_task
     )
-    print(f'ECS response: {pprint.pformat(response)}')
+    print(f'ECS response:\n{pprint.pformat(response)}')
     assert response['ResponseMetadata']['HTTPStatusCode'] == 200
 
 
@@ -74,7 +74,7 @@ def parse_s3_event(event):
 
 
 def main(event, _):
-    print(f'Received event: {pprint.pformat(event)}')
+    print(f'Received event:\n{pprint.pformat(event)}')
     app_name = parse_s3_event(event=event)
     trigger_config_update(app_name=app_name)
 

--- a/lambdas/update_task_for_config_change/update_task_for_config_change.py
+++ b/lambdas/update_task_for_config_change/update_task_for_config_change.py
@@ -10,6 +10,7 @@ scheduler will bring up new instances with the updated config.
 
 """
 
+import pprint
 import re
 
 import boto3
@@ -41,7 +42,7 @@ def clone_latest_task_definition(client, cluster, service):
         service=service,
         taskDefinition=cloned_task
     )
-    print(f'ECS response: {response!r}')
+    print(f'ECS response: {pprint.pformat(response)}')
     assert response['ResponseMetadata']['HTTPStatusCode'] == 200
 
 
@@ -73,7 +74,7 @@ def parse_s3_event(event):
 
 
 def main(event, _):
-    print(f'Received event: {event!r}')
+    print(f'Received event: {pprint.pformat(event)}')
     app_name = parse_s3_event(event=event)
     trigger_config_update(app_name=app_name)
 


### PR DESCRIPTION
### What is this PR trying to achieve?

* Slightly better organisation of Python code
* Some linting fixes
* Logs should be easier to read. `pprint` means logs will now look more like:

    ```
    SNS response: {'MessageId': '648b4d2b-1dd1-580c-bdca-1c9f546e2a29', 'ResponseMetadata': {'RequestId': '33719136-0980-51f3-81a3-c082403ff3d6', 'HTTPStatusCode': 200, 'HTTPHeaders': {'x-amzn-requestid': '33719136-0980-51f3-81a3-c082403ff3d6', 'content-type': 'text/xml', 'content-length': '294', 'date': 'Fri, 09 Jun 2017 07:00:14 GMT'}, 'RetryAttempts': 0}}
    ```

    to

    ```
    SNS response:
    {'MessageId': '648b4d2b-1dd1-580c-bdca-1c9f546e2a29',
     'ResponseMetadata': {'HTTPHeaders': {'content-length': '294',
                                          'content-type': 'text/xml',
                                          'date': 'Fri, 09 Jun 2017 07:00:14 GMT',
                                          'x-amzn-requestid': '33719136-0980-51f3-81a3-c082403ff3d6'},
                          'HTTPStatusCode': 200,
                          'RequestId': '33719136-0980-51f3-81a3-c082403ff3d6',
                          'RetryAttempts': 0}}
    ```

### Who is this change for?

Developers who want nicer logs and cleaner code.

### Have the following been considered/are they needed?

- [ ] Deployed new versions
- [ ] Run `terraform apply`.