### PR TITLE
Make IdentifiersDao a Singleton

### DIFF
--- a/id_minter/src/main/scala/uk/ac/wellcome/platform/idminter/database/IdentifiersDao.scala
+++ b/id_minter/src/main/scala/uk/ac/wellcome/platform/idminter/database/IdentifiersDao.scala
@@ -1,5 +1,7 @@
 package uk.ac.wellcome.platform.idminter.database
 
+import javax.inject.Singleton
+
 import com.google.inject.Inject
 import com.twitter.inject.Logging
 import scalikejdbc._
@@ -8,6 +10,7 @@ import uk.ac.wellcome.utils.GlobalExecutionContext.context
 
 import scala.concurrent.{Future, blocking}
 
+@Singleton
 class IdentifiersDao @Inject()(db: DB, identifiers: IdentifiersTable)
     extends Logging {
 


### PR DESCRIPTION
### What is this PR trying to achieve?

A functioning id_minter.

Since the id_minter was modified to use the IdMinterWorker it tried to open a new DB connection for each message processed, causing the number of open connections to max out and the id_minter to fail.

### Who is this change for?

Everyone who wants to use the platform

### Have the following been considered/are they needed?

- [ ] Deployed new versions
