### PR TITLE
Pass correct event to EC2 ECS tagging lambda

### DIFF
--- a/lambdas/ecs_ec2_instance_tagger/ecs_ec2_instance_tagger.py
+++ b/lambdas/ecs_ec2_instance_tagger/ecs_ec2_instance_tagger.py
@@ -45,11 +45,13 @@ def create_tags(ec2_client, ec2_instance_id, event_detail):
 
 
 def main(event, _):
-    pprint.pprint(event)
+    print(f'Received event:\n{pprint.pformat(event)}')
+
     ec2_client = boto3.client('ec2')
 
     ec2_instance_id = event['detail']['ec2InstanceId']
 
     response = create_tags(ec2_client, ec2_instance_id, event['detail'])
 
-    pprint.pprint(response)
+    print(f'Received response:\n{pprint.pformat(response)}')
+

--- a/terraform/lambda/trigger_cloudwatch/cloudwatch.tf
+++ b/terraform/lambda/trigger_cloudwatch/cloudwatch.tf
@@ -10,7 +10,7 @@ resource "aws_lambda_permission" "allow_cloudwatch_trigger" {
 
 # The count here is substituting for the availability of an if statement in terraform
 # See https://blog.gruntwork.io/terraform-tips-tricks-loops-if-statements-and-gotchas-f739bbae55f9
-resource "aws_cloudwatch_event_target" "event_trigger" {
+resource "aws_cloudwatch_event_target" "event_trigger_custom" {
   count = "${var.custom_input}"
 
   rule  = "${var.cloudwatch_trigger_name}"

--- a/terraform/lambda/trigger_cloudwatch/cloudwatch.tf
+++ b/terraform/lambda/trigger_cloudwatch/cloudwatch.tf
@@ -8,6 +8,8 @@ resource "aws_lambda_permission" "allow_cloudwatch_trigger" {
   source_arn    = "${var.cloudwatch_trigger_arn}"
 }
 
+# The count here is substituting for the availability of an if statement in terraform
+# See https://blog.gruntwork.io/terraform-tips-tricks-loops-if-statements-and-gotchas-f739bbae55f9
 resource "aws_cloudwatch_event_target" "event_trigger" {
   count = "${var.custom_input}"
 

--- a/terraform/lambda/trigger_cloudwatch/cloudwatch.tf
+++ b/terraform/lambda/trigger_cloudwatch/cloudwatch.tf
@@ -9,7 +9,16 @@ resource "aws_lambda_permission" "allow_cloudwatch_trigger" {
 }
 
 resource "aws_cloudwatch_event_target" "event_trigger" {
+  count = "${var.custom_input}"
+
   rule  = "${var.cloudwatch_trigger_name}"
   arn   = "${var.lambda_function_arn}"
   input = "${var.input}"
+}
+
+resource "aws_cloudwatch_event_target" "event_trigger" {
+  count = "${1 - var.custom_input}"
+
+  rule  = "${var.cloudwatch_trigger_name}"
+  arn   = "${var.lambda_function_arn}"
 }

--- a/terraform/lambda/trigger_cloudwatch/variables.tf
+++ b/terraform/lambda/trigger_cloudwatch/variables.tf
@@ -18,3 +18,8 @@ variable "input" {
   description = "Input to the Cloudwatch trigger"
   default     = "{}"
 }
+
+variable "custom_input" {
+  description = "Use custom input or match event"
+  default = true
+}

--- a/terraform/lambdas.tf
+++ b/terraform/lambdas.tf
@@ -2,7 +2,7 @@
 module "lambda_ecs_ec2_instance_tagger" {
   source      = "./lambda"
   name        = "ecs_ec2_instance_tagger"
-  description = "Tag an EC2 instances with ECS cluster/container instance id"
+  description = "Tag an EC2 instance with ECS cluster/container instance id"
   source_dir  = "../lambdas/ecs_ec2_instance_tagger"
 }
 
@@ -12,6 +12,7 @@ module "trigger_ecs_ec2_instance_tagger" {
   lambda_function_arn     = "${module.lambda_ecs_ec2_instance_tagger.arn}"
   cloudwatch_trigger_arn  = "${aws_cloudwatch_event_rule.ecs_container_instance_state_change.arn}"
   cloudwatch_trigger_name = "${aws_cloudwatch_event_rule.ecs_container_instance_state_change.name}"
+  custom_input            = false
 }
 
 # Lambda for publishing ECS service status summary to S3


### PR DESCRIPTION
Currently the tagging lambda gets passed an empty event, this is because our "cloudwatch_trigger" in Terraform is set up to do that by default.

In order to implement a simple `if` statement ... well just look.

- [x] Run `terraform apply`.
