### PR TITLE
Forward healthcheck requests to our apps and not just nginx

### DIFF
--- a/docker/nginx/api.nginx.conf
+++ b/docker/nginx/api.nginx.conf
@@ -15,6 +15,14 @@ http {
     proxy_next_upstream error;
 
     if ($http_x_forwarded_proto != "https") {
+      set $https_redirect "1";
+    }
+
+    if ($http_user_agent != "ELB-HealthChecker/2.0") {
+      set $https_redirect "${https_redirect}1";
+    }
+
+    if ($https_redirect = "11") {
       rewrite ^(.*)$ https://api.wellcomecollection.org$1 permanent;
     }
 

--- a/docker/nginx/grafana.nginx.conf
+++ b/docker/nginx/grafana.nginx.conf
@@ -1,6 +1,6 @@
 worker_processes 1;
 
-events { worker_connections 1024; }
+events {worker_connections 1024;}
 
 http {
   server {
@@ -15,6 +15,14 @@ http {
     proxy_next_upstream error;
 
     if ($http_x_forwarded_proto != "https") {
+      set $https_redirect "1";
+    }
+
+    if ($http_user_agent != "ELB-HealthChecker/2.0") {
+      set $https_redirect "${https_redirect}1";
+    }
+
+    if ($https_redirect = "11") {
       rewrite ^(.*)$ https://monitoring.wellcomecollection.org$1 permanent;
     }
 

--- a/docker/nginx/loris.nginx.conf
+++ b/docker/nginx/loris.nginx.conf
@@ -15,6 +15,14 @@ http {
     proxy_next_upstream error;
 
     if ($http_x_forwarded_proto != "https") {
+      set $https_redirect "1";
+    }
+
+    if ($http_user_agent != "ELB-HealthChecker/2.0") {
+      set $https_redirect "${https_redirect}1";
+    }
+
+    if ($https_redirect = "11") {
       rewrite ^(.*)$ https://iiif.wellcomecollection.org$1 permanent;
     }
 

--- a/docker/nginx/services.nginx.conf
+++ b/docker/nginx/services.nginx.conf
@@ -15,6 +15,14 @@ http {
     proxy_next_upstream error;
 
     if ($http_x_forwarded_proto != "https") {
+      set $https_redirect "1";
+    }
+
+    if ($http_user_agent != "ELB-HealthChecker/2.0") {
+      set $https_redirect "${https_redirect}1";
+    }
+
+    if ($https_redirect = "11") {
       rewrite ^(.*)$ https://services.wellcomecollection.org$1 permanent;
     }
 

--- a/terraform/services/ecs_service/alb.tf
+++ b/terraform/services/ecs_service/alb.tf
@@ -10,7 +10,7 @@ resource "aws_alb_target_group" "ecs_service" {
   health_check {
     protocol = "HTTP"
     path     = "${var.healthcheck_path}"
-    matcher  = "200,301"
+    matcher  = "200"
   }
 }
 


### PR DESCRIPTION
### What is this PR trying to achieve?
Nginx http redirect mean that requests coming from ALB are always redirected meanung that the healthcheck never actually checks if the application is running. Make it forward the request if if comes from the ALB
### Who is this change for?
Everyone
### Have the following been considered/are they needed?

- [x] Run `terraform apply`.
