### PR TITLE
Cloudwatch logs for nginx containers

### DIFF
--- a/terraform/services/ecs_tasks/cloudwatch.tf
+++ b/terraform/services/ecs_tasks/cloudwatch.tf
@@ -1,3 +1,7 @@
 resource "aws_cloudwatch_log_group" "task" {
   name = "platform/${var.task_name}"
 }
+
+resource "aws_cloudwatch_log_group" "nginx_task" {
+  name = "platform/nginx_${var.task_name}"
+}

--- a/terraform/services/ecs_tasks/data.tf
+++ b/terraform/services/ecs_tasks/data.tf
@@ -2,9 +2,9 @@ data "template_file" "definition" {
   template = "${file("${path.module}/templates/${var.template_name}.json.template")}"
 
   vars {
-    log_group_region = "${var.aws_region}"
-    log_group_name   = "${aws_cloudwatch_log_group.task.name}"
-    nginx_log_group_name   = "${aws_cloudwatch_log_group.nginx_task.name}"
+    log_group_region     = "${var.aws_region}"
+    log_group_name       = "${aws_cloudwatch_log_group.task.name}"
+    nginx_log_group_name = "${aws_cloudwatch_log_group.nginx_task.name}"
 
     app_uri      = "${var.app_uri}"
     nginx_uri    = "${var.nginx_uri}"

--- a/terraform/services/ecs_tasks/data.tf
+++ b/terraform/services/ecs_tasks/data.tf
@@ -4,6 +4,7 @@ data "template_file" "definition" {
   vars {
     log_group_region = "${var.aws_region}"
     log_group_name   = "${aws_cloudwatch_log_group.task.name}"
+    nginx_log_group_name   = "${aws_cloudwatch_log_group.nginx_task.name}"
 
     app_uri      = "${var.app_uri}"
     nginx_uri    = "${var.nginx_uri}"

--- a/terraform/services/ecs_tasks/templates/default.json.template
+++ b/terraform/services/ecs_tasks/templates/default.json.template
@@ -11,7 +11,14 @@
         "protocol": "tcp"
       }
     ],
-    "links": ["app"]
+    "links": ["app"],
+    "logConfiguration": {
+        "logDriver": "awslogs",
+        "options": {
+            "awslogs-group": "${nginx_log_group_name}",
+            "awslogs-region": "${log_group_region}"
+        }
+    }
   },
   {
     "cpu": 512,


### PR DESCRIPTION
### What is this PR trying to achieve?
Have visibility on nginx logs so we can figure out what the 400 errors we see are. Don't merge yet, this depends on a change for the grafana task definition, coming soon
### Who is this change for?
Devs
### Have the following been considered/are they needed?


- [ ] Run `terraform apply`.
