### PR TITLE
Adds pagination links to the API results where appropriate

### DIFF
--- a/api/src/main/scala/uk/ac/wellcome/platform/api/requests/Requests.scala
+++ b/api/src/main/scala/uk/ac/wellcome/platform/api/requests/Requests.scala
@@ -1,0 +1,27 @@
+package uk.ac.wellcome.platform.api.requests
+
+import com.twitter.finagle.http.Request
+import com.twitter.finatra.request.{QueryParam, RouteParam}
+import com.twitter.finatra.validation.{Max, Min}
+import uk.ac.wellcome.platform.api.models.WorksIncludes
+
+sealed trait ApiRequest {
+  val request: Request
+}
+
+case class MultipleResultsRequest(
+                                   @Min(1) @QueryParam page: Int = 1,
+                                   @Min(1) @Max(100) @QueryParam pageSize: Option[Int],
+                                   @QueryParam includes: Option[WorksIncludes],
+                                   @RouteParam id: Option[String],
+                                   @QueryParam query: Option[String],
+                                   @QueryParam _index: Option[String],
+                                   request: Request
+                                 ) extends ApiRequest
+
+case class SingleWorkRequest(
+                              @RouteParam id: String,
+                              @QueryParam includes: Option[WorksIncludes],
+                              @QueryParam _index: Option[String],
+                              request: Request
+                            ) extends ApiRequest

--- a/api/src/main/scala/uk/ac/wellcome/platform/api/responses/Responses.scala
+++ b/api/src/main/scala/uk/ac/wellcome/platform/api/responses/Responses.scala
@@ -18,8 +18,8 @@ case class ResultListResponse(
   totalPages: Int = 10,
   totalResults: Int = 100,
   results: Array[_ <: Any],
-  prev: Option[String] = None,
-  next: Option[String] = None
+  prevPage: Option[String] = None,
+  nextPage: Option[String] = None
 ) {
   @JsonProperty("type") val ontologyType: String = "ResultList"
 }
@@ -61,8 +61,8 @@ object ResultListResponse {
       pageSize = displaySearch.pageSize,
       totalPages = displaySearch.totalPages,
       totalResults = displaySearch.totalResults,
-      prev = prevLink,
-      next = nextLink
+      prevPage = prevLink,
+      nextPage = nextLink
     )
   }
 }

--- a/api/src/main/scala/uk/ac/wellcome/platform/api/responses/Responses.scala
+++ b/api/src/main/scala/uk/ac/wellcome/platform/api/responses/Responses.scala
@@ -1,6 +1,10 @@
 package uk.ac.wellcome.platform.api.responses
 
 import com.fasterxml.jackson.annotation.{JsonProperty, JsonUnwrapped}
+import com.twitter.finagle.http.ParamMap
+import uk.ac.wellcome.platform.api.requests.{ApiRequest, MultipleResultsRequest}
+import uk.ac.wellcome.platform.api.models.DisplaySearch
+
 import scala.language.existentials
 
 
