### PR TITLE
Update dynamo-to-sns to lambda to deserialize item nicely

### DIFF
--- a/docker/python3.6_ci/Dockerfile
+++ b/docker/python3.6_ci/Dockerfile
@@ -10,6 +10,8 @@ RUN pip install pytest
 
 RUN pip install moto
 
+RUN pip install simplejson 
+
 COPY run.sh /app/run.sh
 
 ENTRYPOINT /app/run.sh

--- a/lambdas/common/dynamo_utils.py
+++ b/lambdas/common/dynamo_utils.py
@@ -1,8 +1,8 @@
 # -*- encoding: utf-8 -*-
 
-import pprint
-
 import boto3
+from boto3.dynamodb.types import TypeDeserializer
+import pprint
 
 
 class DynamoEvent:
@@ -16,6 +16,14 @@ class DynamoEvent:
     @property
     def source_arn(self):
         return self.event['Records'][0]['eventSourceARN']
+
+    @property
+    def simplified_new_image(self):
+        image = self.event['Records'][0]['dynamodb']['NewImage']
+
+        td = TypeDeserializer()
+
+        return {k: td.deserialize(v) for k, v in image.items()}
 
 
 def change_dynamo_capacity(table_name, desired_capacity):

--- a/lambdas/common/sns_utils.py
+++ b/lambdas/common/sns_utils.py
@@ -1,7 +1,8 @@
 # -*- encoding: utf-8 -*-
 
 from datetime import datetime
-import json
+import decimal
+import simplejson as json
 import pprint
 
 import boto3
@@ -11,6 +12,12 @@ class EnhancedJSONEncoder(json.JSONEncoder):
     def default(self, o):
         if isinstance(o, datetime):
             return o.isoformat()
+
+        if isinstance(o, decimal.Decimal):
+            # wanted a simple yield str(o) in the next line,
+            # but that would mean a yield on the line with super(...),
+            # which wouldn't work (see my comment below), so...
+            return (str(o) for o in [o])
 
         return json.JSONEncoder.default(self, o)
 
@@ -25,7 +32,11 @@ def publish_sns_message(topic_arn, message):
         TopicArn=topic_arn,
         MessageStructure='json',
         Message=json.dumps({
-            'default': json.dumps(message, cls=EnhancedJSONEncoder)
+            'default': json.dumps(
+                message,
+                cls=EnhancedJSONEncoder,
+                iterable_as_array=True
+            )
         })
     )
     print(f'SNS response:\n{pprint.pformat(resp)}')

--- a/lambdas/dynamo_to_sns/dynamo_to_sns.py
+++ b/lambdas/dynamo_to_sns/dynamo_to_sns.py
@@ -16,4 +16,7 @@ def main(event, _):
     dynamo_event = DynamoEvent(event)
     stream_topic_map = json.loads(os.environ["STREAM_TOPIC_MAP"])
     topic_arn = stream_topic_map[dynamo_event.source_arn]
-    publish_sns_message(topic_arn, dynamo_event.new_image)
+
+    print(dynamo_event.simplified_new_image)
+
+    publish_sns_message(topic_arn, dynamo_event.simplified_new_image)

--- a/lambdas/dynamo_to_sns/requirements.in
+++ b/lambdas/dynamo_to_sns/requirements.in
@@ -1,0 +1,1 @@
+simplejson

--- a/lambdas/dynamo_to_sns/test_dynamo_to_sns.py
+++ b/lambdas/dynamo_to_sns/test_dynamo_to_sns.py
@@ -38,12 +38,21 @@ def test_dynamo_to_sns():
     )
 
     stream_arn = 'arn:aws:dynamodb:eu-west-1:123456789012:table/table-stream'
+
     new_image = {
         'ReindexVersion': {'N': '0'},
         'ReindexShard': {'S': 'default'},
         'data': {'S': 'test-json-data'},
         'MiroID': {'S': 'V0010033'},
         'MiroCollection': {'S': 'Images-V'}
+    }
+
+    expected_image = {
+        'ReindexVersion': 0,
+        'ReindexShard': 'default',
+        'data': 'test-json-data',
+        'MiroID': 'V0010033',
+        'MiroCollection': 'Images-V'
     }
 
     event = {
@@ -83,4 +92,4 @@ def test_dynamo_to_sns():
         MaxNumberOfMessages=1
     )
     message_body = messages['Messages'][0]['Body']
-    assert json.loads(message_body)['default'] == json.dumps(new_image)
+    assert json.loads(message_body)['default'] == json.dumps(expected_image)


### PR DESCRIPTION
### What is this PR trying to achieve?

In order to output a more easily deserialised dynamo item and consequently remove dynamo logic downstream we want to output dynamo items in JSON in a fashion that can easily be extracted.

```py
new_image = {
   'ReindexVersion': {'N': '0'},
   'ReindexShard': {'S': 'default'},
   'data': {'S': 'test-json-data'},
   'MiroID': {'S': 'V0010033'},
   'MiroCollection': {'S': 'Images-V'}
}

# Becomes: 

expected_image = {
   'ReindexVersion': 0,
   'ReindexShard': 'default',
   'data': 'test-json-data',
   'MiroID': 'V0010033',
   'MiroCollection': 'Images-V'
}
```
 

### Who is this change for?

💻 

### Have the following been considered/are they needed?

- [ ] Deployed new versions

