### PR TITLE
Fix date serialization issue with sns_utils

### DIFF
--- a/lambdas/common/sns_utils.py
+++ b/lambdas/common/sns_utils.py
@@ -1,6 +1,6 @@
 # -*- encoding: utf-8 -*-
 
-from datetime import date, datetime
+from datetime import datetime
 import json
 import pprint
 

--- a/lambdas/common/sns_utils.py
+++ b/lambdas/common/sns_utils.py
@@ -1,9 +1,18 @@
 # -*- encoding: utf-8 -*-
 
+from datetime import date, datetime
 import json
 import pprint
 
 import boto3
+
+
+class EnhancedJSONEncoder(json.JSONEncoder):
+    def default(self, o):
+        if isinstance(o, datetime):
+            return o.isoformat()
+
+        return json.JSONEncoder.default(self, o)
 
 
 def publish_sns_message(topic_arn, message):
@@ -16,7 +25,7 @@ def publish_sns_message(topic_arn, message):
         TopicArn=topic_arn,
         MessageStructure='json',
         Message=json.dumps({
-            'default': json.dumps(message)
+            'default': json.dumps(message, cls=EnhancedJSONEncoder)
         })
     )
     print(f'SNS response:\n{pprint.pformat(resp)}')

--- a/lambdas/common/test_sns_utils.py
+++ b/lambdas/common/test_sns_utils.py
@@ -1,0 +1,61 @@
+from datetime import datetime
+import json
+
+import boto3
+from moto import mock_sns, mock_sqs
+
+import sns_utils
+
+
+@mock_sns
+@mock_sqs
+def test_publish_sns_message():
+    session = boto3.Session()
+    region = session.region_name
+    boto3.setup_default_session(region_name=region)
+
+    topic_name = "test-topic"
+
+    client = boto3.client('sns')
+    client.create_topic(Name=topic_name)
+
+    sqs_client = boto3.client('sqs')
+    queue_name = "test-queue"
+    queue = sqs_client.create_queue(QueueName=queue_name)
+
+    response = client.list_topics()
+    topic_arn = response["Topics"][0]['TopicArn']
+
+    client.subscribe(
+        TopicArn=topic_arn,
+        Protocol="sqs",
+        Endpoint=f"arn:aws:sqs:eu-west-1:123456789012:{queue_name}"
+    )
+
+    test_message = {
+        'string': 'a',
+        'number': 1,
+        'date':  datetime.strptime(
+            'Jun 1 2005  1:33PM', '%b %d %Y %I:%M%p'
+        )
+    }
+
+    expected_decoded_message = {
+        'string': 'a',
+        'number': 1,
+        'date': '2005-06-01T13:33:00'
+    }
+
+    sns_utils.publish_sns_message(topic_arn, test_message)
+
+    messages = sqs_client.receive_message(
+        QueueUrl=queue['QueueUrl'],
+        MaxNumberOfMessages=1
+    )
+
+    message_body = messages['Messages'][0]['Body']
+
+    inner_message = json.loads(message_body)['default']
+    actual_decoded_message = json.loads(inner_message)
+
+    assert actual_decoded_message == expected_decoded_message

--- a/terraform/lambdas.tf
+++ b/terraform/lambdas.tf
@@ -241,7 +241,7 @@ module "trigger_post_to_slack_dlqs_not_empty" {
 module "trigger_post_to_slack_esg_not_terminating" {
   source               = "./lambda/trigger_sns"
   lambda_function_name = "${module.lambda_post_to_slack.function_name}"
-  lambda_function_arn  = "${module.lambda_post_to_slack.arn}"
+  lambda_function_arn  = "${mo[]dule.lambda_post_to_slack.arn}"
   sns_trigger_arn      = "${module.ec2_instance_terminating_for_too_long_alarm.arn}"
 }
 

--- a/terraform/lambdas.tf
+++ b/terraform/lambdas.tf
@@ -241,7 +241,7 @@ module "trigger_post_to_slack_dlqs_not_empty" {
 module "trigger_post_to_slack_esg_not_terminating" {
   source               = "./lambda/trigger_sns"
   lambda_function_name = "${module.lambda_post_to_slack.function_name}"
-  lambda_function_arn  = "${mo[]dule.lambda_post_to_slack.arn}"
+  lambda_function_arn  = "${module.lambda_post_to_slack.arn}"
   sns_trigger_arn      = "${module.ec2_instance_terminating_for_too_long_alarm.arn}"
 }
 


### PR DESCRIPTION
### What is this PR trying to achieve?

Working date serialisation in `sns_utils` in order that the notify_old_deploy lambda functions as expected, giving us the full details of old deploys.

### Who is this change for?

💻 

### Have the following been considered/are they needed?

- [ ] Run `terraform apply`.
