### PR TITLE
Add a hostname rule to the API ALB requests

### DIFF
--- a/terraform/services.tf
+++ b/terraform/services.tf
@@ -149,6 +149,7 @@ module "api" {
   infra_bucket  = "${var.infra_bucket}"
   config_key    = "config/${var.build_env}/api.ini"
   alb_priority  = "110"
+  host_name     = "api.wellcomecollection.org"
 
   config_vars = {
     api_host    = "${var.api_host}"


### PR DESCRIPTION
### What is this PR trying to achieve?

Get https://iiif.wellcomecollection.org/catalogue/v0/works to stop working.

### Who is this change for?

A Platform team who like a well-defined API that doesn’t leak everywhere.

### Have the following been considered/are they needed?

- [ ] Run `terraform apply`.
