### PR TITLE
Throw a 400 Bad Request error if the user asks for undefined includes

### DIFF
--- a/api/src/main/scala/uk/ac/wellcome/platform/api/Server.scala
+++ b/api/src/main/scala/uk/ac/wellcome/platform/api/Server.scala
@@ -14,13 +14,16 @@ import io.swagger.models.Swagger
 import uk.ac.wellcome.finatra.modules._
 import uk.ac.wellcome.platform.api.controllers._
 import uk.ac.wellcome.platform.api.finatra.exceptions.ElasticsearchExceptionMapper
-import uk.ac.wellcome.platform.api.finatra.modules.ElasticSearchServiceModule.ElasticSearchServiceModule.flag
+import uk.ac.wellcome.platform.api.models.WorksIncludesDeserializerModule
 
 object ServerMain extends Server
 object ApiSwagger extends Swagger
 
 object ApiJacksonModule extends FinatraJacksonModule {
   override val propertyNamingStrategy = CamelCasePropertyNamingStrategy
+  override val additionalJacksonModules = Seq(
+    new WorksIncludesDeserializerModule
+  )
 }
 
 class Server extends HttpServer {

--- a/api/src/main/scala/uk/ac/wellcome/platform/api/controllers/WorksController.scala
+++ b/api/src/main/scala/uk/ac/wellcome/platform/api/controllers/WorksController.scala
@@ -41,12 +41,13 @@ object IncludesValidation {
 
   /// Check if the provided ?includes parameters contain fields we recognise.
   def validateIncludes(queryParam: Option[String]): ValidationResult =
-    WorksIncludes.validate(queryParam) match {
-      case Left(_) => Valid
-      case Right(badIncludes) =>
-        badIncludes.length match {
-          case 1 => Invalid(s"includes: '${badIncludes.head}' is not a valid include")
-          case _ => Invalid(s"includes: ${badIncludes.mkString("'", "', '", "'")} are not valid includes")
+    WorksIncludes.create(queryParam) match {
+      case Right(_) => Valid
+      case Left(badIncludes) =>
+        if (badIncludes.length == 1) {
+          Invalid(s"includes: '${badIncludes.head}' is not a valid include")
+        } else {
+          Invalid(s"includes: ${badIncludes.mkString("'", "', '", "'")} are not valid includes")
         }
     }
 }

--- a/api/src/main/scala/uk/ac/wellcome/platform/api/controllers/WorksController.scala
+++ b/api/src/main/scala/uk/ac/wellcome/platform/api/controllers/WorksController.scala
@@ -21,36 +21,13 @@ case class MultipleResultsRequest(
   @RouteParam id: Option[String],
   @QueryParam query: Option[String],
   @QueryParam _index: Option[String]
-) {
-
-  // @MethodValidation
-  // def validateIncludes = IncludesValidation.validateIncludes(includes)
-}
+)
 
 case class SingleWorkRequest(
   @RouteParam id: String,
   @QueryParam includes: Option[WorksIncludes],
   @QueryParam _index: Option[String]
-) {
-
-  // @MethodValidation
-  // def validateIncludes = IncludesValidation.validateIncludes(includes)
-}
-
-object IncludesValidation {
-
-  /// Check if the provided ?includes parameters contain fields we recognise.
-  def validateIncludes(queryParam: Option[String]): ValidationResult =
-    WorksIncludes.create(queryParam) match {
-      case Right(_) => Valid
-      case Left(badIncludes) =>
-        if (badIncludes.length == 1) {
-          Invalid(s"includes: '${badIncludes.head}' is not a valid include")
-        } else {
-          Invalid(s"includes: ${badIncludes.mkString("'", "', '", "'")} are not valid includes")
-        }
-    }
-}
+)
 
 @Singleton
 class WorksController @Inject()(@Flag("api.prefix") apiPrefix: String,

--- a/api/src/main/scala/uk/ac/wellcome/platform/api/controllers/WorksController.scala
+++ b/api/src/main/scala/uk/ac/wellcome/platform/api/controllers/WorksController.scala
@@ -17,24 +17,24 @@ import uk.ac.wellcome.utils.GlobalExecutionContext.context
 case class MultipleResultsRequest(
   @Min(1) @QueryParam page: Int = 1,
   @Min(1) @Max(100) @QueryParam pageSize: Option[Int],
-  @QueryParam includes: Option[String],
+  @QueryParam includes: Option[WorksIncludes],
   @RouteParam id: Option[String],
   @QueryParam query: Option[String],
   @QueryParam _index: Option[String]
 ) {
 
-  @MethodValidation
-  def validateIncludes = IncludesValidation.validateIncludes(includes)
+  // @MethodValidation
+  // def validateIncludes = IncludesValidation.validateIncludes(includes)
 }
 
 case class SingleWorkRequest(
   @RouteParam id: String,
-  @QueryParam includes: Option[String],
+  @QueryParam includes: Option[WorksIncludes],
   @QueryParam _index: Option[String]
 ) {
 
-  @MethodValidation
-  def validateIncludes = IncludesValidation.validateIncludes(includes)
+  // @MethodValidation
+  // def validateIncludes = IncludesValidation.validateIncludes(includes)
 }
 
 object IncludesValidation {
@@ -94,7 +94,7 @@ class WorksController @Inject()(@Flag("api.prefix") apiPrefix: String,
         // in the public docs.
     } { request: MultipleResultsRequest =>
       val pageSize = request.pageSize.getOrElse((defaultPageSize))
-      val includes = WorksIncludes(request.includes)
+      // val includes = WorksIncludes(request.includes)
 
       val works = request.query match {
         case Some(queryString) =>
@@ -102,14 +102,14 @@ class WorksController @Inject()(@Flag("api.prefix") apiPrefix: String,
             queryString,
             pageSize = pageSize,
             pageNumber = request.page,
-            includes = includes,
+            includes = request.includes.getOrElse(WorksIncludes()),
             index = request._index
           )
         case None =>
           worksService.listWorks(
             pageSize = pageSize,
             pageNumber = request.page,
-            includes = includes,
+            includes = request.includes.getOrElse(WorksIncludes()),
             index = request._index
           )
       }
@@ -142,10 +142,10 @@ class WorksController @Inject()(@Flag("api.prefix") apiPrefix: String,
           required = false)
         // Deliberately undocumented: the index flag.  See above.
     } { request: SingleWorkRequest =>
-      val includes = WorksIncludes(request.includes)
+      // val includes = WorksIncludes(request.includes)
       worksService
         .findWorkById(request.id,
-                      includes,
+                      request.includes.getOrElse(WorksIncludes()),
                       index = request._index)
         .map {
           case Some(result) =>

--- a/api/src/main/scala/uk/ac/wellcome/platform/api/controllers/WorksController.scala
+++ b/api/src/main/scala/uk/ac/wellcome/platform/api/controllers/WorksController.scala
@@ -70,7 +70,7 @@ class WorksController @Inject()(@Flag("api.prefix") apiPrefix: String,
         // in the public docs.
     } { request: MultipleResultsRequest =>
       val pageSize = request.pageSize.getOrElse((defaultPageSize))
-      val includes = parseIncludes(request.includes)
+      val includes = WorksIncludes(request.includes)
 
       val works = request.query match {
         case Some(queryString) =>
@@ -118,7 +118,7 @@ class WorksController @Inject()(@Flag("api.prefix") apiPrefix: String,
           required = false)
         // Deliberately undocumented: the index flag.  See above.
     } { request: SingleWorkRequest =>
-      val includes = parseIncludes(request.includes)
+      val includes = WorksIncludes(request.includes)
       worksService
         .findWorkById(request.id,
                       includes,
@@ -131,15 +131,5 @@ class WorksController @Inject()(@Flag("api.prefix") apiPrefix: String,
         }
     }
 
-  }
-
-  /// Parse a comma-separated ?includes query parameter.
-  ///
-  /// TODO: Throw an exception if we get an unrecognised include.
-  private def parseIncludes(includesString: Option[String]): WorksIncludes = {
-    val includesList = includesString.getOrElse("").split(",").toList
-    WorksIncludes(
-      identifiers = includesList.contains("identifiers")
-    )
   }
 }

--- a/api/src/main/scala/uk/ac/wellcome/platform/api/models/DisplayWork.scala
+++ b/api/src/main/scala/uk/ac/wellcome/platform/api/models/DisplayWork.scala
@@ -6,8 +6,6 @@ import com.sksamuel.elastic4s.http.get.GetResponse
 import uk.ac.wellcome.models._
 import uk.ac.wellcome.utils.JsonUtil
 
-case class WorksIncludes(identifiers: Boolean = false)
-
 case class DisplayWork(id: String,
                        label: String,
                        description: Option[String] = None,

--- a/api/src/main/scala/uk/ac/wellcome/platform/api/models/WorksIncludes.scala
+++ b/api/src/main/scala/uk/ac/wellcome/platform/api/models/WorksIncludes.scala
@@ -23,25 +23,25 @@ case object WorksIncludes {
     }
   }
 
-  /// Validate an ?includes query-parameter string.
+  /// Validate and create an ?includes query-parameter string.
   ///
-  /// Specifically, this checks that every element in the query parameter
-  /// is a known include.  Returns a Left if this is true, or a Right
-  /// containing a list of any unrecognised includes.
-  def validate(queryParam: String): Either[Unit, List[String]] = {
+  /// This checks that every element in the query parameter is a known
+  /// include before creating it.
+  def create(queryParam: String): Either[List[String], WorksIncludes] = {
     val includesList = queryParam.split(",").toList
     val unrecognisedIncludes = includesList
       .filterNot(recognisedIncludes.contains)
-    unrecognisedIncludes.length match {
-      case 0 => Left(Unit)
-      case _ => Right(unrecognisedIncludes)
+    if (unrecognisedIncludes.length == 0) {
+      Right(WorksIncludes(queryParam))
+    } else {
+      Left(unrecognisedIncludes)
     }
   }
 
-  def validate(queryParam: Option[String]): Either[Unit, List[String]] = {
+  def create(queryParam: Option[String]): Either[List[String], WorksIncludes] = {
     queryParam match {
-      case Some(s) => validate(s)
-      case None => Left(Unit)
+      case Some(s) => create(s)
+      case None => Right(WorksIncludes())
     }
   }
 }

--- a/api/src/main/scala/uk/ac/wellcome/platform/api/models/WorksIncludes.scala
+++ b/api/src/main/scala/uk/ac/wellcome/platform/api/models/WorksIncludes.scala
@@ -4,12 +4,7 @@ case class WorksIncludes(identifiers: Boolean = false)
 
 case object WorksIncludes {
 
-  def apply(queryParam: Option[String]): WorksIncludes = {
-    queryParam match {
-      case Some(s) => WorksIncludes(s)
-      case None => WorksIncludes()
-    }
-  }
+  val recognisedIncludes = List("identifiers")
 
   /// Parse an ?includes query-parameter string.
   ///
@@ -19,5 +14,34 @@ case object WorksIncludes {
     WorksIncludes(
       identifiers = includesList.contains("identifiers")
     )
+  }
+
+  def apply(queryParam: Option[String]): WorksIncludes = {
+    queryParam match {
+      case Some(s) => WorksIncludes(s)
+      case None => WorksIncludes()
+    }
+  }
+
+  /// Validate an ?includes query-parameter string.
+  ///
+  /// Specifically, this checks that every element in the query parameter
+  /// is a known include.  Returns a Left if this is true, or a Right
+  /// containing a list of any unrecognised includes.
+  def validate(queryParam: String): Either[Unit, List[String]] = {
+    val includesList = queryParam.split(",").toList
+    val unrecognisedIncludes = includesList
+      .filterNot(recognisedIncludes.contains)
+    unrecognisedIncludes.length match {
+      case 0 => Left(Unit)
+      case _ => Right(unrecognisedIncludes)
+    }
+  }
+
+  def validate(queryParam: Option[String]): Either[Unit, List[String]] = {
+    queryParam match {
+      case Some(s) => validate(s)
+      case None => Left(Unit)
+    }
   }
 }

--- a/api/src/main/scala/uk/ac/wellcome/platform/api/models/WorksIncludes.scala
+++ b/api/src/main/scala/uk/ac/wellcome/platform/api/models/WorksIncludes.scala
@@ -1,6 +1,12 @@
 package uk.ac.wellcome.platform.api.models
 
+import com.fasterxml.jackson.core.JsonParser
+import com.fasterxml.jackson.databind.module.SimpleModule
+import com.fasterxml.jackson.databind.{DeserializationContext, JsonDeserializer, JsonMappingException}
+
 case class WorksIncludes(identifiers: Boolean = false)
+
+class IncludesParsingException(msg: String) extends JsonMappingException(msg: String)
 
 case object WorksIncludes {
 
@@ -10,6 +16,7 @@ case object WorksIncludes {
   ///
   /// In this method, any unrecognised includes are simply ignored.
   def apply(queryParam: String): WorksIncludes = {
+    throw new IncludesParsingException("I haz a very sad")
     val includesList = queryParam.split(",").toList
     WorksIncludes(
       identifiers = includesList.contains("identifiers")
@@ -44,4 +51,14 @@ case object WorksIncludes {
       case None => Right(WorksIncludes())
     }
   }
+}
+
+class WorksIncludesDeserializer extends JsonDeserializer[WorksIncludes] {
+  override def deserialize(p: JsonParser, ctxt: DeserializationContext): WorksIncludes = {
+    WorksIncludes(p.getText())
+  }
+}
+
+class WorksIncludesDeserializerModule extends SimpleModule {
+  addDeserializer(classOf[WorksIncludes], new WorksIncludesDeserializer())
 }

--- a/api/src/main/scala/uk/ac/wellcome/platform/api/models/WorksIncludes.scala
+++ b/api/src/main/scala/uk/ac/wellcome/platform/api/models/WorksIncludes.scala
@@ -1,0 +1,23 @@
+package uk.ac.wellcome.platform.api.models
+
+case class WorksIncludes(identifiers: Boolean = false)
+
+case object WorksIncludes {
+
+  def apply(queryParam: Option[String]): WorksIncludes = {
+    queryParam match {
+      case Some(s) => WorksIncludes(s)
+      case None => WorksIncludes()
+    }
+  }
+
+  /// Parse an ?includes query-parameter string.
+  ///
+  /// In this method, any unrecognised includes are simply ignored.
+  def apply(queryParam: String): WorksIncludes = {
+    val includesList = queryParam.split(",").toList
+    WorksIncludes(
+      identifiers = includesList.contains("identifiers")
+    )
+  }
+}

--- a/api/src/main/scala/uk/ac/wellcome/platform/api/models/WorksIncludes.scala
+++ b/api/src/main/scala/uk/ac/wellcome/platform/api/models/WorksIncludes.scala
@@ -6,7 +6,7 @@ import com.fasterxml.jackson.databind.{DeserializationContext, JsonDeserializer,
 
 case class WorksIncludes(identifiers: Boolean = false)
 
-class IncludesParsingException(msg: String) extends JsonMappingException(msg: String)
+class WorksIncludesParsingException(msg: String) extends JsonMappingException(msg: String)
 
 case object WorksIncludes {
 
@@ -14,49 +14,36 @@ case object WorksIncludes {
 
   /// Parse an ?includes query-parameter string.
   ///
-  /// In this method, any unrecognised includes are simply ignored.
+  /// If any unexpected includes are spotted, we raise an
+  /// `WorksIncludesParsingException`.
   def apply(queryParam: String): WorksIncludes = {
-    throw new IncludesParsingException("I haz a very sad")
-    val includesList = queryParam.split(",").toList
-    WorksIncludes(
-      identifiers = includesList.contains("identifiers")
-    )
-  }
-
-  def apply(queryParam: Option[String]): WorksIncludes = {
-    queryParam match {
-      case Some(s) => WorksIncludes(s)
-      case None => WorksIncludes()
-    }
-  }
-
-  /// Validate and create an ?includes query-parameter string.
-  ///
-  /// This checks that every element in the query parameter is a known
-  /// include before creating it.
-  def create(queryParam: String): Either[List[String], WorksIncludes] = {
     val includesList = queryParam.split(",").toList
     val unrecognisedIncludes = includesList
       .filterNot(recognisedIncludes.contains)
     if (unrecognisedIncludes.length == 0) {
-      Right(WorksIncludes(queryParam))
+      WorksIncludes(
+        identifiers = includesList.contains("identifiers")
+      )
     } else {
-      Left(unrecognisedIncludes)
+      val errorMessage = if (unrecognisedIncludes.length == 1) {
+        s"'${unrecognisedIncludes.head}' is not a valid include"
+      } else {
+        s"${unrecognisedIncludes.mkString("'", "', '", "'")} are not valid includes"
+      }
+      throw new WorksIncludesParsingException(errorMessage)
     }
   }
 
-  def create(queryParam: Option[String]): Either[List[String], WorksIncludes] = {
+  def apply(queryParam: Option[String]): WorksIncludes =
     queryParam match {
-      case Some(s) => create(s)
-      case None => Right(WorksIncludes())
+      case Some(s) => WorksIncludes(s)
+      case None => WorksIncludes()
     }
-  }
 }
 
 class WorksIncludesDeserializer extends JsonDeserializer[WorksIncludes] {
-  override def deserialize(p: JsonParser, ctxt: DeserializationContext): WorksIncludes = {
+  override def deserialize(p: JsonParser, ctxt: DeserializationContext): WorksIncludes =
     WorksIncludes(p.getText())
-  }
 }
 
 class WorksIncludesDeserializerModule extends SimpleModule {

--- a/api/src/test/scala/uk/ac/wellcome/platform/api/ApiWorksTest.scala
+++ b/api/src/test/scala/uk/ac/wellcome/platform/api/ApiWorksTest.scala
@@ -277,6 +277,21 @@ class ApiWorksTest
     )
   }
 
+  it("should return multiple errors if there's more than one invalid parameter") {
+    server.httpGet(
+      path = s"/$apiPrefix/works?pageSize=-60&page=-50",
+      andExpect = Status.BadRequest,
+      withJsonBody = s"""
+        |{
+        |  "errors": [
+        |    "page: [-50] is not greater than or equal to 1",
+        |    "pageSize: [-60] is not greater than or equal to 1"
+        |  ]
+        |}
+      """.stripMargin
+    )
+  }
+
   it("should return matching results if doing a full-text search") {
     val work1 = identifiedWorkWith(
       canonicalId = "1234",
@@ -540,6 +555,52 @@ class ApiWorksTest
                           |  ]
                           |}
           """.stripMargin
+      )
+    }
+  }
+
+  it("should return a Bad Request error if asked for an invalid include") {
+    eventually {
+      server.httpGet(
+        path = s"/$apiPrefix/works?includes=foo",
+        andExpect = Status.BadRequest,
+        withJsonBody = """{"errors" : ["includes: 'foo' is not a valid include"]}"""
+      )
+    }
+  }
+
+  it("should return a Bad Request error if asked for more than one invalid include") {
+    eventually {
+      server.httpGet(
+        path = s"/$apiPrefix/works?includes=foo,bar",
+        andExpect = Status.BadRequest,
+        withJsonBody = """{"errors" : ["includes: 'foo', 'bar' are not valid includes"]}"""
+      )
+    }
+  }
+
+  it("should return a Bad Request error if asked for a mixture of valid and invalid includes") {
+    eventually {
+      server.httpGet(
+        path = s"/$apiPrefix/works?includes=foo,identifiers,bar",
+        andExpect = Status.BadRequest,
+        withJsonBody = """{"errors" : ["includes: 'foo', 'bar' are not valid includes"]}"""
+      )
+    }
+  }
+
+  it("should return a Bad Request error if asked for an invalid include on an individual work") {
+    val work = identifiedWorkWith(
+      canonicalId = "1234",
+      label = "A emu and an elephant"
+    )
+    insertIntoElasticSearch(work)
+
+    eventually {
+      server.httpGet(
+        path = s"/$apiPrefix/works/${work.canonicalId}?includes=foo",
+        andExpect = Status.BadRequest,
+        withJsonBody = """{"errors" : ["includes: 'foo' is not a valid include"]}"""
       )
     }
   }

--- a/api/src/test/scala/uk/ac/wellcome/platform/api/models/WorksIncludesTest.scala
+++ b/api/src/test/scala/uk/ac/wellcome/platform/api/models/WorksIncludesTest.scala
@@ -1,0 +1,21 @@
+package uk.ac.wellcome.platform.api.models
+
+import org.scalatest.{FunSpec, Matchers}
+
+class WorksIncludesTest extends FunSpec with Matchers {
+
+  it("should use default values if nothing is provided") {
+    val includes = WorksIncludes(None)
+    includes.identifiers shouldBe false
+  }
+
+  it("should default a missing value to false") {
+    val includes = WorksIncludes("")
+    includes.identifiers shouldBe false
+  }
+
+  it("should parse a present value as true") {
+    val includes = WorksIncludes("identifiers")
+    includes.identifiers shouldBe true
+  }
+}

--- a/api/src/test/scala/uk/ac/wellcome/platform/api/models/WorksIncludesTest.scala
+++ b/api/src/test/scala/uk/ac/wellcome/platform/api/models/WorksIncludesTest.scala
@@ -4,28 +4,19 @@ import org.scalatest.{FunSpec, Matchers}
 
 class WorksIncludesTest extends FunSpec with Matchers {
 
-  it("should default a missing value to false") {
-    val includes = WorksIncludes("")
-    includes.identifiers shouldBe false
-  }
-
   it("should parse a present value as true") {
     val includes = WorksIncludes("identifiers")
     includes.identifiers shouldBe true
   }
 
-  it("should successfully create from a correct string") {
-    val result = WorksIncludes.create(queryParam = "identifiers")
-    result.isRight shouldBe true
-  }
-
   it("should successfully create if no query parameter is provided") {
-    val result = WorksIncludes.create(queryParam = None)
-    result.isRight shouldBe true
+    val includes = WorksIncludes(queryParam = None)
+    includes.identifiers shouldBe false
   }
 
   it("should successfully reject an correct string") {
-    val result = WorksIncludes.create(queryParam = "foo,bar")
-    result shouldBe Left(List("foo", "bar"))
+    intercept[WorksIncludesParsingException] {
+      WorksIncludes(queryParam = "foo,bar")
+    }
   }
 }

--- a/api/src/test/scala/uk/ac/wellcome/platform/api/models/WorksIncludesTest.scala
+++ b/api/src/test/scala/uk/ac/wellcome/platform/api/models/WorksIncludesTest.scala
@@ -4,11 +4,6 @@ import org.scalatest.{FunSpec, Matchers}
 
 class WorksIncludesTest extends FunSpec with Matchers {
 
-  it("should use default values if nothing is provided") {
-    val includes = WorksIncludes(None)
-    includes.identifiers shouldBe false
-  }
-
   it("should default a missing value to false") {
     val includes = WorksIncludes("")
     includes.identifiers shouldBe false
@@ -19,18 +14,18 @@ class WorksIncludesTest extends FunSpec with Matchers {
     includes.identifiers shouldBe true
   }
 
-  it("should successfully validate a correct string") {
-    val result = WorksIncludes.validate(queryParam = "identifiers")
-    result.isLeft shouldBe true
+  it("should successfully create from a correct string") {
+    val result = WorksIncludes.create(queryParam = "identifiers")
+    result.isRight shouldBe true
   }
 
-  it("should successfully validate if no query parameter is provided") {
-    val result = WorksIncludes.validate(queryParam = None)
-    result.isLeft shouldBe true
+  it("should successfully create if no query parameter is provided") {
+    val result = WorksIncludes.create(queryParam = None)
+    result.isRight shouldBe true
   }
 
   it("should successfully reject an correct string") {
-    val result = WorksIncludes.validate(queryParam = "foo,bar")
-    result shouldBe Right(List("foo", "bar"))
+    val result = WorksIncludes.create(queryParam = "foo,bar")
+    result shouldBe Left(List("foo", "bar"))
   }
 }

--- a/api/src/test/scala/uk/ac/wellcome/platform/api/models/WorksIncludesTest.scala
+++ b/api/src/test/scala/uk/ac/wellcome/platform/api/models/WorksIncludesTest.scala
@@ -18,4 +18,19 @@ class WorksIncludesTest extends FunSpec with Matchers {
     val includes = WorksIncludes("identifiers")
     includes.identifiers shouldBe true
   }
+
+  it("should successfully validate a correct string") {
+    val result = WorksIncludes.validate(queryParam = "identifiers")
+    result.isLeft shouldBe true
+  }
+
+  it("should successfully validate if no query parameter is provided") {
+    val result = WorksIncludes.validate(queryParam = None)
+    result.isLeft shouldBe true
+  }
+
+  it("should successfully reject an correct string") {
+    val result = WorksIncludes.validate(queryParam = "foo,bar")
+    result shouldBe Right(List("foo", "bar"))
+  }
 }


### PR DESCRIPTION
### What is this PR trying to achieve?

If a user tries to pass unrecognised `?includes=` parameters to the API, return a 400 Bad Request error and tell them which errors we didn’t like. The error response will look similar to the response returned on invalid pages:

```json
{"errors":["includes: [\"foo\", \"bar\"] are not recognised includes parameters"]}
```

Resolves #411.

### Who is this change for?

Users of the API.

### Have the following been considered/are they needed?

- [ ] Reviewed by @jtweed
- [ ] Deployed new versions
