### PR TITLE
Make healthchecks check on https port

### DIFF
--- a/terraform/services/ecs_service/alb.tf
+++ b/terraform/services/ecs_service/alb.tf
@@ -8,10 +8,10 @@ resource "aws_alb_target_group" "ecs_service" {
   vpc_id   = "${var.vpc_id}"
 
   health_check {
-    port = 443
+    port     = 443
     protocol = "HTTPS"
-    path    = "${var.healthcheck_path}"
-    matcher = "200"
+    path     = "${var.healthcheck_path}"
+    matcher  = "200"
   }
 }
 

--- a/terraform/services/ecs_service/alb.tf
+++ b/terraform/services/ecs_service/alb.tf
@@ -8,8 +8,10 @@ resource "aws_alb_target_group" "ecs_service" {
   vpc_id   = "${var.vpc_id}"
 
   health_check {
+    port = 443
+    protocol = "HTTPS"
     path    = "${var.healthcheck_path}"
-    matcher = "200,301"
+    matcher = "200"
   }
 }
 


### PR DESCRIPTION
### What is this PR trying to achieve?
Make health check fail if the service is responding. Currently they check that nginx replies with 301 which might still be true even if the actual application si broken
### Who is this change for?
Everyone
### Have the following been considered/are they needed?


- [ ] Run `terraform apply`.
