### PR TITLE
Tag our nginx images with a commit hash

### DIFF
--- a/docker/nginx/manage_images.sh
+++ b/docker/nginx/manage_images.sh
@@ -6,7 +6,7 @@ set -o errexit
 set -o nounset
 
 TASK=${1:-BUILD}
-echo "Task is $TASK"
+echo "*** Task is $TASK"
 
 export AWS_DEFAULT_REGION=${AWS_DEFAULT_REGION:-eu-west-1}
 
@@ -15,11 +15,11 @@ export AWS_DEFAULT_REGION=${AWS_DEFAULT_REGION:-eu-west-1}
 ECR_URI=$(
   aws ecr describe-repositories --repository-name uk.ac.wellcome/nginx | \
   jq -r '.repositories[0].repositoryUri')
-echo "ECR_URI is $ECR_URI"
+echo "*** ECR_URI is $ECR_URI"
 
 if [[ "$ECR_URI" == "" ]]
 then
-  echo "Failed to read ECR repo information" >&2
+  echo "*** Failed to read ECR repo information" >&2
   exit 1
 fi
 
@@ -36,7 +36,7 @@ fi
 for conf_file in *.nginx.conf
 do
   variant="$(echo "$conf_file" | tr '.' ' ' | awk '{print $1}')"
-  echo "Building nginx image for $variant..."
+  echo "*** Building nginx image for $variant..."
 
   docker build --build-arg conf_file="$conf_file" --tag nginx_image .
   docker tag $(docker images -q nginx_image) "$ECR_URI:$variant"

--- a/docker/nginx/manage_images.sh
+++ b/docker/nginx/manage_images.sh
@@ -39,7 +39,7 @@ do
   echo "*** Building nginx image for $variant..."
 
   # Construct the tag used for the image
-  TAG="$ECR_URI:$variant"
+  TAG="$ECR_URI:$variant-$(git rev-parse HEAD)"
   echo "*** Image will be tagged $TAG"
 
   # Actually build the image

--- a/docker/nginx/manage_images.sh
+++ b/docker/nginx/manage_images.sh
@@ -38,11 +38,15 @@ do
   variant="$(echo "$conf_file" | tr '.' ' ' | awk '{print $1}')"
   echo "*** Building nginx image for $variant..."
 
-  docker build --build-arg conf_file="$conf_file" --tag nginx_image .
-  docker tag $(docker images -q nginx_image) "$ECR_URI:$variant"
+  # Construct the tag used for the image
+  TAG="$ECR_URI:$variant"
+  echo "*** Image will be tagged $TAG"
+
+  # Actually build the image
+  docker build --build-arg conf_file="$conf_file" --tag "$TAG" .
 
   if [[ "$TASK" == "DEPLOY" ]]
   then
-    docker push "$ECR_URI:$variant"
+    docker push "$TAG"
   fi
 done


### PR DESCRIPTION
### What is this PR trying to achieve?

Rather than tagging all of our nginx images with their variant name, include the git commit hash as well.

Before:

```console
$ docker images
REPOSITORY                               TAG                 IMAGE ID            CREATED             SIZE
ecr.amazonaws.com/uk.ac.wellcome/nginx   services            b0a2744576dc        33 seconds ago      15.5 MB
ecr.amazonaws.com/uk.ac.wellcome/nginx   loris               7aada70bfbff        34 seconds ago      15.5 MB
ecr.amazonaws.com/uk.ac.wellcome/nginx   api                 7d7af871d130        35 seconds ago      15.5 MB
nginx                                    alpine              a60696d9123b        6 days ago          15.5 MB
```

After:

```console
$ docker images
REPOSITORY                               TAG                                                 IMAGE ID            CREATED             SIZE
ecr.amazonaws.com/uk.ac.wellcome/nginx   services-18c901d3346e915321797239d17e9f1ff4b5e714   b0a2744576dc        7 minutes ago       15.5 MB
ecr.amazonaws.com/uk.ac.wellcome/nginx   loris-18c901d3346e915321797239d17e9f1ff4b5e714      7aada70bfbff        7 minutes ago       15.5 MB
ecr.amazonaws.com/uk.ac.wellcome/nginx   api-18c901d3346e915321797239d17e9f1ff4b5e714        7d7af871d130        7 minutes ago       15.5 MB
nginx                                    alpine                                              a60696d9123b        6 days ago          15.5 MB
```

### Who is this change for?

Developers, with two benefits:

* We can distinguish between different versions of our nginx images
* (Later) We can pin the nginx image version in our task definitions
