### PR TITLE
Adding "edition" property to Works

### DIFF
--- a/ontologies/works.ttl
+++ b/ontologies/works.ttl
@@ -355,4 +355,9 @@ ww:wellcomeCollectionSection rdf:type owl:DatatypeProperty ;
 	rdfs:range rdf:langString ; 
 	rdf:isDefinedBy <http://www.wellcomecollection.org/ontologies/works> .
 	
-	
+ww:edition rdf:type owl:DatatypeProperty ;
+	rdfs:label "edition"@en ;
+	rdfs:comment "Where the work described is a published work that has existed in various editions, this specifies the edition (and, if relevant, the impression)."@en ;
+	rdfs:domain ww:Work ;
+	rdfs:range rdf:langString ; 
+	rdf:isDefinedBy <http://www.wellcomecollection.org/ontologies/works> .	


### PR DESCRIPTION
### What is this PR trying to achieve?
Correcting oversight - Works previously had publisher and publication date etc but no way of indicating which of variant editions this data might describe.
### Who is this change for?
Platform team
