### PR TITLE
Redirect requests to iiif.wellcomecollection.org/image to loris

### DIFF
--- a/api/src/main/scala/uk/ac/wellcome/platform/api/requests/Requests.scala
+++ b/api/src/main/scala/uk/ac/wellcome/platform/api/requests/Requests.scala
@@ -1,0 +1,27 @@
+package uk.ac.wellcome.platform.api.requests
+
+import com.twitter.finagle.http.Request
+import com.twitter.finatra.request.{QueryParam, RouteParam}
+import com.twitter.finatra.validation.{Max, Min}
+import uk.ac.wellcome.platform.api.models.WorksIncludes
+
+sealed trait ApiRequest {
+  val request: Request
+}
+
+case class MultipleResultsRequest(
+                                   @Min(1) @QueryParam page: Int = 1,
+                                   @Min(1) @Max(100) @QueryParam pageSize: Option[Int],
+                                   @QueryParam includes: Option[WorksIncludes],
+                                   @RouteParam id: Option[String],
+                                   @QueryParam query: Option[String],
+                                   @QueryParam _index: Option[String],
+                                   request: Request
+                                 ) extends ApiRequest
+
+case class SingleWorkRequest(
+                              @RouteParam id: String,
+                              @QueryParam includes: Option[WorksIncludes],
+                              @QueryParam _index: Option[String],
+                              request: Request
+                            ) extends ApiRequest

--- a/api/src/main/scala/uk/ac/wellcome/platform/api/responses/Responses.scala
+++ b/api/src/main/scala/uk/ac/wellcome/platform/api/responses/Responses.scala
@@ -1,6 +1,9 @@
 package uk.ac.wellcome.platform.api.responses
 
 import com.fasterxml.jackson.annotation.{JsonProperty, JsonUnwrapped}
+import uk.ac.wellcome.platform.api.models.DisplaySearch
+import uk.ac.wellcome.platform.api.requests.{ApiRequest, MultipleResultsRequest}
+
 import scala.language.existentials
 
 
@@ -14,7 +17,52 @@ case class ResultListResponse(
   pageSize: Int = 10,
   totalPages: Int = 10,
   totalResults: Int = 100,
-  results: Array[_ <: Any]
+  results: Array[_ <: Any],
+  prevPage: Option[String] = None,
+  nextPage: Option[String] = None
 ) {
   @JsonProperty("type") val ontologyType: String = "ResultList"
+}
+
+object ResultListResponse {
+  private def createApiLink(
+                             requestBaseUri: String,
+                             apiRequest: ApiRequest
+                           )(
+    updateMap: Map[String, Any]
+  ): String = {
+
+    val baseUrl = s"$requestBaseUri${apiRequest.request.path}"
+    val queryString = (apiRequest.request.params ++ updateMap).toString()
+
+    s"$baseUrl$queryString"
+  }
+
+  def create(
+              contextUri: String,
+              displaySearch: DisplaySearch,
+              multipleResultsRequest: MultipleResultsRequest,
+              requestBaseUri: String
+            ): ResultListResponse = {
+
+    val currentPage = multipleResultsRequest.page
+    val isLastPage = displaySearch.totalPages == currentPage
+    val isFirstPage = currentPage == 1
+    val isOnlyPage = displaySearch.totalPages <= 1
+
+    val apiLink = createApiLink(requestBaseUri, multipleResultsRequest) _
+
+    val prevLink = if(!isFirstPage && !isOnlyPage) Some(apiLink(Map("page" -> (currentPage - 1) ))) else None
+    val nextLink = if(!isLastPage && !isOnlyPage) Some(apiLink(Map("page" -> (currentPage + 1) ))) else None
+
+    ResultListResponse(
+      context = contextUri,
+      results = displaySearch.results,
+      pageSize = displaySearch.pageSize,
+      totalPages = displaySearch.totalPages,
+      totalResults = displaySearch.totalResults,
+      prevPage = prevLink,
+      nextPage = nextLink
+    )
+  }
 }

