### PR TITLE
Expunge use of pprint() in our Lambda code

### DIFF
--- a/lambdas/common/dynamo_utils.py
+++ b/lambdas/common/dynamo_utils.py
@@ -2,7 +2,6 @@
 
 import boto3
 from boto3.dynamodb.types import TypeDeserializer
-import pprint
 
 
 class DynamoEvent:
@@ -61,5 +60,5 @@ def change_dynamo_capacity(table_name, desired_capacity):
         GlobalSecondaryIndexUpdates=gsi_updates
     )
 
-    print(f'DynamoDB response:\n{pprint.pformat(resp)}')
+    print(f'DynamoDB response = {resp!r}')
     assert resp['ResponseMetadata']['HTTPStatusCode'] == 200

--- a/lambdas/common/sns_utils.py
+++ b/lambdas/common/sns_utils.py
@@ -2,10 +2,9 @@
 
 from datetime import datetime
 import decimal
-import simplejson as json
-import pprint
 
 import boto3
+import simplejson as json
 
 
 class EnhancedJSONEncoder(json.JSONEncoder):
@@ -39,5 +38,5 @@ def publish_sns_message(topic_arn, message):
             )
         })
     )
-    print(f'SNS response:\n{pprint.pformat(resp)}')
+    print(f'SNS response = {resp!r}')
     assert resp['ResponseMetadata']['HTTPStatusCode'] == 200

--- a/lambdas/drain_ecs_container_instance/drain_ecs_container_instance.py
+++ b/lambdas/drain_ecs_container_instance/drain_ecs_container_instance.py
@@ -8,7 +8,6 @@ EC2 instances. If the terminating instance is part of an ECS cluster, it
 drains the ECS tasks on the instance.
 """
 import json
-import pprint
 import time
 
 import boto3
@@ -36,12 +35,12 @@ def continue_lifecycle_action(
         ec2_instance_id,
         lifecycle_hook_name):
 
-    response = asg_client.complete_lifecycle_action(
+    resp = asg_client.complete_lifecycle_action(
         LifecycleHookName=lifecycle_hook_name,
         AutoScalingGroupName=asg_group_name,
         LifecycleActionResult='CONTINUE',
         InstanceId=ec2_instance_id)
-    pprint.pprint(response)
+    print(f'resp = {resp!r}')
 
 
 def get_ec2_tags(ec2_client, ec2_instance_id):
@@ -50,12 +49,12 @@ def get_ec2_tags(ec2_client, ec2_instance_id):
     ])
     tags = ec2_instance_info['Reservations'][0]['Instances'][0]['Tags']
     tag_dict = {t['Key']: t['Value'] for t in tags}
-    print(f"tag_dict: {tag_dict}")
+    print(f'tag_dict = {tag_dict!r}')
     return tag_dict
 
 
 def main(event, _):
-    print(f'Received event:\n{pprint.pformat(event)}')
+    print(f'event = {event!r}')
     asg_client = boto3.client("autoscaling")
     ec2_client = boto3.client("ec2")
     ecs_client = boto3.client('ecs')

--- a/lambdas/ecs_ec2_instance_tagger/ecs_ec2_instance_tagger.py
+++ b/lambdas/ecs_ec2_instance_tagger/ecs_ec2_instance_tagger.py
@@ -19,8 +19,6 @@ Requires a Cloudwatch Event with pattern:
 
 """
 
-import pprint
-
 import boto3
 
 
@@ -45,12 +43,11 @@ def create_tags(ec2_client, ec2_instance_id, event_detail):
 
 
 def main(event, _):
-    print(f'Received event:\n{pprint.pformat(event)}')
+    print(f'event = {event!r}')
 
     ec2_client = boto3.client('ec2')
 
     ec2_instance_id = event['detail']['ec2InstanceId']
 
     response = create_tags(ec2_client, ec2_instance_id, event['detail'])
-
-    print(f'Received response:\n{pprint.pformat(response)}')
+    print(f'response = {response!r}')

--- a/lambdas/notify_old_deploys/notify_old_deploys.py
+++ b/lambdas/notify_old_deploys/notify_old_deploys.py
@@ -13,7 +13,6 @@ than AGE_BOUNDARY_MINS.
 
 from datetime import datetime, timedelta
 import os
-import pprint
 
 import boto3
 
@@ -43,7 +42,7 @@ def publish_deployments(topic_arn, deployments):
 
 
 def main(event, _):
-    print(f'Received event:\n{pprint.pformat(event)}')
+    print(f'event = {event!r}')
 
     table_name = os.environ["TABLE_NAME"]
     topic_arn = os.environ["TOPIC_ARN"]
