### PR TITLE
Fix the Docker build on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,9 @@ language: scala
 
 sudo: required
 
+services:
+  - docker
+
 dist: trusty
 
 branches:

--- a/.travis/install.sh
+++ b/.travis/install.sh
@@ -8,14 +8,5 @@ set -o verbose
 # See https://github.com/travis-ci/travis-ci/issues/6534
 sudo sysctl -w vm.max_map_count=262144
 
-# Install Docker on Travis.  Merely exposing Docker through the Travis
-# settings is insufficient, because the docker-compose tests we use are
-# unable to see it in that case.
-curl -sSL "https://get.docker.com/gpg" | sudo -E apt-key add -
-echo "deb https://apt.dockerproject.org/repo ubuntu-trusty main" | sudo tee -a /etc/apt/sources.list
-sudo apt-get update
-sudo apt-get -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" --assume-yes install docker-engine
-docker version
-
 # Install the AWS tools so we can log in to ECR
 pip install --upgrade --user awscli

--- a/scripts/should_rerun_tests.py
+++ b/scripts/should_rerun_tests.py
@@ -33,6 +33,10 @@ def should_retest_project(changed_files, project):
         print("*** Changes to the test runner mean we should retest")
         return True
 
+    elif any(f.startswith('.travis') for f in changed_files):
+        print("*** Changes to the Travis config mean we should rerun")
+        return True
+
     else:
         return False
 


### PR DESCRIPTION
### What is this PR trying to achieve?

At some point, our build step to install Docker on Travis stopped working. This is blocking #443, and will start breaking any build which touches the core application code. This needs fixing for builds to work. First try: do we still need that custom Docker install code?

(We haven’t touched application code in a week, so we haven’t been hitting this code path.)

### Who is this change for?

Developers who like working builds.