### PR TITLE
Adds cluster view

### DIFF
--- a/dashboard/service-status/src/App.js
+++ b/dashboard/service-status/src/App.js
@@ -1,5 +1,5 @@
 import React, { Component } from 'react';
-import VisibleServiceList from './VisibleServiceList';
+import VisibleClusterList from './VisibleClusterList';
 import VisibleLastUpdated from './VisibleLastUpdated'
 import './App.css';
 
@@ -10,7 +10,7 @@ class App extends Component {
         <div className="App-header">
           <h2>Service Status</h2>
         </div>
-        <VisibleServiceList />
+        <VisibleClusterList />
         <VisibleLastUpdated />
       </div>
     );

--- a/dashboard/service-status/src/ClusterBox.css
+++ b/dashboard/service-status/src/ClusterBox.css
@@ -1,0 +1,19 @@
+.ClusterBox {
+  text-align: center;
+
+  margin-bottom: 20px;
+  background-color: #fff;
+  border: 1px solid transparent;
+  border-radius: 4px;
+  box-shadow: 0 1px 2px rgba(0,0,0,.05);
+  border-color: #ddd;
+
+}
+
+.ClusterBox--Header {
+  background-color: #f5f5f5;
+  padding: 10px 15px;
+  border-bottom: 1px solid transparent;
+  border-top-left-radius: 3px;
+  border-top-right-radius: 3px;
+}

--- a/dashboard/service-status/src/ClusterBox.js
+++ b/dashboard/service-status/src/ClusterBox.js
@@ -1,0 +1,33 @@
+// @flow
+
+import React, { Component } from 'react';
+import type { Services } from './models'
+import ServiceList from './ServiceList'
+import './ClusterBox.css';
+
+class ClusterBox extends Component {
+  props: {
+    clusterName: string,
+    serviceList: Array<Services>
+  }
+
+  render() {
+    return (
+      <div className="ClusterBox">
+        <div className="ClusterBox--Header">
+          {this.props.clusterName}
+        </div>
+        <div className="ClusterBox--Body">
+
+          <ServiceList
+            key={this.props.clusterName}
+            serviceList={this.props.serviceList}
+          />
+
+        </div>
+      </div>
+    );
+  }
+}
+
+export default ClusterBox;

--- a/dashboard/service-status/src/ClusterList.css
+++ b/dashboard/service-status/src/ClusterList.css
@@ -1,0 +1,8 @@
+
+.ClusterList {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  grid-gap: 10px;
+  grid-auto-rows: minmax(100px, auto);
+  margin: 10px
+}

--- a/dashboard/service-status/src/ClusterList.js
+++ b/dashboard/service-status/src/ClusterList.js
@@ -1,0 +1,31 @@
+// @flow
+
+import React, { Component } from 'react';
+import type { ECSStatus } from './models'
+import ClusterBox from './ClusterBox'
+import ErrorBox from './ErrorBox'
+import './ClusterList.css'
+
+class ClusterList extends Component {
+  props: {
+    ecsStatus: ECSStatus,
+    error: ?Error
+  }
+
+  render() {
+      if(this.props.error !== null) {
+        return <ErrorBox error={this.props.error}/>
+      } else {
+        return <div className='ClusterList'>
+          {this.props.ecsStatus.clusterList.map(cluster =>
+            <ClusterBox key={cluster.clusterName}
+            {...cluster}
+            />
+          )}
+        </div>
+    }
+  }
+}
+
+
+export default ClusterList;

--- a/dashboard/service-status/src/ServiceList.js
+++ b/dashboard/service-status/src/ServiceList.js
@@ -1,31 +1,24 @@
 // @flow
 
 import React, { Component } from 'react';
-import type { Services } from './models'
+import type { Service } from './models'
 import ServiceBox from './ServiceBox'