@@ -56,4 +55,4 @@ def main(event, _):
     old_deployments = filter_old_deployments(deployments, age_boundary_mins)
     publish_deployments(topic_arn, old_deployments)
 
-    print(f'Received old deployments:\n{pprint.pformat(old_deployments)}')
+    print(f'old_deployments = {old_deployments!r}')

--- a/lambdas/post_to_slack/post_to_slack.py
+++ b/lambdas/post_to_slack/post_to_slack.py
@@ -5,7 +5,6 @@ Sends slack notifications for alarms events
 """
 
 import json
-import pprint
 import os
 
 from botocore.vendored import requests
@@ -41,7 +40,7 @@ class Alarm:
 
 
 def main(event, _):
-    print(f'Received event:\n{pprint.pformat(event)}')
+    print(f'event = {event!r}')
     alarm = Alarm(event['Records'][0]['Sns']['Message'])
 
     slack_data = {'username': 'cloudwatch-alert',
@@ -57,7 +56,7 @@ def main(event, _):
                           },
                           {
                               "title": "Dimensions",
-                              "value": f"{pprint.pformat(alarm.dimensions)}"
+                              "value": repr(alarm.dimensions)
                           },
                           {
                               "title": "Reason",

--- a/lambdas/post_to_slack/test_post_to_slack.py
+++ b/lambdas/post_to_slack/test_post_to_slack.py
@@ -1,6 +1,5 @@
 import json
 import os
-import pprint
 
 import post_to_slack
 from mock import patch
@@ -106,7 +105,7 @@ def test_post_to_slack(mock_post):
     _assert_field_contains(
         field=attachment['fields'][1],
         title='Dimensions',
-        value=f'{pprint.pformat(dimensions)}'
+        value=repr(dimensions)
     )
     _assert_field_contains(
         field=attachment['fields'][2],

--- a/lambdas/schedule_reindexer/schedule_reindexer.py
+++ b/lambdas/schedule_reindexer/schedule_reindexer.py
@@ -7,7 +7,6 @@ This script is triggered by updates to the reindexer DynamoDB table.
 """
 
 import os
-import pprint
 
 from dynamo_utils import DynamoEvent
 from sns_utils import publish_sns_message
@@ -20,7 +19,7 @@ def get_service_name(reindexers, table_name):
 
 
 def main(event, _):
-    print(f'Received event:\n{pprint.pformat(event)}')
+    print(f'event = {event!r}')
 
     dynamo_event = DynamoEvent(event)
     table_name = dynamo_event.new_image["TableName"]["S"]
@@ -40,13 +39,8 @@ def main(event, _):
     message = {'cluster': cluster, 'service': service,
                'desired_count': desired_count}
 
-    print(f"""
-        desired_count: {desired_count},
-        scheduler_topic_arn: {scheduler_topic_arn},
-        cluster: {cluster},
-        service: {service}
-    """)
-
+    print(f'message = {message!r}')
+    print(f'scheduler_topic_arn = {scheduler_topic_arn!r}')
     publish_sns_message(topic_arn=scheduler_topic_arn, message=message)
 
     dynamo_topic_arn = os.environ["DYNAMO_TOPIC_ARN"]
@@ -54,10 +48,5 @@ def main(event, _):
     message = {'dynamo_table_name': dynamo_table_name,
                'desired_capacity': desired_capacity}
 
-    print(f"""
-        dynamo_topic_arn: {dynamo_topic_arn},
-        dynamo_table_name: {dynamo_table_name},
-        desired_capacity: {desired_capacity}
-    """)
-
+    print(f'message = {message!r}')
     publish_sns_message(topic_arn=dynamo_topic_arn, message=message)

--- a/lambdas/service_deployment_status/service_deployment_status.py
+++ b/lambdas/service_deployment_status/service_deployment_status.py
@@ -8,7 +8,6 @@ stream and writes deployment "color" to dynamo. With color being blue or green.
 """
 
 import os
-import pprint
 
 import boto3
 
@@ -77,7 +76,7 @@ def run_operations(operations, table):
 
 
 def main(event, _):
-    print(f'Received event:\n{pprint.pformat(event)}')
+    print(f'event = {event!r}')
 
     table_name = os.environ["TABLE_NAME"]
 
@@ -91,4 +90,4 @@ def main(event, _):
 
     ops = run_operations(operations, table)
 
-    print(f'Run dynamo ops:\n{pprint.pformat(ops)}')
+    print(f'ops = {ops!r}')

--- a/lambdas/service_scheduler/service_scheduler.py
+++ b/lambdas/service_scheduler/service_scheduler.py
@@ -8,13 +8,11 @@ one of our adapters.  It receives a blob of JSON from a CloudWatch timed
 event, and publishes that to the service scheduler topic.
 """
 
