### PR TITLE
Add timestamp of when the alarm was trigger to slack notifications

### DIFF
--- a/lambdas/post_to_slack/post_to_slack.py
+++ b/lambdas/post_to_slack/post_to_slack.py
@@ -35,6 +35,10 @@ class Alarm:
     def state_reason(self):
         return self.message['NewStateReason']
 
+    @property
+    def state_change_time(self):
+        return self.message['StateChangeTime']
+
 
 def main(event, _):
     print(f'Received event:\n{pprint.pformat(event)}')
@@ -58,6 +62,10 @@ def main(event, _):
                           {
                               "title": "Reason",
                               "value": alarm.state_reason
+                          },
+                          {
+                              "title": "Timestamp",
+                              "value": alarm.state_change_time
                           }
                       ]
                   }]}

--- a/lambdas/post_to_slack/test_post_to_slack.py
+++ b/lambdas/post_to_slack/test_post_to_slack.py
@@ -32,6 +32,7 @@ def test_post_to_slack(mock_post):
     ]
     reason = "Threshold Crossed: 1 datapoint (4.0) was \
         greater than or equal to the threshold (1.0)."
+    timestamp = "2017-07-10T15:42:24.243+0000"
 
     alarm_info = {
         "AlarmName": alarm_name,
@@ -39,7 +40,7 @@ def test_post_to_slack(mock_post):
         "AWSAccountId": "account_id",
         "NewStateValue": "ALARM",
         "NewStateReason": reason,
-        "StateChangeTime": "2017-07-10T15:42:24.243+0000",
+        "StateChangeTime": timestamp,
         "Region": "EU - Ireland",
         "OldStateValue": "INSUFFICIENT_DATA",
         "Trigger": {
@@ -95,7 +96,7 @@ def test_post_to_slack(mock_post):
     attachment = sent_data['attachments'][0]
     assert attachment['fallback'] == alarm_name
     assert attachment['title'] == alarm_name
-    assert len(attachment['fields']) == 3
+    assert len(attachment['fields']) == 4
 
     _assert_field_contains(
         field=attachment['fields'][0],
@@ -111,4 +112,9 @@ def test_post_to_slack(mock_post):
         field=attachment['fields'][2],
         title='Reason',
         value=reason
+    )
+    _assert_field_contains(
+        field=attachment['fields'][3],
+        title='Timestamp',
+        value=timestamp
     )

--- a/lambdas/post_to_slack/test_post_to_slack.py
+++ b/lambdas/post_to_slack/test_post_to_slack.py
@@ -1,0 +1,93 @@
+import json
+import os
+import pprint
+
+import post_to_slack
+from mock import patch
+
+
+@patch('post_to_slack.requests.post')
+def test_post_to_slack(mock_post):
+    url = "http://blah.com"
+    os.environ['SLACK_INCOMING_WEBHOOK'] = url
+    mock_post.return_value.ok = True
+
+    alarm_name = "api-alb-target-500-errors"
+    metric_name = "HTTPCode_Target_5XX_Count"
+    namespace = "AWS/ApplicationELB"
+    dimensions = [
+        {
+            "name": "TargetGroup",
+            "value": "targetgroup/api/e0aa3403356f01e9"
+        },
+        {
+            "name": "LoadBalancer",
+            "value": "app/api/e87a4a5f32874d8b"
+        }
+    ]
+    reason = "Threshold Crossed: 1 datapoint (4.0) was greater than or equal to the threshold (1.0)."
+
+    alarm_info = {
+        "AlarmName": alarm_name,
+        "AlarmDescription": "This metric monitors api-alb-target-500-errors",
+        "AWSAccountId": "account_id",
+        "NewStateValue": "ALARM",
+        "NewStateReason": reason,
+        "StateChangeTime": "2017-07-10T15:42:24.243+0000",
+        "Region": "EU - Ireland",
+        "OldStateValue": "INSUFFICIENT_DATA",
+        "Trigger": {
+            "MetricName": metric_name,
+            "Namespace": namespace,
+            "StatisticType": "Statistic",
+            "Statistic": "SUM",
+            "Unit": "",
+            "Dimensions": dimensions,
+            "Period": 60,
+            "EvaluationPeriods": 1,
+            "ComparisonOperator": "GreaterThanOrEqualToThreshold",
+            "Threshold": 1.0,
+            "TreatMissingData": "",
+            "EvaluateLowSampleCountPercentile": ""
+        }
+    }
+    event = {'Records': [{'EventSource': 'aws:sns', 'EventVersion': '1.0',
+                          'EventSubscriptionArn': 'arn:aws:sns:region:account_id:alb_server_error_alarm:stuff',
+                          'Sns': {'Type': 'Notification', 'MessageId': 'b20eb72b-ffc7-5d09-9636-e6f65d67d10f',
+                                  'TopicArn': 'arn:aws:sns:region:account_id:alb_server_error_alarm',
+                                  'Subject': 'ALARM: "api-alb-target-500-errors" in EU - Ireland',
+                                  'Message': json.dumps(alarm_info),
+                                  'Timestamp': '2017-07-10T15:42:24.307Z', 'SignatureVersion': '1',
+                                  'Signature': 'signature',
+                                  'SigningCertUrl': 'https://cartificate.pem',
+                                  'UnsubscribeUrl': 'https://unsubscribe-url',
+                                  'MessageAttributes': {}}}]}
+
+    post_to_slack.main(event, None)
+
+    calls = mock_post.call_args_list
+    print(calls)
+
+    assert len(calls) == 1
+
+    assert calls[0][0][0] == url
+
+    sent_data = json.loads(calls[0][1]['data'])
+    print(sent_data)
+    assert len(sent_data['attachments']) == 1
+    attachment = sent_data['attachments'][0]
+    assert attachment['fallback'] == alarm_name
+    assert attachment['title'] == alarm_name
+    assert len(attachment['fields']) == 3
+
+    metric_field = attachment['fields'][0]
+    assert metric_field['title'] == 'Metric'
+    assert metric_field['value'] == f'{namespace}/{metric_name}'
+
+    dimensions_field = attachment['fields'][1]
+    assert dimensions_field['title'] == 'Dimensions'
+    assert dimensions_field['value'] == f'{pprint.pformat(dimensions)}'
+
+    reason_field = attachment['fields'][2]
+    assert reason_field['title'] == 'Reason'
+    assert reason_field['value'] == reason

--- a/lambdas/post_to_slack/test_post_to_slack.py
+++ b/lambdas/post_to_slack/test_post_to_slack.py
@@ -30,7 +30,8 @@ def test_post_to_slack(mock_post):
             "value": "app/api/e87a4a5f32874d8b"
         }
     ]