@@ -14,7 +18,64 @@ case class ResultListResponse(
   pageSize: Int = 10,
   totalPages: Int = 10,
   totalResults: Int = 100,
-  results: Array[_ <: Any]
+  results: Array[_ <: Any],
+  prev: Option[String] = None,
+  next: Option[String] = None
 ) {
   @JsonProperty("type") val ontologyType: String = "ResultList"
+}
+
+object ResultListResponse {
+
+  private def getParamMapFromCustomCCRequestParams(cc: ApiRequest): ParamMap =
+    ParamMap((Map[String, String]() /: cc.getClass.getDeclaredFields) {(a, f) =>
+      f.setAccessible(true)
+
+      if(f.getName != "request") {
+        f.get(cc) match {
+          case None => a
+          case Some(o) => a + (f.getName -> o.toString)
+          case o => a + (f.getName -> o.toString)
+        }
+      } else {
+        a
+      }
+    })
+
+  private def apiLink(
+                       requestBaseUri: String,
+                       apiRequest: ApiRequest
+                     ): String = {
+
+    val customRequestParamMap = getParamMapFromCustomCCRequestParams(apiRequest)
+    s"${requestBaseUri}${apiRequest.request.path}${customRequestParamMap.toString()}"
+  }
+
+  def create(
+              contextUri: String,
+              displaySearch: DisplaySearch,
+              multipleResultsRequest: MultipleResultsRequest,
+              requestBaseUri: String
+            ): ResultListResponse = {
+
+    val isLastPage = displaySearch.totalPages == multipleResultsRequest.page
+    val isFirstPage = multipleResultsRequest.page == 1
+    val isOnlyPage = displaySearch.totalPages <= 1
+
+    val prevPageRequest = multipleResultsRequest.copy(page = multipleResultsRequest.page - 1)
+    val nextPageRequest = multipleResultsRequest.copy(page = multipleResultsRequest.page + 1)
+
+    val prevLink = if(!isFirstPage && !isOnlyPage) Some(apiLink(requestBaseUri, prevPageRequest)) else None
+    val nextLink = if(!isLastPage && !isOnlyPage) Some(apiLink(requestBaseUri, nextPageRequest)) else None
+
+    ResultListResponse(
+      context = contextUri,
+      results = displaySearch.results,
+      pageSize = displaySearch.pageSize,
+      totalPages = displaySearch.totalPages,
+      totalResults = displaySearch.totalResults,
+      prev = prevLink,
+      next = nextLink
+    )
+  }
 }

--- a/api/src/test/scala/uk/ac/wellcome/platform/api/ApiWorksTest.scala
+++ b/api/src/test/scala/uk/ac/wellcome/platform/api/ApiWorksTest.scala
@@ -145,10 +145,11 @@ class ApiWorksTest
   }
 
   it(
-    "should return the requested page of results when requested with page & pageSize") {
+    "should return the requested page of results when requested with page & pageSize, alongside correct next/prev links ") {
     val works = createIdentifiedWorks(3)
 
     insertIntoElasticSearch(works: _*)
+
     eventually {
       server.httpGet(
         path = s"/$apiPrefix/works?page=2&pageSize=1",
@@ -160,6 +161,8 @@ class ApiWorksTest
                           |  "pageSize": 1,
                           |  "totalPages": 3,
                           |  "totalResults": 3,
+                          |  "prev": "https://localhost:8888/$apiPrefix/works?page=1&pageSize=1",
+                          |  "next": "https://localhost:8888/$apiPrefix/works?page=3&pageSize=1",
                           |  "results": [
                           |   {
                           |     "type": "Work",
@@ -174,6 +177,72 @@ class ApiWorksTest
                           |     "creators": [{
                           |       "type": "Agent",
                           |       "label": "${works(1).work.creators(0).label}"
+                          |     }]
+                          |   }]
+                          |   }
+                          |  ]
+                          |}
+          """.stripMargin
+      )
+
+      server.httpGet(
+        path = s"/$apiPrefix/works?page=1&pageSize=1",
+        andExpect = Status.Ok,
+        withJsonBody = s"""
+                          |{
+                          |  "@context": "https://localhost:8888/$apiPrefix/context.json",
+                          |  "type": "ResultList",
+                          |  "pageSize": 1,
+                          |  "totalPages": 3,
+                          |  "totalResults": 3,
+                          |  "next": "https://localhost:8888/$apiPrefix/works?page=2&pageSize=1",
+                          |  "results": [
+                          |   {
+                          |     "type": "Work",
+                          |     "id": "${works(0).canonicalId}",
+                          |     "label": "${works(0).work.label}",
+                          |     "description": "${works(0).work.description.get}",
+                          |     "lettering": "${works(0).work.lettering.get}",
+                          |     "createdDate": {
+                          |       "type": "Period",
+                          |       "label": "${works(0).work.createdDate.get.label}"
+                          |     },
+                          |     "creators": [{
+                          |       "type": "Agent",
+                          |       "label": "${works(0).work.creators(0).label}"
+                          |     }]
+                          |   }]
+                          |   }
+                          |  ]
+                          |}
+          """.stripMargin
+      )
+
+      server.httpGet(
+        path = s"/$apiPrefix/works?page=3&pageSize=1",
+        andExpect = Status.Ok,
+        withJsonBody = s"""
+                          |{
+                          |  "@context": "https://localhost:8888/$apiPrefix/context.json",
+                          |  "type": "ResultList",
+                          |  "pageSize": 1,
+                          |  "totalPages": 3,
+                          |  "totalResults": 3,
+                          |  "prev": "https://localhost:8888/$apiPrefix/works?page=2&pageSize=1",
+                          |  "results": [
+                          |   {
+                          |     "type": "Work",
+                          |     "id": "${works(2).canonicalId}",
+                          |     "label": "${works(2).work.label}",
+                          |     "description": "${works(2).work.description.get}",
+                          |     "lettering": "${works(2).work.lettering.get}",
+                          |     "createdDate": {
+                          |       "type": "Period",
+                          |       "label": "${works(2).work.createdDate.get.label}"
+                          |     },
+                          |     "creators": [{
+                          |       "type": "Agent",
+                          |       "label": "${works(2).work.creators(0).label}"
                           |     }]
                           |   }]
                           |   }

