### PR TITLE
Move images in the miro-images-sync bucket to infrequent access

### DIFF
--- a/terraform/s3.tf
+++ b/terraform/s3.tf
@@ -10,6 +10,16 @@ resource "aws_s3_bucket" "miro-data" {
 resource "aws_s3_bucket" "miro-images-sync" {
   bucket = "miro-images-sync"
   acl    = "private"
+
+  lifecycle_rule {
+    id      = "move_to_infrequent_access"
+    enabled = true
+
+    transition {
+      days          = 30
+      storage_class = "STANDARD_IA"
+    }
+  }
 }
 
 resource "aws_s3_bucket" "miro_images_public" {


### PR DESCRIPTION
### What is this PR trying to achieve?

Move objects in the miro-images-sync bucket to the infrequent access storage tier after 30 days.

Resolves #636.

### Who is this change for?

The platform team, who want to save 💰💰💰 by not paying as much for S3 storage.

### Have the following been considered/are they needed?

- [ ] Run `terraform apply`.