### PR TITLE
Tests for drain_ecs_container_instance lambda

### DIFF
--- a/lambdas/common/conftest.py
+++ b/lambdas/common/conftest.py
@@ -10,6 +10,17 @@ def moto_start():
     mock_ecs().start()
     mock_sns().start()
     mock_sqs().start()
+    # Need this otherwise boto complains about missing region
+    # in sns_utils.pblish_sns_message when trying to create client
+    # with sns = boto3.client('sns') (despite region being set with
+    # the environment variable AWS_DEFAULT_REGION, which should be
+    # read by default by boto)
+    # Weirdly enough it doesn't complain in this file when it tries
+    # to do the same thing.
+    # After investigation this is not related to moto
+    session = boto3.Session()
+    region = session.region_name
+    boto3.setup_default_session(region_name=region)
     yield
     mock_autoscaling().stop()
     mock_ec2().stop()

--- a/lambdas/common/conftest.py
+++ b/lambdas/common/conftest.py
@@ -1,0 +1,40 @@
+import boto3
+from moto import mock_ec2, mock_autoscaling, mock_ecs, mock_sns, mock_sqs
+import pytest
+
+
+@pytest.fixture()
+def moto_start():
+    mock_autoscaling().start()
+    mock_ec2().start()
+    mock_ecs().start()
+    mock_sns().start()
+    mock_sqs().start()
+    yield
+    mock_autoscaling().stop()
+    mock_ec2().stop()
+    mock_ecs().stop()
+    mock_sns().stop()
+    mock_sqs().stop()
+
+
+@pytest.fixture()
+def sns_sqs(moto_start):
+    fake_sns_client = boto3.client('sns')
+    fake_sqs_client = boto3.client('sqs')
+    queue_name = "test-queue"
+    topic_name = "test-topic"
+    print(f"Creating topic {topic_name} and queue {queue_name}")
+
+    fake_sns_client.create_topic(Name=topic_name)
+    response = fake_sns_client.list_topics()
+    topic_arn = response["Topics"][0]['TopicArn']
+
+    queue = fake_sqs_client.create_queue(QueueName=queue_name)
+
+    fake_sns_client.subscribe(
+        TopicArn=topic_arn,
+        Protocol="sqs",
+        Endpoint=f"arn:aws:sqs:eu-west-1:123456789012:{queue_name}"
+    )
+    yield topic_arn, queue['QueueUrl']

--- a/lambdas/common/conftest.py
+++ b/lambdas/common/conftest.py
@@ -4,12 +4,7 @@ import pytest
 
 
 @pytest.fixture()
-def moto_start():
-    mock_autoscaling().start()
-    mock_ec2().start()
-    mock_ecs().start()
-    mock_sns().start()
-    mock_sqs().start()
+def set_region():
     # Need this otherwise boto complains about missing region
     # in sns_utils.pblish_sns_message when trying to create client
     # with sns = boto3.client('sns') (despite region being set with
@@ -21,6 +16,15 @@ def moto_start():
     session = boto3.Session()
     region = session.region_name
     boto3.setup_default_session(region_name=region)
+
+
+@pytest.fixture()
+def moto_start(set_region):
+    mock_autoscaling().start()
+    mock_ec2().start()
+    mock_ecs().start()
+    mock_sns().start()
+    mock_sqs().start()
     yield
     mock_autoscaling().stop()
     mock_ec2().stop()

--- a/lambdas/drain_ecs_container_instance/conftest.py
+++ b/lambdas/drain_ecs_container_instance/conftest.py
@@ -1,0 +1,1 @@
+../common/conftest.py

--- a/lambdas/drain_ecs_container_instance/drain_ecs_container_instance.py
+++ b/lambdas/drain_ecs_container_instance/drain_ecs_container_instance.py
@@ -53,12 +53,7 @@ def get_ec2_tags(ec2_client, ec2_instance_id):
     return tag_dict
 
 
-def main(event, _):
-    print(f'event = {event!r}')
-    asg_client = boto3.client("autoscaling")
-    ec2_client = boto3.client("ec2")
-    ecs_client = boto3.client('ecs')
-
+def drain_ecs_container_instance(asg_client, ec2_client, ecs_client, event):
     topic_arn = event['Records'][0]['Sns']['TopicArn']
     message = event['Records'][0]['Sns']['Message']
     message_data = json.loads(message)