--- a/api/src/test/scala/uk/ac/wellcome/platform/api/ApiWorksTest.scala
+++ b/api/src/test/scala/uk/ac/wellcome/platform/api/ApiWorksTest.scala
@@ -161,8 +161,8 @@ class ApiWorksTest
                           |  "pageSize": 1,
                           |  "totalPages": 3,
                           |  "totalResults": 3,
-                          |  "prev": "https://localhost:8888/$apiPrefix/works?page=1&pageSize=1",
-                          |  "next": "https://localhost:8888/$apiPrefix/works?page=3&pageSize=1",
+                          |  "prevPage": "https://localhost:8888/$apiPrefix/works?page=1&pageSize=1",
+                          |  "nextPage": "https://localhost:8888/$apiPrefix/works?page=3&pageSize=1",
                           |  "results": [
                           |   {
                           |     "type": "Work",
@@ -195,7 +195,7 @@ class ApiWorksTest
                           |  "pageSize": 1,
                           |  "totalPages": 3,
                           |  "totalResults": 3,
-                          |  "next": "https://localhost:8888/$apiPrefix/works?page=2&pageSize=1",
+                          |  "nextPage": "https://localhost:8888/$apiPrefix/works?page=2&pageSize=1",
                           |  "results": [
                           |   {
                           |     "type": "Work",
@@ -228,7 +228,7 @@ class ApiWorksTest
                           |  "pageSize": 1,
                           |  "totalPages": 3,
                           |  "totalResults": 3,
-                          |  "prev": "https://localhost:8888/$apiPrefix/works?page=2&pageSize=1",
+                          |  "prevPage": "https://localhost:8888/$apiPrefix/works?page=2&pageSize=1",
                           |  "results": [
                           |   {
                           |     "type": "Work",


### PR DESCRIPTION
### What is this PR trying to achieve?

In order to move the burden of working out where the next page of results is from the client to the server we will provide next/prev links on API results where appropriate so that the client can simplify pagination logic.

### Who is this change for?

Clients consuming multi-page query requests - specifically the Digital Experience team.

### Have the following been considered/are they needed?

- [x] Reviewed by @jtweed
- [x] Updated the Swagger documentation
- [X] Added tests
- [x] Deployed new versions

Fixes: https://github.com/wellcometrust/platform-api/issues/453

An example API response:

`GET https://localhost:8888/catalogue/v0/works?page=2&pageSize=1`

```json
{
  "@context" : "https://localhost:8888/catalogue/v0/context.json",
  "pageSize" : 1,
  "totalPages" : 3,
  "totalResults" : 3,
  "results" : [
    {
      "id" : "2-1234",
      "label" : "2-this is the first image title",
      "description" : "2-this is a description",
      "lettering" : "2-some lettering",
      "createdDate" : {
        "label" : "2-the past",
        "type" : "Period"
      },
      "creators" : [
        {
          "label" : "2-a person",
          "type" : "Agent"
        }
      ],
      "type" : "Work"
    }
  ],
  "prev" : "https://localhost:8888/catalogue/v0/works?page=1&pageSize=1",
  "next" : "https://localhost:8888/catalogue/v0/works?page=3&pageSize=1",
  "type" : "ResultList"
}
```