### PR TITLE
Add terminalFailureHook to TryBackoff

### DIFF
--- a/common/src/main/scala/uk/ac/wellcome/utils/TryBackoff.scala
+++ b/common/src/main/scala/uk/ac/wellcome/utils/TryBackoff.scala
@@ -47,6 +47,9 @@ trait TryBackoff extends Logging {
   lazy val baseWait: Duration = 100 millis
   lazy val totalWait: Duration = 12 seconds
 
+  // This method is intended to be optionally overridden
+  def terminalFailureHook(): Unit = Unit
+
   // This value is cached to save us repeating the calculation.
   private val maxAttempts = maximumAttemptsToTry()
 
@@ -71,6 +74,8 @@ trait TryBackoff extends Logging {
 
       val shouldReschedule = if (numberOfAttempts > maxAttempts) {
         error("Max retry attempts exceeded")
+
+        terminalFailureHook()
         false
       } else continuous || attempted.isLeft
 


### PR DESCRIPTION
### What is this PR trying to achieve?

Extending objects may want a means to alert on terminal failure of a TryBackoff - this PR adds an overridable hook that can be used to execute some arbitrary side-effect on terminal failure.

### Who is this change for?

💻 

### Have the following been considered/are they needed?

- [ ] Deployed new versions

