### PR TITLE
Add the deployment config for Loris

### DIFF
--- a/docker/nginx/loris.nginx.conf
+++ b/docker/nginx/loris.nginx.conf
@@ -1,0 +1,19 @@
+worker_processes 1;
+
+events { worker_connections 1024; }
+
+http {
+  server {
+    listen 9000;
+
+    location ~ ^/image/V[0-9]{4}.* {
+      rewrite ^/image/(V([0-9]{4}).*) /V$2000/$1 break;
+      proxy_pass http://app:8888;
+    }
+
+    location ~ ^/image/.* {
+      rewrite ^/image/(.*) /$1 break;
+      proxy_pass http://app:8888;
+    }
+  }
+}

--- a/terraform/ecr.tf
+++ b/terraform/ecr.tf
@@ -34,3 +34,8 @@ module "ecr_repository_reindexer" {
   source = "./ecr"
   name   = "reindexer"
 }
+
+module "ecr_repository_loris" {
+  source = "./ecr"
+  name   = "loris"
+}

--- a/terraform/iam.tf
+++ b/terraform/iam.tf
@@ -38,6 +38,11 @@ module "ecs_api_iam" {
   name   = "api"
 }
 
+module "ecs_loris_iam" {
+  source = "./ecs_iam"
+  name   = "loris"
+}
+
 module "ecs_grafana_iam" {
   source = "./ecs_iam"
   name   = "grafana"

--- a/terraform/services.tf
+++ b/terraform/services.tf
@@ -170,12 +170,12 @@ module "loris" {
   task_role_arn    = "${module.ecs_loris_iam.task_role_arn}"
   vpc_id           = "${module.vpc_api.vpc_id}"
   app_uri          = "${module.ecr_repository_loris.repository_url}:latest"
-  nginx_uri        = "${module.ecr_repository_nginx.repository_url}:services"
+  nginx_uri        = "${module.ecr_repository_nginx.repository_url}:loris"
   listener_arn     = "${module.api_alb.listener_arn}"
   infra_bucket     = "${var.infra_bucket}"
   config_key       = "config/${var.build_env}/loris.ini"
-  path_pattern     = "/iiif/*"
-  healthcheck_path = "/iiif/"
+  path_pattern     = "/image/*"
+  healthcheck_path = "/image/"
   alb_priority     = "108"
 }
 

--- a/terraform/services.tf
+++ b/terraform/services.tf
@@ -148,6 +148,7 @@ module "api" {
   listener_arn  = "${module.api_alb.listener_arn}"
   infra_bucket  = "${var.infra_bucket}"
   config_key    = "config/${var.build_env}/api.ini"
+  alb_priority  = "110"
 
   config_vars = {
     api_host    = "${var.api_host}"
@@ -163,17 +164,19 @@ module "api" {
 }
 
 module "loris" {
-  source        = "./services"
-  name          = "loris"
-  cluster_id    = "${aws_ecs_cluster.api.id}"
-  task_role_arn = "${module.ecs_loris_iam.task_role_arn}"
-  vpc_id        = "${module.vpc_api.vpc_id}"
-  app_uri       = "${module.ecr_repository_loris.repository_url}:latest"
-  nginx_uri     = "${module.ecr_repository_nginx.repository_url}:api"
-  listener_arn  = "${module.api_alb.listener_arn}"
-  infra_bucket  = "${var.infra_bucket}"
-  config_key    = "config/${var.build_env}/loris.ini"
-  alb_priority  = "108"
+  source           = "./services"
+  name             = "loris"
+  cluster_id       = "${aws_ecs_cluster.api.id}"
+  task_role_arn    = "${module.ecs_loris_iam.task_role_arn}"
+  vpc_id           = "${module.vpc_api.vpc_id}"
+  app_uri          = "${module.ecr_repository_loris.repository_url}:latest"
+  nginx_uri        = "${module.ecr_repository_nginx.repository_url}:services"
+  listener_arn     = "${module.api_alb.listener_arn}"
+  infra_bucket     = "${var.infra_bucket}"
+  config_key       = "config/${var.build_env}/loris.ini"
+  path_pattern     = "/iiif/*"
+  healthcheck_path = "/iiif/"
+  alb_priority     = "108"
 }
 
 module "grafana" {

--- a/terraform/services.tf
+++ b/terraform/services.tf
@@ -162,6 +162,20 @@ module "api" {
   }
 }
 
+module "loris" {
+  source        = "./services"
+  name          = "loris"
+  cluster_id    = "${aws_ecs_cluster.api.id}"
+  task_role_arn = "${module.ecs_loris_iam.task_role_arn}"
+  vpc_id        = "${module.vpc_api.vpc_id}"
+  app_uri       = "${module.ecr_repository_loris.repository_url}:latest"
+  nginx_uri     = "${module.ecr_repository_nginx.repository_url}:api"
+  listener_arn  = "${module.api_alb.listener_arn}"
+  infra_bucket  = "${var.infra_bucket}"
+  config_key    = "config/${var.build_env}/loris.ini"
+  alb_priority  = "108"
+}
+
 module "grafana" {
   source           = "./services"
   name             = "grafana"

--- a/terraform/services/config/templates/loris.ini.template
+++ b/terraform/services/config/templates/loris.ini.template
@@ -1,0 +1,1 @@
+; This file intentionally left blank


### PR DESCRIPTION
### What is this PR trying to achieve?

Add Terraform for us to deploy Loris. Still missing:

- [ ] Loris images have to be pushed manually – we might want a Travis job on the loris-docker repo pushing to Docker Hub
- [x] I don’t think it’s possible to access Loris externally
- [ ] Nothing for proxy stuff

### Who is this change for?

Users who want a IIIF server!

### Have the following been considered/are they needed?

- [x] Deployed new versions
- [x] Run `terraform apply`.
