### PR TITLE
Use the description for the Miro label, not a truncated version

### DIFF
--- a/common/src/main/scala/uk/ac/wellcome/models/MiroTransformable.scala
+++ b/common/src/main/scala/uk/ac/wellcome/models/MiroTransformable.scala
@@ -54,11 +54,20 @@ case class MiroTransformable(MiroID: String,
 
       // <image_title>: the Short Description.  This maps to our property
       // "label".
-      val label = miroData.title.get
+      //
+      // In the V collection, this is just a truncated form of the desc field,
+      // so we pass the full string as the label and omit a description.
+      val label = MiroCollection match {
+        case "Images-V" => miroData.description.get
+        case _ => miroData.title.get
+      }
 
       // <image_image_desc>: the Description, which maps to our property
       // "description".
-      val description = miroData.description
+      val description = MiroCollection match {
+        case "Images-V" => None
+        case _ => miroData.description
+      }
 
       // <image_creator>: the Creator, which maps to our property "hasCreator"
       val creators: List[Agent] = miroData.creator match {

--- a/common/src/test/scala/uk/ac/wellcome/models/MiroTransformableTest.scala
+++ b/common/src/test/scala/uk/ac/wellcome/models/MiroTransformableTest.scala
@@ -27,6 +27,19 @@ class MiroTransformableTest extends FunSpec with Matchers {
     work.label shouldBe title
   }
 
+  it("should use the description field for label in the V collection") {
+    val title = "A falsehood about a ferret"
+    val description = "A falsehood about a ferret could be frightful"
+    val work = transformMiroRecord(
+      miroCollection = "Images-V",
+      data = s"""{
+        "image_title": "$title",
+        "image_description": "$description"
+      }"""
+    )
+    work.label shouldBe description
+  }
+
   it("should have an empty list if no image_creator field is present") {
     val work = transformMiroRecord(data = s"""{
       "image_title": "A guide to giraffes",

--- a/common/src/test/scala/uk/ac/wellcome/models/MiroTransformableTest.scala
+++ b/common/src/test/scala/uk/ac/wellcome/models/MiroTransformableTest.scala
@@ -34,7 +34,9 @@ class MiroTransformableTest extends FunSpec with Matchers {
       miroCollection = "Images-V",
       data = s"""{
         "image_title": "$title",
-        "image_description": "$description"
+        "image_image_desc": "$description",
+        "image_cleared": "Y",
+        "image_copyright_cleared": "Y"
       }"""
     )
     work.label shouldBe description
@@ -116,6 +118,7 @@ class MiroTransformableTest extends FunSpec with Matchers {
     val work = transformMiroRecord(
       data = s"""{
         "image_title": "A description of a dalmation",
+        "image_image_desc": "A description of a dalmation with dots",
         "image_artwork_date": "$date",
         "image_cleared": "Y",
         "image_copyright_cleared": "Y"


### PR DESCRIPTION
### What is this PR trying to achieve?

Metadata for Miro records won’t have weird amounts of duplication for V images.

Resolves #616.

### Who is this change for?

End-users who want a less repetitive API. End-users who want a less repetitive API.

### Have the following been considered/are they needed?

- [ ] Deployed new versions
