### PR TITLE
Turn our ?includes query parameter into a typed structure

### DIFF
--- a/api/src/main/scala/uk/ac/wellcome/platform/api/models/DisplaySearch.scala
+++ b/api/src/main/scala/uk/ac/wellcome/platform/api/models/DisplaySearch.scala
@@ -10,7 +10,7 @@ case class DisplaySearch(
   results: Array[DisplayWork]
 )
 case object DisplaySearch {
-  def apply(searchResponse: SearchResponse, pageSize: Int, includes: List[String]): DisplaySearch = {
+  def apply(searchResponse: SearchResponse, pageSize: Int, includes: WorksIncludes): DisplaySearch = {
     DisplaySearch(
       results = searchResponse.hits.hits.map { DisplayWork(_, includes) },
       pageSize = pageSize,

--- a/api/src/main/scala/uk/ac/wellcome/platform/api/models/DisplayWork.scala
+++ b/api/src/main/scala/uk/ac/wellcome/platform/api/models/DisplayWork.scala
@@ -6,6 +6,8 @@ import com.sksamuel.elastic4s.http.get.GetResponse
 import uk.ac.wellcome.models._
 import uk.ac.wellcome.utils.JsonUtil
 
+case class WorksIncludes(identifiers: Boolean = false)
+
 case class DisplayWork(id: String,
                        label: String,
                        description: Option[String] = None,
@@ -18,17 +20,17 @@ case class DisplayWork(id: String,
 
 case object DisplayWork {
 
-  def apply(hit: SearchHit): DisplayWork = apply(hit, includes = List())
+  def apply(hit: SearchHit): DisplayWork = apply(hit, includes = WorksIncludes())
 
-  def apply(hit: SearchHit, includes: List[String]): DisplayWork = {
+  def apply(hit: SearchHit, includes: WorksIncludes): DisplayWork = {
     jsonToDisplayWork(hit.sourceAsString, includes)
   }
 
-  def apply(got: GetResponse, includes: List[String]): DisplayWork = {
+  def apply(got: GetResponse, includes: WorksIncludes): DisplayWork = {
     jsonToDisplayWork(got.sourceAsString, includes)
   }
 
-  private def jsonToDisplayWork(document: String, includes: List[String]) = {
+  private def jsonToDisplayWork(document: String, includes: WorksIncludes) = {
     val identifiedWork =
       JsonUtil.fromJson[IdentifiedWork](document).get
 
@@ -41,7 +43,7 @@ case object DisplayWork {
       // Wrapping this in Option to catch null value from Jackson
       creators = Option(identifiedWork.work.creators).getOrElse(Nil),
       identifiers =
-        if (includes.contains("identifiers"))
+        if (includes.identifiers)
           Some(identifiedWork.work.identifiers.map(DisplayIdentifier(_)))
         else None
     )

--- a/api/src/main/scala/uk/ac/wellcome/platform/api/services/WorksService.scala
+++ b/api/src/main/scala/uk/ac/wellcome/platform/api/services/WorksService.scala
@@ -4,7 +4,7 @@ import javax.inject.{Inject, Singleton}
 
 import com.twitter.inject.Logging
 import com.twitter.inject.annotations.Flag
-import uk.ac.wellcome.platform.api.models.{DisplaySearch, DisplayWork}
+import uk.ac.wellcome.platform.api.models.{DisplaySearch, DisplayWork, WorksIncludes}
 import uk.ac.wellcome.utils.GlobalExecutionContext.context
 
 import scala.concurrent.Future
@@ -14,7 +14,7 @@ class WorksService @Inject()(@Flag("api.pageSize") defaultPageSize: Int,
                              searchService: ElasticSearchService) {
 
   def findWorkById(canonicalId: String,
-                   includes: List[String] = Nil,
+                   includes: WorksIncludes = WorksIncludes(),
                    index: Option[String] = None): Future[Option[DisplayWork]] =
     searchService
       .findResultById(canonicalId, index = index)
@@ -24,7 +24,7 @@ class WorksService @Inject()(@Flag("api.pageSize") defaultPageSize: Int,
 
   def listWorks(pageSize: Int = defaultPageSize,
                 pageNumber: Int = 1,
-                includes: List[String] = Nil,
+                includes: WorksIncludes = WorksIncludes(),
                 index: Option[String] = None): Future[DisplaySearch] =
     searchService
       .listResults(
@@ -38,7 +38,7 @@ class WorksService @Inject()(@Flag("api.pageSize") defaultPageSize: Int,
   def searchWorks(query: String,
                   pageSize: Int = defaultPageSize,
                   pageNumber: Int = 1,
-                  includes: List[String] = Nil,
+                  includes: WorksIncludes = WorksIncludes(),
                   index: Option[String] = None): Future[DisplaySearch] =
     searchService
       .simpleStringQueryResults(

--- a/api/src/test/scala/uk/ac/wellcome/platform/api/services/WorksServiceTest.scala
+++ b/api/src/test/scala/uk/ac/wellcome/platform/api/services/WorksServiceTest.scala
@@ -7,7 +7,8 @@ import uk.ac.wellcome.platform.api.WorksUtil
 import uk.ac.wellcome.platform.api.models.{
   DisplayIdentifier,
   DisplaySearch,
-  DisplayWork
+  DisplayWork,
+  WorksIncludes
 }
 import uk.ac.wellcome.test.utils.IndexedElasticSearchLocal
 
@@ -183,8 +184,10 @@ class WorksServiceTest
                                                      value = miroId)))
     insertIntoElasticSearch(work)
 
-    val getByIdResult =
-      worksService.findWorkById(canonicalId, includes = List("identifiers"))
+    val getByIdResult = worksService.findWorkById(
+      canonicalId,
+      includes = WorksIncludes(identifiers = true)
+    )
 
     whenReady(getByIdResult) { maybeDisplayWork =>
       maybeDisplayWork.isDefined shouldBe true
@@ -213,7 +216,7 @@ class WorksServiceTest
     insertIntoElasticSearch(work)
 
     val listWorksResult =
-      worksService.listWorks(includes = List("identifiers"))
+      worksService.listWorks(includes = WorksIncludes(identifiers = true))
 
     whenReady(listWorksResult) { (displayWork: DisplaySearch) =>
       displayWork.results.head.identifiers.get shouldBe List(
@@ -239,9 +242,10 @@ class WorksServiceTest
                                                      value = miroId)))
     insertIntoElasticSearch(work)
 
-    val searchWorksResult = worksService.searchWorks(query = "snail",
-                                                     includes =
-                                                       List("identifiers"))
+    val searchWorksResult = worksService.searchWorks(
+      query = "snail",
+      includes = WorksIncludes(identifiers = true)
+    )
 
     whenReady(searchWorksResult) { (displayWork: DisplaySearch) =>
       displayWork.results.head.identifiers.get shouldBe List(


### PR DESCRIPTION
This turns it into a series of boolean switches which can be parsed in the WorksController, simplifying the logic in downstream classes. Additionally, this gives us a good point to check whether the includes parameter contains valid values.

A first step towards #407.

### What is this PR trying to achieve?

Tidy up some of our internal logic around ?includes.

### Who is this change for?

Developers who like tidy code. No externally visible changes.

### Have the following been considered/are they needed?

- [ ] Deployed new versions
