### PR TITLE
Adds Events view

### DIFF
--- a/dashboard/service-status/src/ClusterList.css
+++ b/dashboard/service-status/src/ClusterList.css
@@ -1,7 +1,7 @@
 
 .ClusterList {
   display: grid;
-  grid-template-columns: repeat(3, 1fr);
+  grid-template-columns: repeat(3, 2fr);
   grid-gap: 10px;
   grid-auto-rows: minmax(100px, auto);
   margin: 10px

--- a/dashboard/service-status/src/ServiceBox.css
+++ b/dashboard/service-status/src/ServiceBox.css
@@ -7,7 +7,7 @@
   border-radius: 4px;
   box-shadow: 0 1px 2px rgba(0,0,0,.05);
   border-color: #ddd;
-
+  max-width: 400px;
 }
 
 .ServiceBox--Header {
@@ -60,5 +60,30 @@
   display: grid;
   grid-template-columns: repeat(3, 1fr);
   grid-gap: 10px;
-  grid-auto-rows: minmax(50px, 100px);
+  grid-auto-rows: minmax(50px, 70px);
+}
+
+.EventBox {
+  background-color: #f5f5f5;
+  margin-top: 10px;
+  padding: 3px 3px 3px 5px;
+  border: 1px solid #ddd;
+  border-radius: 4px;
+  height: 100px;
+  position: relative;
+  overflow: hidden;
+}
+
+.EventList {
+  color: #2B8539;
+  font-family: monospace;
+  font-size: x-small;
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  max-width: 100%;
+}
+
+.EventList--Event {
+  text-align: left;
 }

--- a/dashboard/service-status/src/ServiceBox.js
+++ b/dashboard/service-status/src/ServiceBox.js
@@ -2,6 +2,7 @@
 
 import React, { Component } from 'react';
 import TaskCounter from './TaskCounter'
+import type { Event } from './models'
 import './ServiceBox.css'
 
 class ServiceBox extends Component {
@@ -10,6 +11,7 @@ class ServiceBox extends Component {
     desiredCount: number,
     pendingCount: number,
     runningCount: number,
+    events: Array<Event>,
     status: string
   }
 
@@ -28,6 +30,14 @@ class ServiceBox extends Component {
             <TaskCounter type="Pending" count={this.props.pendingCount} shouldBeZero={true}/>
           </div>
           <div className="ServiceBox--Status ">{this.props.status}</div>
+          <div className="EventBox">
+            <div className="EventList">
+              {this.props.events.reverse().map(event => {
+                return <div className="EventList--Event" key={event.timestamp}>&gt; {event.message}</div>
+              })}
+              <div className="EventList--Event">&gt;</div>
+            </div>
+          </div>
         </div>
       </div>
     );

--- a/dashboard/service-status/src/TaskCounter.css
+++ b/dashboard/service-status/src/TaskCounter.css
@@ -17,9 +17,9 @@
 .TaskCounter--Type {
   font-weight: bolder;
   color: rgb(50, 50, 50);
-  padding: 10px 10px 5px 10px;
+  padding: 5px 5px 2px 5px;
 }
 
 .TaskCounter--Count {
-  font-size: 50px;
+  font-size: 30px;
 }

--- a/lambdas/update_service_list/update_service_list.py
+++ b/lambdas/update_service_list/update_service_list.py
@@ -16,6 +16,7 @@ import boto3
 
 from ecs_utils import get_cluster_arns, get_service_arns, describe_service, describe_cluster
 
+
 def _create_event_dict(event):
     return {
         'timestamp': event['createdAt'].timestamp(),


### PR DESCRIPTION
### What is this PR trying to achieve?

More visibility of the cluster status.

![adding events](https://user-images.githubusercontent.com/953792/27340479-80e3d046-55d2-11e7-82bf-668435b0ff56.png)


### Who is this change for?

Folks who want visibility of service status.

### Have the following been considered/are they needed?

- [ ] Deployed new versions
