### PR TITLE
Adding general note

### DIFF
--- a/ontologies/works.ttl
+++ b/ontologies/works.ttl
@@ -367,4 +367,12 @@ ww:generalNote rdf:type owl:DatatypeProperty ;
 	rdfs:comment "A note of any aspect of this work the cataloguer thought important to record but which does not map to any other more-defined property in this ontology."@en ;
 	rdfs:domain ww:Work ;
 	rdfs:range rdf:langString ; 
+	rdf:isDefinedBy <http://www.wellcomecollection.org/ontologies/works> .
+	
+ww:isbn rdf:type owl:DatatypeProperty ;
+	rdfs:label "isbn"@en ;
+	rdfs:comment "The ISBN / ISSN number of a modern published work."@en ;
+	rdfs:domain ww:Work ;
+	rdfs:range rdf:langString ; 
 	rdf:isDefinedBy <http://www.wellcomecollection.org/ontologies/works> .	
+

--- a/ontologies/works.ttl
+++ b/ontologies/works.ttl
@@ -361,3 +361,10 @@ ww:edition rdf:type owl:DatatypeProperty ;
 	rdfs:domain ww:Work ;
 	rdfs:range rdf:langString ; 
 	rdf:isDefinedBy <http://www.wellcomecollection.org/ontologies/works> .	
+	
+ww:generalNote rdf:type owl:DatatypeProperty ;
+	rdfs:label "generalNote"@en ;
+	rdfs:comment "A note of any aspect of this work the cataloguer thought important to record but which does not map to any other more-defined property in this ontology."@en ;
+	rdfs:domain ww:Work ;
+	rdfs:range rdf:langString ; 
+	rdf:isDefinedBy <http://www.wellcomecollection.org/ontologies/works> .	


### PR DESCRIPTION
### What is this PR trying to achieve?
Both CALM and Sierra have fields for general miscellaneous notes: this adds this concept to the ontology (woolly though it is)
### Who is this change for?
Platform team