@@ -121,3 +116,12 @@ def main(event, _):
 
             time.sleep(30)
             publish_sns_message(topic_arn, message_data)
+
+
+def main(event, _):
+    print(f'event = {event!r}')
+    asg_client = boto3.client("autoscaling")
+    ec2_client = boto3.client("ec2")
+    ecs_client = boto3.client('ecs')
+
+    drain_ecs_container_instance(asg_client, ec2_client, ecs_client, event)

--- a/lambdas/drain_ecs_container_instance/drain_ecs_container_instance.py
+++ b/lambdas/drain_ecs_container_instance/drain_ecs_container_instance.py
@@ -19,7 +19,6 @@ def set_container_instance_to_draining(
         ecs_client,
         cluster_arn,
         ecs_container_instance_arn):
-
     resp = ecs_client.update_container_instances_state(
         cluster=cluster_arn,
         containerInstances=[
@@ -27,7 +26,7 @@ def set_container_instance_to_draining(
         ],
         status='DRAINING'
     )
-    print(resp)
+    print(f'Updating container instance response:\n{resp}')
 
 
 def continue_lifecycle_action(
@@ -112,6 +111,7 @@ def main(event, _):
             )
 
             status = container_instance_info['containerInstances'][0]['status']
+            print(ecs_container_instance_arn)
 
             if status != 'DRAINING':
                 set_container_instance_to_draining(

--- a/lambdas/drain_ecs_container_instance/drain_ecs_container_instance.py
+++ b/lambdas/drain_ecs_container_instance/drain_ecs_container_instance.py
@@ -20,13 +20,14 @@ def set_container_instance_to_draining(
         cluster_arn,
         ecs_container_instance_arn):
 
-    ecs_client.update_container_instances_state(
+    resp = ecs_client.update_container_instances_state(
         cluster=cluster_arn,
         containerInstances=[
             ecs_container_instance_arn,
         ],
         status='DRAINING'
     )
+    print(resp)
 
 
 def continue_lifecycle_action(

--- a/lambdas/drain_ecs_container_instance/drain_ecs_container_instance.py
+++ b/lambdas/drain_ecs_container_instance/drain_ecs_container_instance.py
@@ -106,7 +106,6 @@ def drain_ecs_container_instance(asg_client, ec2_client, ecs_client, event):
             )
 
             status = container_instance_info['containerInstances'][0]['status']
-            print(ecs_container_instance_arn)
 
             if status != 'DRAINING':
                 set_container_instance_to_draining(

--- a/lambdas/drain_ecs_container_instance/test_drain_ecs_container_instance.py
+++ b/lambdas/drain_ecs_container_instance/test_drain_ecs_container_instance.py
@@ -28,6 +28,7 @@ def moto_start():
 @pytest.fixture()
 def autoscaling_group_info(moto_start):
     auto_scaling_group_name = 'TestGroup1'
+    print(f"creating autoscaling group {auto_scaling_group_name}")
     fake_asg_client = boto3.client('autoscaling')
     fake_asg_client.create_launch_configuration(
         LaunchConfigurationName='TestLC'
@@ -50,13 +51,14 @@ def autoscaling_group_info(moto_start):
 def sns_sqs_info(moto_start):
     fake_sns_client = boto3.client('sns')
     fake_sqs_client = boto3.client('sqs')
+    queue_name = "test-queue"
+    topic_name = "test-topic"
+    print(f"Creating topic {topic_name} and queue {queue_name}")
 
-    fake_sns_client.create_topic(Name="test-topic")
-
+    fake_sns_client.create_topic(Name=topic_name)
     response = fake_sns_client.list_topics()
     topic_arn = response["Topics"][0]['TopicArn']
 
-    queue_name = "test-queue"
     queue = fake_sqs_client.create_queue(QueueName=queue_name)
 
     fake_sns_client.subscribe(
@@ -65,6 +67,93 @@ def sns_sqs_info(moto_start):
         Endpoint=f"arn:aws:sqs:eu-west-1:123456789012:{queue_name}"
     )
     yield topic_arn, queue['QueueUrl']
+
+
+@pytest.fixture()
+def ecs_cluster(autoscaling_group_info):
+    fake_ecs_client = boto3.client('ecs')
+    fake_ec2_client = boto3.client('ec2')
+    cluster_name = 'test_ecs_cluster'
+    print(f"Creating ecs cluster {cluster_name}")
+    instance_id = autoscaling_group_info[1]
+    cluster_response = fake_ecs_client.create_cluster(
+        clusterName=cluster_name
+    )
+
+    ec2 = boto3.resource('ec2')
+    instance = ec2.Instance(instance_id)
+
+    instance_id_document = json.dumps(
+        ec2_utils.generate_instance_identity_document(instance)
+    )
+
+    register_container_response = fake_ecs_client.register_container_instance(
+        cluster=cluster_name,
+        instanceIdentityDocument=instance_id_document
+    )
+
+    container_instance_arn = \
+        register_container_response['containerInstance']['containerInstanceArn']
+    cluster_arn = cluster_response['cluster']['clusterArn']
+
+    fake_ec2_client.create_tags(
+        Resources=[
+            instance_id,
+        ],
+        Tags=[
+            {
+                'Key': 'clusterArn',
+                'Value': cluster_arn
+            },
+            {
+                'Key': 'containerInstanceArn',
+                'Value': container_instance_arn
+            }
+        ]
+    )
+    yield cluster_arn, cluster_arn, container_instance_arn
+
+
+@pytest.fixture()
+def ecs_task(ecs_cluster):
+    fake_ecs_client = boto3.client('ecs')
+    task_name = 'test_ecs_task'
+
+    cluster_name = ecs_cluster[0]
+    cluster_arn = ecs_cluster[1]
+    container_instance_arn = ecs_cluster[2]
+    fake_ecs_client.register_task_definition(
+        family=task_name,
+        containerDefinitions=[
+            {
+                'name': 'hello_world',
+                'image': 'docker/hello-world:latest',
+                'cpu': 1024,
+                'memory': 400,
+                'essential': True,
+                'environment': [{
+                    'name': 'AWS_ACCESS_KEY_ID',
+                    'value': 'SOME_ACCESS_KEY'
+                }],
+                'logConfiguration': {'logDriver': 'json-file'}
+            }
+        ]
+    )
+
+    fake_ecs_client.run_task(
+        cluster=cluster_name,
+        overrides={},
+        taskDefinition=task_name,
+        count=1,
+        startedBy='moto'
+    )
+
+    tasks = fake_ecs_client.list_tasks(
+        cluster=cluster_arn,
+        containerInstance=container_instance_arn
+    )
+    assert len(tasks['taskArns']) == 1
+    yield
 
 
 def test_complete_ec2_shutdown_if_no_ecs_cluster(autoscaling_group_info):
@@ -126,7 +215,7 @@ def test_complete_ec2_shutdown_if_no_ecs_cluster(autoscaling_group_info):
         )
 
 
-def test_drain_ecs_instance_if_running_tasks(sns_sqs_info, autoscaling_group_info):
+def test_drain_ecs_instance_if_running_tasks(sns_sqs_info, autoscaling_group_info, ecs_task):
     fake_ec2_client = boto3.client('ec2')
     fake_ecs_client = boto3.client('ecs')
     fake_sqs_client = boto3.client('sqs')
@@ -134,75 +223,7 @@ def test_drain_ecs_instance_if_running_tasks(sns_sqs_info, autoscaling_group_inf
     queue_url = sns_sqs_info[1]
     auto_scaling_group_name = autoscaling_group_info[0]
     instance_id = autoscaling_group_info[1]
-    cluster_name = 'test_ecs_cluster'
-    cluster_response = fake_ecs_client.create_cluster(
-        clusterName=cluster_name
-    )
 
-    ec2 = boto3.resource('ec2')
-    instance = ec2.Instance(instance_id)
-
-    instance_id_document = json.dumps(
-        ec2_utils.generate_instance_identity_document(instance)
-    )
-
-    register_container_response = fake_ecs_client.register_container_instance(
-        cluster=cluster_name,
-        instanceIdentityDocument=instance_id_document
-    )
-
-    container_instance_arn = \
-        register_container_response['containerInstance']['containerInstanceArn']
-    cluster_arn = cluster_response['cluster']['clusterArn']
-
-    fake_ec2_client.create_tags(
-        Resources=[
-            instance_id,
-        ],
-        Tags=[
-            {
-                'Key': 'clusterArn',
-                'Value': cluster_arn
-            },
-            {
-                'Key': 'containerInstanceArn',
-                'Value': container_instance_arn
-            }
-        ]
-    )
-
-    task_name = 'test_ecs_task'
-    fake_ecs_client.register_task_definition(
-        family=task_name,
-        containerDefinitions=[
-            {
-                'name': 'hello_world',
-                'image': 'docker/hello-world:latest',
-                'cpu': 1024,
-                'memory': 400,
-                'essential': True,
-                'environment': [{
-                    'name': 'AWS_ACCESS_KEY_ID',
-                    'value': 'SOME_ACCESS_KEY'
-                }],
-                'logConfiguration': {'logDriver': 'json-file'}
-            }
-        ]
-    )
-
-    fake_ecs_client.run_task(
-        cluster=cluster_name,
-        overrides={},
-        taskDefinition=task_name,
-        count=1,
-        startedBy='moto'
-    )
-
-    tasks = fake_ecs_client.list_tasks(
-        cluster=cluster_arn,
-        containerInstance=container_instance_arn
-    )
-    assert len(tasks['taskArns']) == 1
     lifecycle_action_token = "78c16884-6bd4-4296-ac0c-2da9eb6a0d29"
 
     lifecycle_hook_name = "monitoring-cluster-LifecycleHook-OENP6M5XGYVM"

--- a/lambdas/drain_ecs_container_instance/test_drain_ecs_container_instance.py
+++ b/lambdas/drain_ecs_container_instance/test_drain_ecs_container_instance.py
@@ -19,12 +19,16 @@ def test_complete_ec2_shutdown_if_no_ecs_cluster():
     auto_scaling_group_name = 'TestGroup1'
     lifecycle_hook_name = "monitoring-cluster-LifecycleHook-OENP6M5XGYVM"
 
-    fake_asg_client.create_launch_configuration(LaunchConfigurationName='TestLC')
+    fake_asg_client.create_launch_configuration(
+        LaunchConfigurationName='TestLC'
+    )
 
-    fake_asg_client.create_auto_scaling_group(AutoScalingGroupName=auto_scaling_group_name,
-                                              MinSize=1,
-                                              MaxSize=1,
-                                              LaunchConfigurationName='TestLC')
+    fake_asg_client.create_auto_scaling_group(
+        AutoScalingGroupName=auto_scaling_group_name,
+        MinSize=1,
+        MaxSize=1,
+        LaunchConfigurationName='TestLC'
+    )
 
     instances = fake_ec2_client.describe_instances()
     print(instances)
@@ -45,7 +49,8 @@ def test_complete_ec2_shutdown_if_no_ecs_cluster():
     event = {
         'Records': [{
             'EventSource': 'aws:sns',
-            'EventSubscriptionArn': 'arn:aws:sns:region:account_id:ec2_terminating_topic:stuff',
+            'EventSubscriptionArn':
+                'arn:aws:sns:region:account_id:ec2_terminating_topic:stuff',
             'EventVersion': '1.0',
             'Sns': {
                 'Message': json.dumps(message),
@@ -56,7 +61,8 @@ def test_complete_ec2_shutdown_if_no_ecs_cluster():
                 'SigningCertUrl': 'https://certificate.pem',
                 'Subject': None,
                 'Timestamp': '2017-07-10T12:43:55.664Z',
-                'TopicArn': 'arn:aws:sns:region:account_id:ec2_terminating_topic',
+                'TopicArn':
+                    'arn:aws:sns:region:account_id:ec2_terminating_topic',
                 'Type': 'Notification',
                 'UnsubscribeUrl': 'https://unsubscribe-url'
             }}]}
@@ -91,9 +97,12 @@ def test_complete_ec2_shutdown_if_no_ecs_cluster():
     with patch("boto3.client", new_callable=client_patcher):
         drain_ecs_container_instance.main(event, None)
 
-        mocked_clients['autoscaling'].complete_lifecycle_action.assert_called_once_with(
-            LifecycleHookName=lifecycle_hook_name,
-            AutoScalingGroupName=auto_scaling_group_name,
-            LifecycleActionResult='CONTINUE',
-            InstanceId=instance_id
-        )
+        mocked_asg_client = mocked_clients['autoscaling']
+        mocked_asg_client \
+            .complete_lifecycle_action \
+            .assert_called_once_with(
+                LifecycleHookName=lifecycle_hook_name,
+                AutoScalingGroupName=auto_scaling_group_name,
+                LifecycleActionResult='CONTINUE',
+                InstanceId=instance_id
+            )

--- a/lambdas/drain_ecs_container_instance/test_drain_ecs_container_instance.py
+++ b/lambdas/drain_ecs_container_instance/test_drain_ecs_container_instance.py
@@ -2,27 +2,11 @@ import json
 
 import boto3
 from mock import Mock
-from moto import mock_ec2, mock_autoscaling, mock_ecs, mock_sns, mock_sqs
 from moto.ec2 import utils as ec2_utils
 
 import drain_ecs_container_instance
 
 import pytest
-
-
-@pytest.fixture()
-def moto_start():
-    mock_autoscaling().start()
-    mock_ec2().start()
-    mock_ecs().start()
-    mock_sns().start()
-    mock_sqs().start()
-    yield
-    mock_autoscaling().stop()
-    mock_ec2().stop()
-    mock_ecs().stop()
-    mock_sns().stop()
-    mock_sqs().stop()
 
 
 @pytest.fixture()
@@ -45,28 +29,6 @@ def autoscaling_group(moto_start):
     instances = fake_ec2_client.describe_instances()
     instance_id = instances['Reservations'][0]['Instances'][0]['InstanceId']
     yield auto_scaling_group_name, instance_id
-
-
-@pytest.fixture()
-def sns_sqs(moto_start):
-    fake_sns_client = boto3.client('sns')
-    fake_sqs_client = boto3.client('sqs')
-    queue_name = "test-queue"
-    topic_name = "test-topic"
-    print(f"Creating topic {topic_name} and queue {queue_name}")
-
-    fake_sns_client.create_topic(Name=topic_name)
-    response = fake_sns_client.list_topics()
-    topic_arn = response["Topics"][0]['TopicArn']
-
-    queue = fake_sqs_client.create_queue(QueueName=queue_name)
-
-    fake_sns_client.subscribe(
-        TopicArn=topic_arn,
-        Protocol="sqs",
-        Endpoint=f"arn:aws:sqs:eu-west-1:123456789012:{queue_name}"
-    )
-    yield topic_arn, queue['QueueUrl']
 
 
 @pytest.fixture()

--- a/lambdas/drain_ecs_container_instance/test_drain_ecs_container_instance.py
+++ b/lambdas/drain_ecs_container_instance/test_drain_ecs_container_instance.py
@@ -3,10 +3,9 @@ import json
 import boto3
 from mock import Mock
 from moto.ec2 import utils as ec2_utils
+import pytest
 
 import drain_ecs_container_instance
-
-import pytest
 
 
 @pytest.fixture()

--- a/lambdas/drain_ecs_container_instance/test_drain_ecs_container_instance.py
+++ b/lambdas/drain_ecs_container_instance/test_drain_ecs_container_instance.py
@@ -1,0 +1,65 @@
+import json
+from mock import patch
+
+import boto3
+from moto import mock_ec2, mock_ecs, mock_autoscaling
+
+import drain_ecs_container_instance
+
+
+
+@mock_ec2
+@mock_autoscaling
+@patch('drain_ecs_container_instance.asg_client.complete_lifecycle_action')
+def test_complete_ec2_shutdown_if_no_ecs_cluster(mock_complete_call):
+    mock_asg_client = boto3.client('autoscaling')
+    mock_ec2_client = boto3.client('ec2')
+
+    auto_scaling_group_name = 'TestGroup1'
+
+    mock_asg_client.create_launch_configuration(LaunchConfigurationName='TestLC')
+
+    mock_asg_client.create_auto_scaling_group(AutoScalingGroupName=auto_scaling_group_name,
+                                              MinSize=1,
+                                              MaxSize=1,
+                                              LaunchConfigurationName='TestLC')
+
+    instances = mock_ec2_client.describe_instances()
+    print(instances)
+    instance_id = instances['Reservations'][0]['Instances'][0]['InstanceId']
+
+    message = {
+        "LifecycleHookName": "monitoring-cluster-LifecycleHook-OENP6M5XGYVM",
+        "AccountId": "account_id",
+        "RequestId": "f29364ad-8523-4d58-9a70-3537f4edec15",
+        "LifecycleTransition": "autoscaling:EC2_INSTANCE_TERMINATING",
+        "AutoScalingGroupName": auto_scaling_group_name,
+        "Service": "AWS Auto Scaling",
+        "Time": "2017-07-10T12:36:05.857Z",
+        "EC2InstanceId": instance_id,
+        "LifecycleActionToken": "78c16884-6bd4-4296-ac0c-2da9eb6a0d29"
+    }
+
+    event = {
+        'Records': [{
+            'EventSource': 'aws:sns',
+            'EventSubscriptionArn': 'arn:aws:sns:region:account_id:ec2_terminating_topic:stuff',
+            'EventVersion': '1.0',
+            'Sns': {
+                'Message': json.dumps(message),
+                'MessageAttributes': {},
+                'MessageId': 'a4416c50-9ec6-5a8e-934a-3d8de60d1428',
+                'Signature': 'signature',
+                'SignatureVersion': '1',
+                'SigningCertUrl': 'https://certificate.pem',
+                'Subject': None,
+                'Timestamp': '2017-07-10T12:43:55.664Z',
+                'TopicArn': 'arn:aws:sns:region:account_id:ec2_terminating_topic',
+                'Type': 'Notification',
+                'UnsubscribeUrl': 'https://unsubscribe-url'
+            }}]}
+
+    drain_ecs_container_instance.main(event, None)
+
+    calls = mock_complete_call.call_list
+    assert len(calls) == 1

--- a/lambdas/drain_ecs_container_instance/test_drain_ecs_container_instance.py
+++ b/lambdas/drain_ecs_container_instance/test_drain_ecs_container_instance.py
@@ -80,7 +80,7 @@ def test_complete_ec2_shutdown_if_no_ecs_cluster():
     # to mock each client individually (patch needs in importable target
     # string), the only way is to patch the entire boto3.client function.
     def mock_asg_client():
-        def patch(*args):
+        def mock(*args):
             if args[0] == 'autoscaling':
                 client = Mock()
                 mocked_clients[args[0]] = client
@@ -93,7 +93,7 @@ def test_complete_ec2_shutdown_if_no_ecs_cluster():
 
             return client
 
-        return patch
+        return mock
 
     with patch("boto3.client", new_callable=mock_asg_client):
         drain_ecs_container_instance.main(event, None)
@@ -267,7 +267,7 @@ def test_drain_ecs_instance_if_running_tasks():
     # to mock each client individually (patch needs in importable target
     # string), the only way is to patch the entire boto3.client function.
     def mock_asg_client():
-        def patch(*args):
+        def mock(*args):
             if args[0] == 'autoscaling':
                 client = Mock()
                 mocked_clients[args[0]] = client
@@ -282,7 +282,7 @@ def test_drain_ecs_instance_if_running_tasks():
 
             return client
 
-        return patch
+        return mock
 
     with patch("boto3.client", new_callable=mock_asg_client):
         drain_ecs_container_instance.main(event, None)
@@ -305,6 +305,10 @@ def test_drain_ecs_instance_if_running_tasks():
                 LifecycleActionToken=lifecycle_action_token,
                 InstanceId=instance_id,
             )
+
+        mocked_asg_client\
+            .complete_lifecycle_action\
+            .assert_not_called()
 
         messages = fake_sqs_client.receive_message(
             QueueUrl=queue['QueueUrl'],

--- a/lambdas/drain_ecs_container_instance/test_drain_ecs_container_instance.py
+++ b/lambdas/drain_ecs_container_instance/test_drain_ecs_container_instance.py
@@ -2,7 +2,8 @@ import json
 
 import boto3
 from mock import patch, Mock
-from moto import mock_ec2, mock_autoscaling
+from moto import mock_ec2, mock_autoscaling, mock_ecs, mock_sns, mock_sqs
+from moto.ec2 import utils as ec2_utils
 
 import drain_ecs_container_instance
 
@@ -68,17 +69,17 @@ def test_complete_ec2_shutdown_if_no_ecs_cluster():
             }}]}
 
     # Horrible hack be able to mock the autoscaling client:
-    # client_patcher returns a function that behaves differently
+    # mock_asg_client returns a function that behaves differently
     # based on the service_name parameter passed to a call to
     # boto3.client.
     #
     # I need to mock the autoscaling client only, to be able to assert
-    # on what function are called on it (As far as I know moto
+    # on what function is called on it (As far as I know moto
     # does not have this functionality).
     # The other clients don't have to be mocked but, as there is no way
     # to mock each client individually (patch needs in importable target
     # string), the only way is to patch the entire boto3.client function.
-    def client_patcher():
+    def mock_asg_client():
         def patch(*args):
             if args[0] == 'autoscaling':
                 client = Mock()
@@ -94,7 +95,7 @@ def test_complete_ec2_shutdown_if_no_ecs_cluster():
 
         return patch
 
-    with patch("boto3.client", new_callable=client_patcher):
+    with patch("boto3.client", new_callable=mock_asg_client):
         drain_ecs_container_instance.main(event, None)
 
         mocked_asg_client = mocked_clients['autoscaling']
@@ -106,3 +107,206 @@ def test_complete_ec2_shutdown_if_no_ecs_cluster():
                 LifecycleActionResult='CONTINUE',
                 InstanceId=instance_id
             )