-import ErrorBox from './ErrorBox'
 import './ServiceList.css';
 
 class ServiceList extends Component {
   props: {
-    services: Services,
-    isError: boolean,
-    error: ?Error
+    serviceList: Array<Service>
   }
 
   render() {
-      if(this.props.isError) {
-        return <ErrorBox error={this.props.error}/>
-      } else {
-        return <div className='ServiceList'>
-          {this.props.services.services.map(service =>
+      return <div className='ServiceList'>
+          {this.props.serviceList.map(service =>
             <ServiceBox key={service.serviceName}
             {...service}
             />
           )}
-        </div>
+      </div>
     }
-  }
 }
 
 

--- a/dashboard/service-status/src/Store.js
+++ b/dashboard/service-status/src/Store.js
@@ -1,8 +1,8 @@
 // @flow
 
-import type { Services } from './models'
+import type { ECSStatus } from './models'
 
 export type AppState = {
-  services: Services,
+  ecsStatus: ECSStatus,
   error: ?Error
 }

--- a/dashboard/service-status/src/VisibleClusterList.js
+++ b/dashboard/service-status/src/VisibleClusterList.js
@@ -1,0 +1,21 @@
+// @flow
+
+import { connect } from 'react-redux'
+import ClusterList from './ClusterList'
+
+function getProps(ecsStatus, error) {
+  return {
+    ecsStatus: ecsStatus,
+    error: error
+  };
+}
+
+const mapStateToProps = (state) => {
+  return getProps(state.ecsStatus, state.error)
+}
+
+const VisibleClusterList = connect(
+  mapStateToProps
+)(ClusterList)
+
+export default VisibleClusterList

--- a/dashboard/service-status/src/VisibleLastUpdated.js
+++ b/dashboard/service-status/src/VisibleLastUpdated.js
@@ -8,7 +8,7 @@ function getProps(statePart) {
 }
 
 const mapStateToProps = (state) => {
-  return getProps(state.services);
+  return getProps(state.ecsStatus);
 }
 
 const VisibleLastUpdated = connect(

--- a/dashboard/service-status/src/actions.js
+++ b/dashboard/service-status/src/actions.js
@@ -1,33 +1,33 @@
 // @flow
 
-import type {Services} from './models'
+import type {ECSStatus} from './models'
 import AppConfig from './config'
 
-export type Action  = { type: string, payload: Services, error: ?Error}
+export type Action  = { type: string, payload: ECSStatus, error: ?Error}
 
-function requestServices(): Action {
-  return { type: REQUEST_SERVICES, payload: { services: [] }, error: null };
+function requestStatus(): Action {
+  return { type: REQUEST_SERVICES, payload: { clusterList: [] }, error: null };
 }
 
-function receiveServices(services: Services): Action {
-  return { type: RECEIVE_SERVICES, payload: services, error: null };
+function receiveStatus(ecsStatus: ECSStatus): Action {
+  return { type: RECEIVE_SERVICES, payload: ecsStatus, error: null };
 }
 
-function failedNetwork(reason: Error): Action {
-  return { type: FAILED_NETWORK, payload: { services: [] }, error: reason };
+function failedToGetStatus(reason: Error): Action {
+  return { type: FAILED_RETRIEVAL, payload: { clusterList: [] }, error: reason };
 }
 
 function fetchServices() {
   return (dispatch: Function) => {
-    dispatch(requestServices());
+    dispatch(requestStatus());
     return fetch(AppConfig.serviceListLocation)
       .then(response => response.json())
-      .then(json => dispatch(receiveServices(json)))
-      .catch(reason => dispatch(failedNetwork(reason)));
+      .then(json => dispatch(receiveStatus(json)))
+      .catch(reason => dispatch(failedToGetStatus(reason)));
   }
 }
 
-export const FAILED_NETWORK   = 'FAILED_NETWORK'
+export const FAILED_RETRIEVAL = 'FAILED_RETRIEVAL'
 export const REQUEST_SERVICES = 'REQUEST_SERVICES'
 export const RECEIVE_SERVICES = 'RECEIVE_SERVICES'
 

--- a/dashboard/service-status/src/models.js
+++ b/dashboard/service-status/src/models.js
@@ -1,16 +1,36 @@
 // @flow
 
+export type ECSStatus = {
+  clusterList: Array<Cluster>,
+  lastUpdated: ?Date
+}
+
+export type Cluster = {
+  clusterName: string,
+  instanceCount: number,
+  serviceList: Array<Service>,
+  status: string
+}
+
+export type Deployment = {
+  id: string,
+  taskDefinition: string,
+  status: string
+}
+
+export type Event = {
+  timestamp: number,
+  message: string
+}
+
 export type Service = {
   serviceName: string,
   desiredCount: number,
   pendingCount: number,
   runningCount: number,
+  deployments: Array<Deployment>,
+  events: Array<Event>,
   status: string
-}
-
-export type Services = {
-  services: Array<Service>,
-  lastUpdated: ?Date
 }
 
 export type Config = {

--- a/dashboard/service-status/src/reducers.js
+++ b/dashboard/service-status/src/reducers.js
@@ -1,34 +1,34 @@
 // @flow
 
 import {
-  REQUEST_SERVICES, RECEIVE_SERVICES, FAILED_NETWORK
+  REQUEST_SERVICES, RECEIVE_SERVICES, FAILED_RETRIEVAL
 } from './actions'
 import type { AppState } from './Store'
-import type { Services } from './models'
+import type { ECSStatus } from './models'
 import type { Action } from './actions'
 
 function errorReducer(error: ?Error, action: Action): ?Error {
   switch (action.type) {
-    case FAILED_NETWORK:
+    case FAILED_RETRIEVAL:
       return action.error;
     default:
       return null;
   }
 }
 
-function servicesReducer(services: Services, action: Action): Services {
+function ecsStatusReducer(ecsStatus: ECSStatus, action: Action): ECSStatus {
   switch (action.type) {
     case RECEIVE_SERVICES:
       return action.payload;
     case REQUEST_SERVICES:
     default:
-      return services;
+      return ecsStatus;
   }
 }
 
-function rootReducer(state: AppState = { services: { services: [] }, error: null }, action: Action): AppState {
+function rootReducer(state: AppState = { ecsStatus: { clusterList: [], lastUpdated: null }, error: null }, action: Action): AppState {
   return {
-    services: servicesReducer(state.services, action),
+    ecsStatus: ecsStatusReducer(state.ecsStatus, action),
     error: errorReducer(state.error, action)
   }
 }

--- a/lambdas/common/ecs_utils.py
+++ b/lambdas/common/ecs_utils.py
@@ -116,13 +116,22 @@ def get_service_arns(client, cluster_arn):
 
     return response['serviceArns']
 
+def describe_cluster(ecs_client, cluster_arn):
+    """
+    Given a cluster ARN attempts to find a matching cluster description.
+
+    Returns a cluster description.
+    """
+    response = ecs_client.describe_clusters(clusters = [cluster_arn])
+
+    return response['clusters'][0]
 
 def describe_service(ecs_client, cluster_arn, service_arn):
     """
     Given a cluster ARN and service ARN, attempts to find a matching
     service description.
 
-    Returns a service description or None if none exist.
+    Returns a service description.
     """
     response = ecs_client.describe_services(
         cluster=_name_from_arn(cluster_arn),

--- a/lambdas/update_service_list/update_service_list.py
+++ b/lambdas/update_service_list/update_service_list.py
@@ -67,14 +67,14 @@ def get_cluster_list(ecs_client):
     for cluster_arn in get_cluster_arns(ecs_client):
         cluster = describe_cluster(ecs_client, cluster_arn)
         service_list = get_service_list(ecs_client, cluster_arn)
-        cluster_list = _create_cluster_dict(cluster, service_list)
+        cluster_list.append(_create_cluster_dict(cluster, service_list))
 
     return cluster_list
 
 def send_ecs_status_to_s3(ecs_client, s3_client, bucket_name, object_key):
     cluster_list = get_cluster_list(ecs_client)
     service_snapshot = {
-        'cluster_list': cluster_list,
+        'clusterList': cluster_list,
         'lastUpdated': str(datetime.datetime.utcnow())
     }
 
@@ -90,7 +90,6 @@ def send_ecs_status_to_s3(ecs_client, s3_client, bucket_name, object_key):
 
 
 def main(event, _):
-
     pprint.pprint(event)
 
     ecs_client = boto3.client('ecs')

--- a/terraform/lambdas.tf
+++ b/terraform/lambdas.tf
@@ -7,7 +7,7 @@ module "lambda_update_service_list" {
 
   environment_variables = {
     BUCKET_NAME = "${aws_s3_bucket.dashboard.id}"
-    OBJECT_KEY  = "data/services.json"
+    OBJECT_KEY  = "data/ecs_status.json"
   }
 }
 


### PR DESCRIPTION
### What is this PR trying to achieve?

Display the different clusters ringfencing each service:

![status_clusters](https://user-images.githubusercontent.com/953792/27331379-1b5ba2de-55b5-11e7-9335-0ba44f7843ff.png)

### Who is this change for?

Folks who want more visibility of service status.

### Have the following been considered/are they needed?

- [ ] Deployed new versions

**Depends:** https://github.com/wellcometrust/platform-api/pull/420
