### PR TITLE
Changes to the way we handle title/description on V records

### DIFF
--- a/common/src/main/scala/uk/ac/wellcome/models/MiroTransformable.scala
+++ b/common/src/main/scala/uk/ac/wellcome/models/MiroTransformable.scala
@@ -58,7 +58,10 @@ case class MiroTransformable(MiroID: String,
       // In the V collection, this is just a truncated form of the desc field,
       // so we pass the full string as the label and omit a description.
       val label = MiroCollection match {
-        case "Images-V" => miroData.description.get
+        case "Images-V" => miroData.description match {
+          case Some(s) => s
+          case None => miroData.title.get
+        }
         case _ => miroData.title.get
       }
 

--- a/common/src/main/scala/uk/ac/wellcome/models/MiroTransformable.scala
+++ b/common/src/main/scala/uk/ac/wellcome/models/MiroTransformable.scala
@@ -52,25 +52,27 @@ case class MiroTransformable(MiroID: String,
           "image_copyright_cleared field is not Y")
       }
 
+      // In at least the V collection, many of the titles are truncated
+      // versions of the description.  In this case, we drop the description
+      // field and put the full description in the label instead.
+      val titleIsTruncatedDescription = miroData.description.getOrElse("")
+        .startsWith(miroData.title.get)
+
+      val useDescriptionAsTitle = (
+        titleIsTruncatedDescription &&
+        MiroCollection == "Images-V")
+
       // <image_title>: the Short Description.  This maps to our property
       // "label".
       //
-      // In the V collection, this is just a truncated form of the desc field,
-      // so we pass the full string as the label and omit a description.
-      val label = MiroCollection match {
-        case "Images-V" => miroData.description match {
-          case Some(s) => s
-          case None => miroData.title.get
-        }
-        case _ => miroData.title.get
-      }
+      // Every image in the V collection that has image_cleared == Y has a
+      // non-empty title.  This is _not_ true for the MIRO records in general.
+      // TODO: Work out what label to use for those records.
+      val label = if (useDescriptionAsTitle) miroData.description.get else miroData.title.get
 
       // <image_image_desc>: the Description, which maps to our property
       // "description".
-      val description = MiroCollection match {
-        case "Images-V" => None
-        case _ => miroData.description
-      }
+      val description = if (useDescriptionAsTitle) None else miroData.description
 
       // <image_creator>: the Creator, which maps to our property "hasCreator"
       val creators: List[Agent] = miroData.creator match {

--- a/common/src/main/scala/uk/ac/wellcome/models/MiroTransformable.scala
+++ b/common/src/main/scala/uk/ac/wellcome/models/MiroTransformable.scala
@@ -55,11 +55,11 @@ case class MiroTransformable(MiroID: String,
       // In at least the V collection, many of the titles are truncated
       // versions of the description.  In this case, we drop the description
       // field and put the full description in the label instead.
-      val titleIsTruncatedDescription = miroData.description.getOrElse("")
+      val titleIsTruncatedDescription = miroData.description
+        .getOrElse("")
         .startsWith(miroData.title.get)
 
-      val useDescriptionAsTitle = (
-        titleIsTruncatedDescription &&
+      val useDescriptionAsTitle = (titleIsTruncatedDescription &&
         MiroCollection == "Images-V")
 
       // <image_title>: the Short Description.  This maps to our property
@@ -68,11 +68,14 @@ case class MiroTransformable(MiroID: String,
       // Every image in the V collection that has image_cleared == Y has a
       // non-empty title.  This is _not_ true for the MIRO records in general.
       // TODO: Work out what label to use for those records.
-      val label = if (useDescriptionAsTitle) miroData.description.get else miroData.title.get
+      val label =
+        if (useDescriptionAsTitle) miroData.description.get
+        else miroData.title.get
 
       // <image_image_desc>: the Description, which maps to our property
       // "description".
-      val description = if (useDescriptionAsTitle) None else miroData.description
+      val description =
+        if (useDescriptionAsTitle) None else miroData.description
 
       // <image_creator>: the Creator, which maps to our property "hasCreator"
       val creators: List[Agent] = miroData.creator match {

--- a/common/src/test/scala/uk/ac/wellcome/models/MiroTransformableTest.scala
+++ b/common/src/test/scala/uk/ac/wellcome/models/MiroTransformableTest.scala
@@ -68,7 +68,7 @@ class MiroTransformableTest extends FunSpec with Matchers {
       }"""
     )
     work.label shouldBe title
-    work.description shouldBe description
+    work.description.get shouldBe description
   }
 
   it("should have an empty list if no image_creator field is present") {

--- a/common/src/test/scala/uk/ac/wellcome/models/MiroTransformableTest.scala
+++ b/common/src/test/scala/uk/ac/wellcome/models/MiroTransformableTest.scala
@@ -42,6 +42,20 @@ class MiroTransformableTest extends FunSpec with Matchers {
     work.label shouldBe description
   }
 
+  it("should fall back to the label field in the V collection if the description field is missing") {
+    val title = "A missive about a mouse"
+    val label = "A lemon and a lime"
+    val work = transformMiroRecord(
+      miroCollection = "Images-V",
+      data = s"""{
+        "image_title": "$title",
+        "image_cleared": "Y",
+        "image_copyright_cleared": "Y"
+      }"""
+    )
+    work.label shouldBe title
+  }
+
   it("should have an empty list if no image_creator field is present") {
     val work = transformMiroRecord(data = s"""{
       "image_title": "A guide to giraffes",

--- a/common/src/test/scala/uk/ac/wellcome/models/MiroTransformableTest.scala
+++ b/common/src/test/scala/uk/ac/wellcome/models/MiroTransformableTest.scala
@@ -44,7 +44,6 @@ class MiroTransformableTest extends FunSpec with Matchers {
 
   it("should fall back to the label field in the V collection if the description field is missing") {
     val title = "A missive about a mouse"
-    val label = "A lemon and a lime"
     val work = transformMiroRecord(
       miroCollection = "Images-V",
       data = s"""{
@@ -54,6 +53,22 @@ class MiroTransformableTest extends FunSpec with Matchers {
       }"""
     )
     work.label shouldBe title
+  }
+
+  it("should only use description as label in the V collection if the title is a prefix of the description") {
+    val title = "A prefix of a parrot"
+    val description = "A suffix to a snake"
+    val work = transformMiroRecord(
+      miroCollection = "Images-V",
+      data = s"""{
+        "image_title": "$title",
+        "image_image_desc": "$description",
+        "image_cleared": "Y",
+        "image_copyright_cleared": "Y"
+      }"""
+    )
+    work.label shouldBe title
+    work.description shouldBe description
   }
 
   it("should have an empty list if no image_creator field is present") {


### PR DESCRIPTION
### What is this PR trying to achieve?

Two fixes to the way we handle title/description on V records:

* If the description is missing but the title is present, use the default behaviour of setting label := title.
* If the title isn’t a truncated form of the description, use the title as the label. e.g.

    ```json
    {
        "id": "a23qt57a",
        "label": "Friedrich Heinrich Alexander von Humboldt.",
        "description": "R. Burgess, Portraits of doctors & scientists in the Wellcome Institute, London Friedrich Heinrich Alexander von Humboldt. Engraving. 1 print R. Burgess, Portraits of doctors & scientists in the Wellcome Institute, London1973, no. 1467.22",
        "creators": [ ],
        "type": "Work"
    }
    ```

I’ll merge and deploy this before re-running the indexer for #616.

### Who is this change for?

Users of the API.

### Have the following been considered/are they needed?

- [ ] Reviewed by @jtweed
- [ ] Deployed new versions
