### PR TITLE
Adds neo-sbt-scalafmt plugin

### DIFF
--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,3 +1,4 @@
 addSbtPlugin("io.spray" % "sbt-revolver" % "0.8.0")
 addSbtPlugin("com.tapad" % "sbt-docker-compose" % "1.0.20")
 addSbtPlugin("com.typesafe.sbt" % "sbt-native-packager" % "1.1.4")
+addSbtPlugin("com.lucidchart" % "sbt-scalafmt" % "1.8")


### PR DESCRIPTION
### What is this PR trying to achieve?

Adds https://github.com/lucidsoftware/neo-sbt-scalafmt plugin (Thanks Lucidchart!) in order that scalafmt is easy to run from within sbt.

### Who is this change for?

💻 
