### PR TITLE
Loris nginx config

### DIFF
--- a/docker/nginx/loris.nginx.conf
+++ b/docker/nginx/loris.nginx.conf
@@ -6,6 +6,17 @@ http {
   server {
     listen 9000;
 
+    # Requests for iiif.wellcomecollection.org/image should be forwarded to our IIIF Image API, Loris
+    #
+    # Wellcome Collection V images are currenly hosted in an s3 bucket and
+    # they are sharded based on their file name, so we need to construct the image path in
+    # the s3 bucket when we send the request to the iiif image API.
+    #
+    # File names start with V and are followed by 7 digits. The name of the directory in which each
+    # file is stored is based on the first 4 digits of its filename.
+    # For example V0002007.jpg is actually stored in V0002000/V0002007.jpg in the s3 bucket.
+    # Therefore every request for V0002007.jpg needs to be routed to s3:V0002000/V0002007.jpg
+    #
     location ~ "^/image/V[0-9]{4}.*" {
       rewrite "^/image/(?<filename>(?<shard>V[0-9]{4}).*)" "/s3:${shard}000/${filename}" break;
       proxy_pass http://app:8888;

--- a/docker/nginx/loris.nginx.conf
+++ b/docker/nginx/loris.nginx.conf
@@ -6,8 +6,8 @@ http {
   server {
     listen 9000;
 
-    location ~ ^/image/V[0-9]\{4\}.* {
-      rewrite ^/image/(?<filename>(?<shard>V[0-9]\{4\}).*) /s3:\k<shard>000/\k<filename> break;
+    location ~ "^/image/V[0-9]{4}.*" {
+      rewrite "^/image/(?<filename>(?<shard>V[0-9]{4}).*)" "/s3:${shard}000/${filename}" break;
       proxy_pass http://app:8888;
     }
 

--- a/docker/nginx/loris.nginx.conf
+++ b/docker/nginx/loris.nginx.conf
@@ -6,8 +6,8 @@ http {
   server {
     listen 9000;
 
-    location ~ ^/image/V[0-9]{4}.* {
-      rewrite ^/image/(V([0-9]{4}).*) /V$2000/$1 break;
+    location ~ ^/image/V[0-9]\{4\}.* {
+      rewrite ^/image/(?<filename>(?<shard>V[0-9]\{4\}).*) /s3:\k<shard>000/\k<filename> break;
       proxy_pass http://app:8888;
     }
 


### PR DESCRIPTION
### What is this PR trying to achieve?
Make loris rewrite Urls for miro images so that our clients don't need to know the structure of the s3 bucket
### Who is this change for?
Users
### Have the following been considered/are they needed?

- [ ] Run `terraform apply`.