--- a/api/src/test/scala/uk/ac/wellcome/platform/api/ApiWorksTest.scala
+++ b/api/src/test/scala/uk/ac/wellcome/platform/api/ApiWorksTest.scala
@@ -145,10 +145,11 @@ class ApiWorksTest
   }
 
   it(
-    "should return the requested page of results when requested with page & pageSize") {
+    "should return the requested page of results when requested with page & pageSize, alongside correct next/prev links ") {
     val works = createIdentifiedWorks(3)
 
     insertIntoElasticSearch(works: _*)
+
     eventually {
       server.httpGet(
         path = s"/$apiPrefix/works?page=2&pageSize=1",
@@ -160,6 +161,8 @@ class ApiWorksTest
                           |  "pageSize": 1,
                           |  "totalPages": 3,
                           |  "totalResults": 3,
+                          |  "prevPage": "https://localhost:8888/$apiPrefix/works?page=1&pageSize=1",
+                          |  "nextPage": "https://localhost:8888/$apiPrefix/works?page=3&pageSize=1",
                           |  "results": [
                           |   {
                           |     "type": "Work",
@@ -174,6 +177,72 @@ class ApiWorksTest
                           |     "creators": [{
                           |       "type": "Agent",
                           |       "label": "${works(1).work.creators(0).label}"
+                          |     }]
+                          |   }]
+                          |   }
+                          |  ]
+                          |}
+          """.stripMargin
+      )
+
+      server.httpGet(
+        path = s"/$apiPrefix/works?page=1&pageSize=1",
+        andExpect = Status.Ok,
+        withJsonBody = s"""
+                          |{
+                          |  "@context": "https://localhost:8888/$apiPrefix/context.json",
+                          |  "type": "ResultList",
+                          |  "pageSize": 1,
+                          |  "totalPages": 3,
+                          |  "totalResults": 3,
+                          |  "nextPage": "https://localhost:8888/$apiPrefix/works?page=2&pageSize=1",
+                          |  "results": [
+                          |   {
+                          |     "type": "Work",
+                          |     "id": "${works(0).canonicalId}",
+                          |     "label": "${works(0).work.label}",
+                          |     "description": "${works(0).work.description.get}",
+                          |     "lettering": "${works(0).work.lettering.get}",
+                          |     "createdDate": {
+                          |       "type": "Period",
+                          |       "label": "${works(0).work.createdDate.get.label}"
+                          |     },
+                          |     "creators": [{
+                          |       "type": "Agent",
+                          |       "label": "${works(0).work.creators(0).label}"
+                          |     }]
+                          |   }]
+                          |   }
+                          |  ]
+                          |}
+          """.stripMargin
+      )
+
+      server.httpGet(
+        path = s"/$apiPrefix/works?page=3&pageSize=1",
+        andExpect = Status.Ok,
+        withJsonBody = s"""
+                          |{
+                          |  "@context": "https://localhost:8888/$apiPrefix/context.json",
+                          |  "type": "ResultList",
+                          |  "pageSize": 1,
+                          |  "totalPages": 3,
+                          |  "totalResults": 3,
+                          |  "prevPage": "https://localhost:8888/$apiPrefix/works?page=2&pageSize=1",
+                          |  "results": [
+                          |   {
+                          |     "type": "Work",
+                          |     "id": "${works(2).canonicalId}",
+                          |     "label": "${works(2).work.label}",
+                          |     "description": "${works(2).work.description.get}",
+                          |     "lettering": "${works(2).work.lettering.get}",
+                          |     "createdDate": {
+                          |       "type": "Period",
+                          |       "label": "${works(2).work.createdDate.get.label}"
+                          |     },
+                          |     "creators": [{
+                          |       "type": "Agent",
+                          |       "label": "${works(2).work.creators(0).label}"
                           |     }]
                           |   }]
                           |   }

--- a/docker/nginx/loris.nginx.conf
+++ b/docker/nginx/loris.nginx.conf
@@ -1,0 +1,19 @@
+worker_processes 1;
+
+events { worker_connections 1024; }
+
+http {
+  server {
+    listen 9000;
+
+    location ~ ^/image/V[0-9]{4}.* {
+      rewrite ^/image/(V([0-9]{4}).*) /V$2000/$1 break;
+      proxy_pass http://app:8888;
+    }
+
+    location ~ ^/image/.* {
+      rewrite ^/image/(.*) /$1 break;
+      proxy_pass http://app:8888;
+    }
+  }
+}

