### PR TITLE
Adds DescribeCluster permission for dashboard lambda

### DIFF
--- a/terraform/iam_policy_document.tf
+++ b/terraform/iam_policy_document.tf
@@ -138,6 +138,7 @@ data "aws_iam_policy_document" "describe_services" {
   statement {
     actions = [
       "ecs:DescribeServices",
+      "ecs:DescribeClusters",
       "ecs:DescribeTaskDefinition",
       "ecs:ListClusters",
       "ecs:ListServices",


### PR DESCRIPTION
Adds permissions for dashboard lambda to read cluster info.

- [x] Run `terraform apply`.
