### PR TITLE
Add a user with readonly permissions for the Miro images bucket

### DIFF
--- a/terraform/iam_policy_document.tf
+++ b/terraform/iam_policy_document.tf
@@ -223,6 +223,19 @@ data "aws_iam_policy_document" "s3_put_dashboard_status" {
   }
 }
 
+data "aws_iam_policy_document" "s3_read_miro_images" {
+	statement {
+		actions = [
+			"s3:Get*",
+			"s3:List*",
+		]
+
+		resources = [
+			"${aws_s3_bucket.miro_images_public.arn}",
+		]
+	}
+}
+
 data "aws_iam_policy_document" "write_ec2_tags" {
   statement {
     actions = [

--- a/terraform/iam_users.tf
+++ b/terraform/iam_users.tf
@@ -25,3 +25,19 @@ resource "aws_iam_user_policy" "miro_images_sync" {
   user   = "${aws_iam_user.miro_images_sync.name}"
   policy = "${data.aws_iam_policy_document.miro_images_sync.json}"
 }
+
+# User that provides read-only access to the Miro images bucket.
+# This is for temporary use by the Experience team in their Imgix instance
+# until we make the images available properly.
+resource "aws_iam_user" "miro_images_readonly" {
+	name = "miro_images_readonly"
+}
+
+resource "aws_iam_access_key" "miro_images_readonly" {
+	user = "${aws_iam_user.miro_images_readonly.name}"
+}
+
+resource "aws_iam_user_policy" "miro_images_readonly" {
+	user = "${aws_iam_user.miro_images_readonly.name}"
+	policy = "${data.aws_iam_policy_document.s3_read_miro_images.json}"
+}

--- a/terraform/outputs.tf
+++ b/terraform/outputs.tf
@@ -1,3 +1,11 @@
 output "ecr_nginx" {
   value = "${aws_ecr_repository.nginx.repository_url}"
 }
+
+output "miro_readonly_key_id" {
+	value = "${aws_iam_access_key.miro_images_readonly.id}"
+}
+
+output "miro_readonly_key_secret" {
+	value = "${aws_iam_access_key.miro_images_readonly.secret}"
+}


### PR DESCRIPTION
### What is this PR trying to achieve?

Add a read-only Miro user for the experience team’s imgix installation

### Who is this change for?

The experience team.

### Have the following been considered/are they needed?

- [ ] Run `terraform apply`.