--- a/terraform/services.tf
+++ b/terraform/services.tf
@@ -170,7 +170,7 @@ module "loris" {
   task_role_arn      = "${module.ecs_loris_iam.task_role_arn}"
   vpc_id             = "${module.vpc_api.vpc_id}"
   app_uri            = "${module.ecr_repository_loris.repository_url}:latest"
-  nginx_uri          = "${module.ecr_repository_nginx.repository_url}:services"
+  nginx_uri          = "${module.ecr_repository_nginx.repository_url}:loris"
   listener_arn       = "${module.api_alb.listener_arn}"
   infra_bucket       = "${var.infra_bucket}"
   config_key         = "config/${var.build_env}/loris.ini"

--- a/terraform/services.tf
+++ b/terraform/services.tf
@@ -164,19 +164,21 @@ module "api" {
 }
 
 module "loris" {
-  source           = "./services"
-  name             = "loris"
-  cluster_id       = "${aws_ecs_cluster.api.id}"
-  task_role_arn    = "${module.ecs_loris_iam.task_role_arn}"
-  vpc_id           = "${module.vpc_api.vpc_id}"
-  app_uri          = "${module.ecr_repository_loris.repository_url}:latest"
-  nginx_uri        = "${module.ecr_repository_nginx.repository_url}:services"
-  listener_arn     = "${module.api_alb.listener_arn}"
-  infra_bucket     = "${var.infra_bucket}"
-  config_key       = "config/${var.build_env}/loris.ini"
-  path_pattern     = "/iiif/*"
-  healthcheck_path = "/iiif/"
-  alb_priority     = "108"
+  source             = "./services"
+  name               = "loris"
+  cluster_id         = "${aws_ecs_cluster.api.id}"
+  task_role_arn      = "${module.ecs_loris_iam.task_role_arn}"
+  vpc_id             = "${module.vpc_api.vpc_id}"
+  app_uri            = "${module.ecr_repository_loris.repository_url}:latest"
+  nginx_uri          = "${module.ecr_repository_nginx.repository_url}:services"
+  listener_arn       = "${module.api_alb.listener_arn}"
+  infra_bucket       = "${var.infra_bucket}"
+  config_key         = "config/${var.build_env}/loris.ini"
+  path_pattern       = "/image/*"
+  healthcheck_path   = "/image/"
+  alb_priority       = "108"
+  use_host_condition = true
+  host_name          = "iiif.wellcomecollection.org"
 }
 
 module "grafana" {

--- a/terraform/services/ecs_service/alb.tf
+++ b/terraform/services/ecs_service/alb.tf
@@ -12,7 +12,8 @@ resource "aws_alb_target_group" "ecs_service" {
   }
 }
 
-resource "aws_alb_listener_rule" "rule" {
+resource "aws_alb_listener_rule" "path_rule" {
+  count        = "${1 - var.use_host_condition}"
   listener_arn = "${var.listener_arn}"
   priority     = "${var.alb_priority}"
 
@@ -24,5 +25,26 @@ resource "aws_alb_listener_rule" "rule" {
   condition {
     field  = "path-pattern"
     values = ["${var.path_pattern}"]
+  }
+}
+
+resource "aws_alb_listener_rule" "path_host_rule" {
+  count        = "${var.use_host_condition}"
+  listener_arn = "${var.listener_arn}"
+  priority     = "${var.alb_priority}"
+
+  action {
+    type             = "forward"
+    target_group_arn = "${aws_alb_target_group.ecs_service.arn}"
+  }
+
+  condition {
+    field  = "path-pattern"
+    values = ["${var.path_pattern}"]
+  }
+
+  condition {
+    field  = "host-header"
+    values = ["${var.host_name}"]
   }
 }

--- a/terraform/services/ecs_service/variables.tf
+++ b/terraform/services/ecs_service/variables.tf
@@ -49,3 +49,13 @@ variable "healthcheck_path" {
 variable "infra_bucket" {
   description = "Name of the AWS Infra bucket"
 }
+
+variable "use_host_condition" {
+  description = "Boolean value to tell whether we should add a host condition"
+  default     = false
+}
+
+variable "host_name" {
+  description = "Hostname to be matched in the host condition"
+  default     = ""
+}

--- a/terraform/services/main.tf
+++ b/terraform/services/main.tf
@@ -12,6 +12,8 @@ module "service" {
   desired_count       = "${var.desired_count}"
   healthcheck_path    = "${var.healthcheck_path}"
   infra_bucket        = "${var.infra_bucket}"
+  use_host_condition  = "${var.use_host_condition}"
+  host_name           = "${var.host_name}"
 }
 
 module "task" {

--- a/terraform/services/variables.tf
+++ b/terraform/services/variables.tf
@@ -106,3 +106,13 @@ variable "is_config_managed" {
   description = "Flag to tell whether the config should be generated using templates and put in S3"
   default     = true
 }
+
+variable "use_host_condition" {
+  description = "Boolean value to tell whether we should add a host condition"
+  default = false
+}
+
+variable "host_name" {
+  description = "Hostname to be matched in the host condition"
+  default = ""
+}


### PR DESCRIPTION
### What is this PR trying to achieve?
Make loris accessible from https://iiif.wellcomecollection.org/image
### Who is this change for?
Everyone accessing our iiif API
### Have the following been considered/are they needed?

<!-- Remove this section if you don't have Terraform changes -->
- [ ] Run `terraform apply`.
