### PR TITLE
Fix lint task failure because of third party libs

### DIFF
--- a/docker/python3.6_ci/run.sh
+++ b/docker/python3.6_ci/run.sh
@@ -9,7 +9,7 @@ cd /data
 if [[ "$OP" == "lint" ]]
 then
   echo "Linting Lambdas"
-  flake8 .
+  flake8 --exclude six.py,six-*,structlog* .
 elif [[ "$OP" == "test" ]]
 then
   echo "Testing Lambdas"


### PR DESCRIPTION
### What is this PR trying to achieve?

Linting Python that doesn't include 3rd party libraries and consequently error incorrectly.

### Who is this change for?

💻 

