### PR TITLE
Fix the ternary operator for creating ALB rules

### DIFF
--- a/terraform/services.tf
+++ b/terraform/services.tf
@@ -176,7 +176,7 @@ module "loris" {
   config_key         = "config/${var.build_env}/loris.ini"
   path_pattern       = "/image/*"
   healthcheck_path   = "/image/"
-  alb_priority       = "108"
+  alb_priority       = "109"
   host_name          = "iiif.wellcomecollection.org"
 }
 

--- a/terraform/services/ecs_service/alb.tf
+++ b/terraform/services/ecs_service/alb.tf
@@ -12,8 +12,12 @@ resource "aws_alb_target_group" "ecs_service" {
   }
 }
 
+# When using the module, the user can specify a path pattern and (optionally)
+# a hostname pattern.  We only want a path rule OR a hostname/path rule, but
+# not both.  We use the `count` parameter to only create one of these.
+
 resource "aws_alb_listener_rule" "path_rule" {
-  count        = "${var.host_name == "" ? 0 : 1}"
+  count        = "${var.host_name == "" ? 1 : 0}"
   listener_arn = "${var.listener_arn}"
   priority     = "${var.alb_priority}"
 
@@ -29,7 +33,7 @@ resource "aws_alb_listener_rule" "path_rule" {
 }
 
 resource "aws_alb_listener_rule" "path_host_rule" {
-  count        = "${var.host_name == "" ? 1 : 0}"
+  count        = "${var.host_name != "" ? 1 : 0}"
   listener_arn = "${var.listener_arn}"
   priority     = "${var.alb_priority}"
 


### PR DESCRIPTION
### What is this PR trying to achieve?

We were creating a path rule if a hostname was supplied, and a
hostname rule if only a path was supplied.  This is the opposite
of what we want!

And was making Terraform sad. :-(

Now Terraform is less sad.

### Who is this change for?

Developers who want to be able to apply Terraform changes.

### Have the following been considered/are they needed?

- [x] Run `terraform apply`.
