### PR TITLE
Lambda to tag EC2 instances & ECS cluster and container instance id

### DIFF
--- a/lambdas/ecs_ec2_instance_tagger/ecs_ec2_instance_tagger.py
+++ b/lambdas/ecs_ec2_instance_tagger/ecs_ec2_instance_tagger.py
@@ -1,0 +1,55 @@
+#!/usr/bin/env python
+# -*- encoding: utf-8 -*-
+"""
+Tag EC2 instances with their cluster ARN and container instance ARN.
+This allows us to easily follow an instance back to its ECS cluster.
+
+This script is triggered by an ECS Container Instance State Change event.
+
+Requires a Cloudwatch Event with pattern:
+
+{
+  "source": [
+    "aws.ecs"
+  ],
+  "detail-type": [
+    "ECS Container Instance State Change"
+  ]
+}
+
+"""
+
+import pprint
+
+import boto3
+
+
+def create_tags(ec2_client, ec2_instance_id, event_detail):
+    """
+    Given an EC2 Instance ID, and event['detail'] from an ECS Container
+    Instance State Change, updates EC2 Instance tags with clusterArn &
+    containerInstanceArn
+
+    Returns the SDK response to the create_tags call.
+    """
+    return ec2_client.create_tags(
+        Resources=[ec2_instance_id],
+        Tags=[{
+            "Key": "clusterArn",
+            "Value": event_detail['clusterArn']
+        },{
+            "Key": "containerInstanceArn",
+            "Value": event_detail['containerInstanceArn']
+        }]
+    )
+
+
+def main(event, _):
+    pprint.pprint(event)
+    ec2_client = boto3.client('ec2')
+
+    ec2_instance_id = event['detail']['ec2InstanceId']
+
+    response = create_tags(ec2_client, ec2_instance_id, event['detail'])
+
+    pprint.pprint(response)

--- a/terraform/cloudwatch.tf
+++ b/terraform/cloudwatch.tf
@@ -19,3 +19,20 @@ resource "aws_cloudwatch_event_rule" "ecs_task_state_change" {
 }
 PATTERN
 }
+
+resource "aws_cloudwatch_event_rule" "ecs_container_instance_state_change" {
+  name        = "ecs_container_instance_state_change"
+  description = "Capture any ECS Container Instance state change"
+
+  event_pattern = <<PATTERN
+{
+  "source": [
+    "aws.ecs"
+  ],
+  "detail-type": [
+    "ECS Container Instance State Change"
+  ]
+}
+PATTERN
+}
+

--- a/terraform/iam_policy_document.tf
+++ b/terraform/iam_policy_document.tf
@@ -222,3 +222,18 @@ data "aws_iam_policy_document" "s3_put_dashboard_status" {
     ]
   }
 }
+
+data "aws_iam_policy_document" "write_ec2_tags" {
+  statement {
+    actions = [
+      "tag:addResourceTags",
+      "tag:removeResourceTags",
+      "tag:tagResources",
+      "tag:untagResources",
+    ]
+
+    resources = [
+      "arn:aws:ec2:*",
+    ]
+  }
+}

--- a/terraform/iam_role_policy.tf
+++ b/terraform/iam_role_policy.tf
@@ -123,6 +123,13 @@ resource "aws_iam_role_policy" "update_service_list_push_to_s3" {
   policy = "${data.aws_iam_policy_document.s3_put_dashboard_status.json}"
 }
 
+# Role policies for ecs_ec2_instance_tagger lambda
+
+resource "aws_iam_role_policy" "ecs_ec2_instance_tagger_thing" {
+  role   = "${module.lambda_ecs_ec2_instance_tagger.role_name}"
+  policy = "${data.aws_iam_policy_document.write_ec2_tags.json}"
+}
+
 # Role policies for the miro_reindexer service
 
 resource "aws_iam_role_policy" "reindexer_tracker_table" {

--- a/terraform/lambdas.tf
+++ b/terraform/lambdas.tf
@@ -1,3 +1,19 @@
+# Lambda for tagging EC2 instances with ECS cluster/container instance id
+module "lambda_ecs_ec2_instance_tagger" {
+  source      = "./lambda"
+  name        = "ecs_ec2_instance_tagger"
+  description = "Tag an EC2 instances with ECS cluster/container instance id"
+  source_dir  = "../lambdas/ecs_ec2_instance_tagger"
+}
+
+module "trigger_ecs_ec2_instance_tagger" {
+  source                  = "./lambda/trigger_cloudwatch"
+  lambda_function_name    = "${module.lambda_ecs_ec2_instance_tagger.function_name}"
+  lambda_function_arn     = "${module.lambda_ecs_ec2_instance_tagger.arn}"
+  cloudwatch_trigger_arn  = "${aws_cloudwatch_event_rule.ecs_container_instance_state_change.arn}"
+  cloudwatch_trigger_name = "${aws_cloudwatch_event_rule.ecs_container_instance_state_change.name}"
+}
+
 # Lambda for publishing ECS service status summary to S3
 module "lambda_update_service_list" {
   source      = "./lambda"


### PR DESCRIPTION
### What is this PR trying to achieve?

Simpler identification of EC2 instance participation in an ECS cluster.

### Who is this change for?

Developers who want simpler logic when mapping EC2 instances to ECS containers

### Have the following been considered/are they needed?

- [ ] Run `terraform apply`.
