### PR TITLE
Fix Lambda runs in CI

### DIFF
--- a/docker/python3.6_ci/run.sh
+++ b/docker/python3.6_ci/run.sh
@@ -14,7 +14,7 @@ elif [[ "$OP" == "test" ]]
 then
   echo "Testing Lambdas"
   ./install_lambda_deps.sh
-  find **/test_*.py | py.test
+  find . -maxdepth 2 -name "test_*.py" | py.test
 elif [[ "$OP" == "install-deps" ]]
 then
   echo "Installing Lambda dependencies"

--- a/docker/python3.6_ci/run.sh
+++ b/docker/python3.6_ci/run.sh
@@ -14,7 +14,7 @@ elif [[ "$OP" == "test" ]]
 then
   echo "Testing Lambdas"
   ./install_lambda_deps.sh
-  find . -maxdepth 2 -name "test_*.py" | py.test
+  find . -maxdepth 2 -name "test_*.py" | xargs py.test
 elif [[ "$OP" == "install-deps" ]]
 then
   echo "Installing Lambda dependencies"

--- a/lambdas/.gitignore
+++ b/lambdas/.gitignore
@@ -1,3 +1,4 @@
 *.dist-info
 six.py
 */structlog/*
+*/simplejson/*


### PR DESCRIPTION
### What is this PR trying to achieve?

Fix our Lambda tests. When you run `pip install simplejson`, it includes the tests in the installed files (obviously that’s what you want, right?). So we need to ignore them when we run our tests.

### Who is this change for?

🌳 