### PR TITLE
Redirect requests to iiif.wellcomecollection.org/image to loris

### DIFF
--- a/terraform/iam_policy_document.tf
+++ b/terraform/iam_policy_document.tf
@@ -224,16 +224,16 @@ data "aws_iam_policy_document" "s3_put_dashboard_status" {
 }
 
 data "aws_iam_policy_document" "s3_read_miro_images" {
-	statement {
-		actions = [
-			"s3:Get*",
-			"s3:List*",
-		]
+  statement {
+    actions = [
+      "s3:Get*",
+      "s3:List*",
+    ]
 
-		resources = [
-			"${aws_s3_bucket.miro_images_public.arn}",
-		]
-	}
+    resources = [
+      "${aws_s3_bucket.miro_images_public.arn}",
+    ]
+  }
 }
 
 data "aws_iam_policy_document" "write_ec2_tags" {

--- a/terraform/iam_users.tf
+++ b/terraform/iam_users.tf
@@ -30,14 +30,14 @@ resource "aws_iam_user_policy" "miro_images_sync" {
 # This is for temporary use by the Experience team in their Imgix instance
 # until we make the images available properly.
 resource "aws_iam_user" "miro_images_readonly" {
-	name = "miro_images_readonly"
+  name = "miro_images_readonly"
 }
 
 resource "aws_iam_access_key" "miro_images_readonly" {
-	user = "${aws_iam_user.miro_images_readonly.name}"
+  user = "${aws_iam_user.miro_images_readonly.name}"
 }
 
 resource "aws_iam_user_policy" "miro_images_readonly" {
-	user = "${aws_iam_user.miro_images_readonly.name}"
-	policy = "${data.aws_iam_policy_document.s3_read_miro_images.json}"
+  user   = "${aws_iam_user.miro_images_readonly.name}"
+  policy = "${data.aws_iam_policy_document.s3_read_miro_images.json}"
 }

--- a/terraform/lambda/trigger_cloudwatch/cloudwatch.tf
+++ b/terraform/lambda/trigger_cloudwatch/cloudwatch.tf
@@ -19,6 +19,6 @@ resource "aws_cloudwatch_event_target" "event_trigger_custom" {
 
 resource "aws_cloudwatch_event_target" "event_trigger" {
   count = "${1 - var.custom_input}"
-  rule = "${var.cloudwatch_trigger_name}"
-  arn  = "${var.lambda_function_arn}"
+  rule  = "${var.cloudwatch_trigger_name}"
+  arn   = "${var.lambda_function_arn}"
 }

--- a/terraform/outputs.tf
+++ b/terraform/outputs.tf
@@ -3,9 +3,9 @@ output "ecr_nginx" {
 }
 
 output "miro_readonly_key_id" {
-	value = "${aws_iam_access_key.miro_images_readonly.id}"
+  value = "${aws_iam_access_key.miro_images_readonly.id}"
 }
 
 output "miro_readonly_key_secret" {
-	value = "${aws_iam_access_key.miro_images_readonly.secret}"
+  value = "${aws_iam_access_key.miro_images_readonly.secret}"
 }

--- a/terraform/services.tf
+++ b/terraform/services.tf
@@ -164,19 +164,20 @@ module "api" {
 }
 
 module "loris" {
-  source           = "./services"
-  name             = "loris"
-  cluster_id       = "${aws_ecs_cluster.api.id}"
-  task_role_arn    = "${module.ecs_loris_iam.task_role_arn}"
-  vpc_id           = "${module.vpc_api.vpc_id}"
-  app_uri          = "${module.ecr_repository_loris.repository_url}:latest"
-  nginx_uri        = "${module.ecr_repository_nginx.repository_url}:loris"
-  listener_arn     = "${module.api_alb.listener_arn}"
-  infra_bucket     = "${var.infra_bucket}"
-  config_key       = "config/${var.build_env}/loris.ini"
-  path_pattern     = "/image/*"
-  healthcheck_path = "/image/"
-  alb_priority     = "108"
+  source             = "./services"
+  name               = "loris"
+  cluster_id         = "${aws_ecs_cluster.api.id}"
+  task_role_arn      = "${module.ecs_loris_iam.task_role_arn}"
+  vpc_id             = "${module.vpc_api.vpc_id}"
+  app_uri            = "${module.ecr_repository_loris.repository_url}:latest"
+  nginx_uri          = "${module.ecr_repository_nginx.repository_url}:loris"
+  listener_arn       = "${module.api_alb.listener_arn}"
+  infra_bucket       = "${var.infra_bucket}"
+  config_key         = "config/${var.build_env}/loris.ini"
+  path_pattern       = "/image/*"
+  healthcheck_path   = "/image/"
+  alb_priority       = "108"
+  host_name          = "iiif.wellcomecollection.org"
 }
 
 module "grafana" {

--- a/terraform/services/ecs_service/alb.tf
+++ b/terraform/services/ecs_service/alb.tf
@@ -12,7 +12,8 @@ resource "aws_alb_target_group" "ecs_service" {
   }
 }
 
-resource "aws_alb_listener_rule" "rule" {
+resource "aws_alb_listener_rule" "path_rule" {
+  count        = "${var.host_name == "" ? 0 : 1}"
   listener_arn = "${var.listener_arn}"
   priority     = "${var.alb_priority}"
 
@@ -24,5 +25,26 @@ resource "aws_alb_listener_rule" "rule" {
   condition {
     field  = "path-pattern"
     values = ["${var.path_pattern}"]
+  }
+}
+
+resource "aws_alb_listener_rule" "path_host_rule" {
+  count        = "${var.host_name == "" ? 1 : 0}"
+  listener_arn = "${var.listener_arn}"
+  priority     = "${var.alb_priority}"
+
+  action {
+    type             = "forward"
+    target_group_arn = "${aws_alb_target_group.ecs_service.arn}"
+  }
+
+  condition {
+    field  = "path-pattern"
+    values = ["${var.path_pattern}"]
+  }
+
+  condition {
+    field  = "host-header"
+    values = ["${var.host_name}"]
   }
 }

--- a/terraform/services/ecs_service/variables.tf
+++ b/terraform/services/ecs_service/variables.tf
@@ -49,3 +49,8 @@ variable "healthcheck_path" {
 variable "infra_bucket" {
   description = "Name of the AWS Infra bucket"
 }
+
+variable "host_name" {
+  description = "Hostname to be matched in the host condition"
+  default     = ""
+}

--- a/terraform/services/main.tf
+++ b/terraform/services/main.tf
@@ -12,6 +12,7 @@ module "service" {
   desired_count       = "${var.desired_count}"
   healthcheck_path    = "${var.healthcheck_path}"
   infra_bucket        = "${var.infra_bucket}"
+  host_name           = "${var.host_name}"
 }
 
 module "task" {

--- a/terraform/services/variables.tf
+++ b/terraform/services/variables.tf
@@ -106,3 +106,8 @@ variable "is_config_managed" {
   description = "Flag to tell whether the config should be generated using templates and put in S3"
   default     = true
 }
+
+variable "host_name" {
+  description = "Hostname to be matched in the host condition"
+  default     = ""
+}

--- a/terraform/topics.tf
+++ b/terraform/topics.tf
@@ -22,7 +22,7 @@ module "ec2_terminating_topic" {
   source = "./sns"
   name   = "ec2_terminating_topic"
 }
-  
+
 module "old_deployments" {
   source = "./sns"
   name   = "old_deployments"


### PR DESCRIPTION
### What is this PR trying to achieve?
Make loris accessible from https://iiif.wellcomecollection.org/image
### Who is this change for?
Everyone accessing our iiif API
### Have the following been considered/are they needed?

<!-- Remove this section if you don't have Terraform changes -->
- [ ] Run `terraform apply`.