+
+
+@mock_ec2
+@mock_ecs
+@mock_autoscaling
+@mock_sns
+@mock_sqs
+def test_drain_ecs_instance_if_running_tasks():
+    fake_asg_client = boto3.client('autoscaling')
+    fake_ec2_client = boto3.client('ec2')
+    fake_ecs_client = boto3.client('ecs')
+    fake_sns_client = boto3.client('sns')
+    fake_sqs_client = boto3.client('sqs')
+
+    fake_sns_client.create_topic(Name="test-topic")
+
+    response = fake_sns_client.list_topics()
+    topic_arn = response["Topics"][0]['TopicArn']
+
+    queue_name = "test-queue"
+    queue = fake_sqs_client.create_queue(QueueName=queue_name)
+
+    fake_sns_client.subscribe(
+        TopicArn=topic_arn,
+        Protocol="sqs",
+        Endpoint=f"arn:aws:sqs:eu-west-1:123456789012:{queue_name}"
+    )
+    auto_scaling_group_name = 'TestGroup1'
+    lifecycle_hook_name = "monitoring-cluster-LifecycleHook-OENP6M5XGYVM"
+
+    fake_asg_client.create_launch_configuration(
+        LaunchConfigurationName='TestLC'
+    )
+
+    fake_asg_client.create_auto_scaling_group(
+        AutoScalingGroupName=auto_scaling_group_name,
+        MinSize=1,
+        MaxSize=1,
+        LaunchConfigurationName='TestLC'
+    )
+
+    instances = fake_ec2_client.describe_instances()
+
+    instance_id = instances['Reservations'][0]['Instances'][0]['InstanceId']
+
+    cluster_name = 'test_ecs_cluster'
+    cluster_response = fake_ecs_client.create_cluster(
+        clusterName=cluster_name
+    )
+
+    ec2 = boto3.resource('ec2')
+    instance = ec2.Instance(instance_id)
+
+    instance_id_document = json.dumps(
+        ec2_utils.generate_instance_identity_document(instance)
+    )
+
+    container_instance_response = fake_ecs_client.register_container_instance(
+        cluster=cluster_name,
+        instanceIdentityDocument=instance_id_document
+    )
+
+    container_instance_arn = container_instance_response['containerInstance']['containerInstanceArn']
+    cluster_arn = cluster_response['cluster']['clusterArn']
+
+    fake_ec2_client.create_tags(
+        Resources=[
+            instance_id,
+        ],
+        Tags=[
+            {
+                'Key': 'clusterArn',
+                'Value': cluster_arn
+            },
+            {
+                'Key': 'containerInstanceArn',
+                'Value': container_instance_arn
+            }
+        ]
+    )
+
+    task_name = 'test_ecs_task'
+    fake_ecs_client.register_task_definition(
+        family=task_name,
+        containerDefinitions=[
+            {
+                'name': 'hello_world',
+                'image': 'docker/hello-world:latest',
+                'cpu': 1024,
+                'memory': 400,
+                'essential': True,
+                'environment': [{
+                    'name': 'AWS_ACCESS_KEY_ID',
+                    'value': 'SOME_ACCESS_KEY'
+                }],
+                'logConfiguration': {'logDriver': 'json-file'}
+            }
+        ]
+    )
+
+    fake_ecs_client.run_task(
+        cluster=cluster_name,
+        overrides={},
+        taskDefinition=task_name,
+        count=1,
+        startedBy='moto'
+    )
+
+    tasks = fake_ecs_client.list_tasks(
+        cluster=cluster_arn,
+        containerInstance=container_instance_arn
+    )
+    assert len(tasks['taskArns']) == 1
+
+    message = {
+        "LifecycleHookName": lifecycle_hook_name,
+        "AccountId": "account_id",
+        "RequestId": "f29364ad-8523-4d58-9a70-3537f4edec15",
+        "LifecycleTransition": "autoscaling:EC2_INSTANCE_TERMINATING",
+        "AutoScalingGroupName": auto_scaling_group_name,
+        "Service": "AWS Auto Scaling",
+        "Time": "2017-07-10T12:36:05.857Z",
+        "EC2InstanceId": instance_id,
+        "LifecycleActionToken": "78c16884-6bd4-4296-ac0c-2da9eb6a0d29"
+    }
+
+    event = {
+        'Records': [{
+            'EventSource': 'aws:sns',
+            'EventSubscriptionArn':
+                'arn:aws:sns:region:account_id:ec2_terminating_topic:stuff',
+            'EventVersion': '1.0',
+            'Sns': {
+                'Message': json.dumps(message),
+                'MessageAttributes': {},
+                'MessageId': 'a4416c50-9ec6-5a8e-934a-3d8de60d1428',
+                'Signature': 'signature',
+                'SignatureVersion': '1',
+                'SigningCertUrl': 'https://certificate.pem',
+                'Subject': None,
+                'Timestamp': '2017-07-10T12:43:55.664Z',
+                'TopicArn': topic_arn,
+                'Type': 'Notification',
+                'UnsubscribeUrl': 'https://unsubscribe-url'
+            }}]}
+
+
+    # Horrible hack be able to mock the autoscaling client:
+    # mock_asg_client returns a function that behaves differently
+    # based on the service_name parameter passed to a call to
+    # boto3.client.
+    #
+    # I need to mock the autoscaling client only, to be able to assert
+    # on what function is called on it (As far as I know moto
+    # does not have this functionality).
+    # The other clients don't have to be mocked but, as there is no way
+    # to mock each client individually (patch needs in importable target
+    # string), the only way is to patch the entire boto3.client function.
+    def mock_asg_client():
+        def patch(*args):
+            if args[0] == 'autoscaling':
+                client = Mock()
+                mocked_clients[args[0]] = client
+            elif args[0] == 'ec2':
+                client = fake_ec2_client
+            elif args[0] == 'ecs':
+                client = fake_ecs_client
+            elif args[0] == 'sns':
+                client = fake_sns_client
+            else:
+                raise Exception(f'Invalid {args[0]}')
+
+            return client
+
+        return patch
+
+    with patch("boto3.client", new_callable=mock_asg_client):
+        drain_ecs_container_instance.main(event, None)
+
+        container_instance_info = fake_ecs_client.describe_container_instances(
+            cluster=cluster_name,
+            containerInstances=[container_instance_arn]
+        )
+
+        assert container_instance_info['containerInstances'][0]['status'] == "DRAINING"
+
+        mocked_asg_client = mocked_clients['autoscaling']
+        mocked_asg_client \
+            .record_lifecycle_action_heartbeat \
+            .assert_called_once_with(
+                LifecycleHookName=lifecycle_hook_name,
+                AutoScalingGroupName=auto_scaling_group_name,
+                LifecycleActionResult='CONTINUE',
+                InstanceId=instance_id
+            )
+
+        messages = fake_sqs_client.receive_message(
+            QueueUrl=queue['QueueUrl'],
+            MaxNumberOfMessages=1
+        )
+        message_body = messages['Messages'][0]['Body']
+
+        assert json.loads(message_body)['default'] == json.dumps(message)

--- a/lambdas/dynamo_to_sns/conftest.py
+++ b/lambdas/dynamo_to_sns/conftest.py
@@ -1,0 +1,1 @@
+../common/conftest.py


### PR DESCRIPTION
### What is this PR trying to achieve?
Test the blue-green ec2 deployment lambda and get a better general understanding of how we would use moto for Lambda tests
### Who is this change for?
Devs
### TODO
- [x] Refactor to reduce code duplication (fixtures?)
- [x]  Extract common fixture in lambdas/common/conftest.py
- [x]  Use common fixtures in other tests (sns fixture)