-    reason = "Threshold Crossed: 1 datapoint (4.0) was greater than or equal to the threshold (1.0)."
+    reason = "Threshold Crossed: 1 datapoint (4.0) was \
+        greater than or equal to the threshold (1.0)."
 
     alarm_info = {
         "AlarmName": alarm_name,
@@ -56,17 +57,29 @@ def test_post_to_slack(mock_post):
             "EvaluateLowSampleCountPercentile": ""
         }
     }
-    event = {'Records': [{'EventSource': 'aws:sns', 'EventVersion': '1.0',
-                          'EventSubscriptionArn': 'arn:aws:sns:region:account_id:alb_server_error_alarm:stuff',
-                          'Sns': {'Type': 'Notification', 'MessageId': 'b20eb72b-ffc7-5d09-9636-e6f65d67d10f',
-                                  'TopicArn': 'arn:aws:sns:region:account_id:alb_server_error_alarm',
-                                  'Subject': 'ALARM: "api-alb-target-500-errors" in EU - Ireland',
-                                  'Message': json.dumps(alarm_info),
-                                  'Timestamp': '2017-07-10T15:42:24.307Z', 'SignatureVersion': '1',
-                                  'Signature': 'signature',
-                                  'SigningCertUrl': 'https://cartificate.pem',
-                                  'UnsubscribeUrl': 'https://unsubscribe-url',
-                                  'MessageAttributes': {}}}]}
+
+    event = {
+        'Records': [{
+            'EventSource': 'aws:sns',
+            'EventVersion': '1.0',
+            'EventSubscriptionArn':
+                'arn:aws:sns:region:account_id:alb_server_error_alarm:stuff',
+            'Sns': {
+                'Type': 'Notification',
+                'MessageId': 'b20eb72b-ffc7-5d09-9636-e6f65d67d10f',
+                'TopicArn':
+                    'arn:aws:sns:region:account_id:alb_server_error_alarm',
+                'Subject':
+                    'ALARM: "api-alb-target-500-errors" in EU - Ireland',
+                'Message': json.dumps(alarm_info),
+                'Timestamp': '2017-07-10T15:42:24.307Z',
+                'SignatureVersion': '1',
+                'Signature': 'signature',
+                'SigningCertUrl': 'https://certificate.pem',
+                'UnsubscribeUrl': 'https://unsubscribe-url',
+                'MessageAttributes': {}}
+        }]
+    }
 
     post_to_slack.main(event, None)
 

--- a/lambdas/post_to_slack/test_post_to_slack.py
+++ b/lambdas/post_to_slack/test_post_to_slack.py
@@ -6,6 +6,11 @@ import post_to_slack
 from mock import patch
 
 
+def _assert_field_contains(field, title, value):
+    assert field['title'] == title
+    assert field['value'] == value
+
+
 @patch('post_to_slack.requests.post')
 def test_post_to_slack(mock_post):
     url = "http://blah.com"
@@ -66,28 +71,31 @@ def test_post_to_slack(mock_post):
     post_to_slack.main(event, None)
 
     calls = mock_post.call_args_list
-    print(calls)
 
     assert len(calls) == 1
 
     assert calls[0][0][0] == url
 
     sent_data = json.loads(calls[0][1]['data'])
-    print(sent_data)
+
     assert len(sent_data['attachments']) == 1
     attachment = sent_data['attachments'][0]
     assert attachment['fallback'] == alarm_name
     assert attachment['title'] == alarm_name
     assert len(attachment['fields']) == 3
 
-    metric_field = attachment['fields'][0]
-    assert metric_field['title'] == 'Metric'
-    assert metric_field['value'] == f'{namespace}/{metric_name}'
-
-    dimensions_field = attachment['fields'][1]
-    assert dimensions_field['title'] == 'Dimensions'
-    assert dimensions_field['value'] == f'{pprint.pformat(dimensions)}'
-
-    reason_field = attachment['fields'][2]
-    assert reason_field['title'] == 'Reason'
-    assert reason_field['value'] == reason
+    _assert_field_contains(
+        field=attachment['fields'][0],
+        title='Metric',
+        value=f'{namespace}/{metric_name}'
+    )
+    _assert_field_contains(
+        field=attachment['fields'][1],
+        title='Dimensions',
+        value=f'{pprint.pformat(dimensions)}'
+    )
+    _assert_field_contains(
+        field=attachment['fields'][2],
+        title='Reason',
+        value=reason
+    )


### PR DESCRIPTION
### What is this PR trying to achieve?
Give us more information when troubleshooting slack errors
### Who is this change for?
Devs
### Have the following been considered/are they needed?

- [ ] Run `terraform apply`.