-import pprint
-
 from sns_utils import publish_sns_message
 
 
 def main(event, _):
-    print(f'Received event:\n{pprint.pformat(event)}')
+    print(f'event = {event!r}')
     message = {
         'cluster': event['cluster'],
         'service': event['service'],

--- a/lambdas/update_dynamo_capacity/update_dynamo_capacity.py
+++ b/lambdas/update_dynamo_capacity/update_dynamo_capacity.py
@@ -10,13 +10,12 @@ and "desired_capacity".
 """
 
 import json
-import pprint
 
 from dynamo_utils import change_dynamo_capacity
 
 
 def main(event, _):
-    print(f'Received event:\n{pprint.pformat(event)}')
+    print(f'event = {event!r}')
     message = event['Records'][0]['Sns']['Message']
     message_data = json.loads(message)
 

--- a/lambdas/update_ecs_service_size/update_ecs_service_size.py
+++ b/lambdas/update_ecs_service_size/update_ecs_service_size.py
@@ -13,7 +13,6 @@ message should be a JSON string that includes "cluster", "service" and
 """
 
 import json
-import pprint
 
 import boto3
 
@@ -29,12 +28,12 @@ def change_desired_count(cluster, service, desired_count):
         service=service,
         desiredCount=desired_count
     )
-    print(f'ECS response:\n{pprint.pformat(resp)}')
+    print(f'resp = {resp!r}')
     assert resp['ResponseMetadata']['HTTPStatusCode'] == 200
 
 
 def main(event, _):
-    print(f'Received event:\n{pprint.pformat(event)}')
+    print(f'event = {event!r}')
     message = event['Records'][0]['Sns']['Message']
     message_data = json.loads(message)
 

--- a/lambdas/update_service_list/update_service_list.py
+++ b/lambdas/update_service_list/update_service_list.py
@@ -116,6 +116,7 @@ def create_boto_client(service, role_arn):
 
 
 def main(event, _):
+    print(f'event = {event!r}')
     assumable_roles = (
         [s for s in os.environ["ASSUMABLE_ROLES"].split(",") if s]
     )
@@ -137,7 +138,7 @@ def main(event, _):
         'lastUpdated': str(datetime.datetime.utcnow())
     }
 
-    print(service_snapshot)
+    print(f'service_snapshot = {service_snapshot!r}')
 
     s3_client = boto3.client('s3')
 
@@ -148,4 +149,4 @@ def main(event, _):
         object_key
     )
 
-    print(response)
+    print(f'response = {response}')

--- a/lambdas/update_task_for_config_change/update_task_for_config_change.py
+++ b/lambdas/update_task_for_config_change/update_task_for_config_change.py
@@ -10,7 +10,6 @@ scheduler will bring up new instances with the updated config.
 
 """
 
-import pprint
 import re
 
 import boto3
@@ -37,13 +36,13 @@ def clone_latest_task_definition(client, cluster, service):
     )
     print(f'The cloned task definition is {cloned_task}, updating {service}')
 
-    response = client.update_service(
+    resp = client.update_service(
         cluster=cluster,
         service=service,
         taskDefinition=cloned_task
     )
-    print(f'ECS response:\n{pprint.pformat(response)}')
-    assert response['ResponseMetadata']['HTTPStatusCode'] == 200
+    print(f'ECS response = {resp!r}')
+    assert resp['ResponseMetadata']['HTTPStatusCode'] == 200
 
 
 def trigger_config_update(app_name):
@@ -74,7 +73,7 @@ def parse_s3_event(event):
 
 
 def main(event, _):
-    print(f'Received event:\n{pprint.pformat(event)}')
+    print(f'event = {event!r}')
     app_name = parse_s3_event(event=event)
     trigger_config_update(app_name=app_name)
 


### PR DESCRIPTION
### What is this PR trying to achieve?

Our Lambdas now use standard printing, not pprint. Resolves #633.

### Who is this change for?

Anybody who has to wade through our CloudWatch logs, which were unnecessarily spammy thanks to pprint. It’s useful when debugging locally, but was causing logs to take up much more space than necessary.

Reviewer note: the `!r` in all the print calls tells Python to use the _repr_ of the object – the repr is the unambiguous representation of an object, as opposed to its _str_(ing), which is meant to be human-readable, at the sometimes cost of ambiguity.

### Have the following been considered/are they needed?

- [ ] Deployed new versions
