### PR TITLE
make iiif.wellcomecollection.org/image work

### DIFF
--- a/docker/nginx/loris.nginx.conf
+++ b/docker/nginx/loris.nginx.conf
@@ -22,8 +22,8 @@ http {
       proxy_pass http://app:8888;
     }
 
-    location ~ ^/image/.* {
-      rewrite ^/image/(.*) /$1 break;
+    location ~ "^/image($|/.*)" {
+      rewrite "^/image($|/.*)" /$1 break;
       proxy_pass http://app:8888;
     }
   }

--- a/terraform/services.tf
+++ b/terraform/services.tf
@@ -175,7 +175,7 @@ module "loris" {
   listener_arn       = "${module.api_alb.listener_arn}"
   infra_bucket       = "${var.infra_bucket}"
   config_key         = "config/${var.build_env}/loris.ini"
-  path_pattern       = "/image/*"
+  path_pattern       = "/image*"
   healthcheck_path   = "/image/"
   alb_priority       = "109"
   host_name          = "iiif.wellcomecollection.org"


### PR DESCRIPTION
### What is this PR trying to achieve?
Make iiif.wellcomecollection.org/image behave as  https://iiif.wellcomecollection.org/image/
### Who is this change for?
Everyone
### Have the following been considered/are they needed?

<!-- Remove this section if you don't have Terraform changes -->
- [ ] Run `terraform apply`.
