### PR TITLE
Stamp out release IDs when building Docker images

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ terraform/releases
 terraform.tfvars
 release_ids.tfvars
 terraform.tfstate.backup
+.releases
 
 # Created by https://www.gitignore.io/api/osx,vim,java,linux,scala,python,textmate,intellij
 

--- a/docker/nginx/manage_images.sh
+++ b/docker/nginx/manage_images.sh
@@ -14,6 +14,9 @@ export AWS_DEFAULT_REGION=${AWS_DEFAULT_REGION:-eu-west-1}
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 cd "$DIR"
 
+# Root of the repository
+ROOT="$(git rev-parse HEAD)"
+
 # Log in to ECR so that we can do 'docker push'
 if [[ "$TASK" == "DEPLOY" ]]
 then
@@ -39,11 +42,15 @@ do
   fi
 
   # Construct the tag used for the image
-  TAG="$ECR_URI:$(git rev-parse HEAD)"
+  RELEASE_ID="$(git rev-parse HEAD)"
+  TAG="$ECR_URI:$RELEASE_ID"
   echo "*** Image will be tagged $TAG"
 
   # Actually build the image
   docker build --build-arg conf_file="$conf_file" --tag "$TAG" .
+
+  mkdir -p "$ROOT/.releases"
+  echo "$RELEASE_ID" >> "$ROOT/.releases/nginx_$variant"
 
   if [[ "$TASK" == "DEPLOY" ]]
   then

--- a/scripts/build_docker_image.sh
+++ b/scripts/build_docker_image.sh
@@ -9,4 +9,7 @@ sbt "project $PROJECT" stage
 
 docker build --build-arg project="$PROJECT" --tag="$TAG" .
 
+mkdir -p .releases
+echo "$RELEASE_ID" >> ".releases/$PROJECT"
+
 exit 0


### PR DESCRIPTION
### What is this PR trying to achieve?

Trying to make #552 a little more tractable (for me if nobody else!). When we build an image, stamp out the release ID to a local `.releases` directory.

This means the build and deploy scripts don’t necessarily have to be the same file, or run at the same time.