### PR TITLE
Prevent EC2 tagging rate limit in tagger lambda

### DIFF
--- a/lambdas/ecs_ec2_instance_tagger/ecs_ec2_instance_tagger.py
+++ b/lambdas/ecs_ec2_instance_tagger/ecs_ec2_instance_tagger.py
@@ -20,6 +20,7 @@ Requires a Cloudwatch Event with pattern:
 """
 
 import json
+import os
 
 import boto3
 from botocore.exceptions import ClientError
@@ -37,8 +38,10 @@ def create_tags(ec2_client, ec2_instance_id, event_detail):
     cluster_arn = event_detail['clusterArn']
     container_instance_arn = event_detail['containerInstanceArn']
 
-    print(f'Tagging {ec2_instance_id} clusterArn: {cluster_arn}')
-    print(f'Tagging {ec2_instance_id} containerInstanceArn: {container_instance_arn}')
+    print(f'Tag {ec2_instance_id} clusterArn: {cluster_arn}')
+    print(
+        f'Tag {ec2_instance_id} containerInstanceArn: {container_instance_arn}'
+    )
 
     return ec2_client.create_tags(
         Resources=[ec2_instance_id],
@@ -66,12 +69,17 @@ def main(event, _):
     try:
         s3_client.get_object(
             Bucket=bucket_name,
-            Key=f'{object_path}/foo/{ec2_instance_id}'
+            Key=f'{object_path}/{ec2_instance_id}'
         )
     except ClientError as ex:
         if ex.response['Error']['Code'] == 'NoSuchKey':
             print(f'{ec2_instance_id} not seen yet, tagging!')
-            response = create_tags(ec2_client, ec2_instance_id, event['detail'])
+
+            response = create_tags(
+                ec2_client,
+                ec2_instance_id,
+                event['detail'])
+
             print(f'response = {response!r}')
         else:
             raise ex

--- a/lambdas/ecs_ec2_instance_tagger/ecs_ec2_instance_tagger.py
+++ b/lambdas/ecs_ec2_instance_tagger/ecs_ec2_instance_tagger.py
@@ -82,7 +82,7 @@ def main(event, _):
 
             print(f'response = {response!r}')
         else:
-            raise ex
+            raise
 
     s3_client.put_object(
         Bucket=bucket_name,

--- a/lambdas/ecs_ec2_instance_tagger/ecs_ec2_instance_tagger.py
+++ b/lambdas/ecs_ec2_instance_tagger/ecs_ec2_instance_tagger.py
@@ -19,7 +19,10 @@ Requires a Cloudwatch Event with pattern:
 
 """
 
+import json
+
 import boto3
+from botocore.exceptions import ClientError
 
 
 def create_tags(ec2_client, ec2_instance_id, event_detail):
@@ -30,6 +33,13 @@ def create_tags(ec2_client, ec2_instance_id, event_detail):
 
     Returns the SDK response to the create_tags call.
     """
+
+    cluster_arn = event_detail['clusterArn']
+    container_instance_arn = event_detail['containerInstanceArn']
+
+    print(f'Tagging {ec2_instance_id} clusterArn: {cluster_arn}')
+    print(f'Tagging {ec2_instance_id} containerInstanceArn: {container_instance_arn}')
+
     return ec2_client.create_tags(
         Resources=[ec2_instance_id],
         Tags=[{
@@ -46,8 +56,30 @@ def main(event, _):
     print(f'event = {event!r}')
 
     ec2_client = boto3.client('ec2')
+    s3_client = boto3.client('s3')
+
+    bucket_name = os.environ["BUCKET_NAME"]
+    object_path = os.environ["OBJECT_PATH"]
 
     ec2_instance_id = event['detail']['ec2InstanceId']
 
-    response = create_tags(ec2_client, ec2_instance_id, event['detail'])
-    print(f'response = {response!r}')
+    try:
+        s3_client.get_object(
+            Bucket=bucket_name,
+            Key=f'{object_path}/foo/{ec2_instance_id}'
+        )
+    except ClientError as ex:
+        if ex.response['Error']['Code'] == 'NoSuchKey':
+            print(f'{ec2_instance_id} not seen yet, tagging!')
+            response = create_tags(ec2_client, ec2_instance_id, event['detail'])
+            print(f'response = {response!r}')
+        else:
+            raise ex
+
+    s3_client.put_object(
+        Bucket=bucket_name,
+        Key=f'{object_path}/{ec2_instance_id}',
+        Body=json.dumps(event)
+    )
+
+    print(f'{ec2_instance_id} tagged.')

--- a/lambdas/ecs_ec2_instance_tagger/ecs_ec2_instance_tagger.py
+++ b/lambdas/ecs_ec2_instance_tagger/ecs_ec2_instance_tagger.py
@@ -67,12 +67,12 @@ def main(event, _):
     ec2_instance_id = event['detail']['ec2InstanceId']
 
     try:
-        s3_client.get_object(
+        s3_client.head_object(
             Bucket=bucket_name,
             Key=f'{object_path}/{ec2_instance_id}'
         )
     except ClientError as ex:
-        if ex.response['Error']['Code'] == 'NoSuchKey':
+        if ex.response['Error']['Code'] == '404':
             print(f'{ec2_instance_id} not seen yet, tagging!')
 
             response = create_tags(

--- a/lambdas/ecs_ec2_instance_tagger/test_ecs_ec2_instance_tagger.py
+++ b/lambdas/ecs_ec2_instance_tagger/test_ecs_ec2_instance_tagger.py
@@ -1,0 +1,197 @@
+import os
+import json
+
+import boto3
+from moto import mock_s3, mock_ec2
+
+import ecs_ec2_instance_tagger
+
+
+def create_ecs_container_instance_state_change(
+        instance_id,
+        cluster_arn,
+        container_instance_arn):
+
+    return f'''
+    {{
+      "version": "0",
+      "id": "8952ba83-7be2-4ab5-9c32-6687532d15a2",
+      "detail-type": "ECS Container Instance State Change",
+      "source": "aws.ecs",
+      "account": "111122223333",
+      "time": "2016-12-06T16:41:06Z",
+      "region": "us-east-1",
+      "resources": [
+        "{container_instance_arn}"
+      ],
+      "detail": {{
+        "agentConnected": true,
+        "attributes": [
+          {{
+            "name": "foo"
+          }}
+        ],
+        "clusterArn": "{cluster_arn}",
+        "containerInstanceArn": "{container_instance_arn}",
+        "ec2InstanceId": "{instance_id}",
+        "registeredResources": [
+          {{
+            "name": "CPU",
+            "type": "INTEGER",
+            "integerValue": 2048
+          }}
+        ],
+        "remainingResources": [
+          {{
+            "name": "CPU",
+            "type": "INTEGER",
+            "integerValue": 1988
+          }}
+        ],
+        "status": "ACTIVE",
+        "version": 14801,
+        "versionInfo": {{
+          "agentHash": "aebcbca",
+          "agentVersion": "1.13.0",
+          "dockerVersion": "DockerVersion: 1.11.2"
+        }},
+        "updatedAt": "2016-12-06T16:41:06.991Z"
+      }}
+    }}
+    '''
+
+
+bucket_name = 'bukkit'
+
+object_path = 'tmp/ecs_ec2_instance_tagger'
+
+base_arn = 'arn:aws:ecs:us-east-1:111122223333'
+
+cluster_arn = f'{base_arn}:cluster/default'
+
+container_instance_arn = f'{base_arn}:container-instance/foo'
+
+
+@mock_ec2
+@mock_s3
+def test_ecs_ec2_instance_tagger_creates_s3_cache():
+    instance_id = 'i-0209cc3b3d10166bf'
+
+    s3_client = boto3.client('s3')
+    s3_client.create_bucket(Bucket=bucket_name)
+
+    event = create_ecs_container_instance_state_change(
+        instance_id,
+        cluster_arn,
+        container_instance_arn)
+
+    os.environ["BUCKET_NAME"] = bucket_name
+    os.environ["OBJECT_PATH"] = object_path
+
+    ecs_ec2_instance_tagger.main(json.loads(event), {})
+
+    body = s3_client.get_object(
+        Bucket=bucket_name,
+        Key=f'{object_path}/{instance_id}'
+    )['Body'].read()
+
+    assert json.loads(body) == json.loads(event)
+
+
+@mock_ec2
+@mock_s3
+def test_ecs_ec2_instance_tagger_creates_ec2_tags():
+    ec2_client = boto3.client('ec2')
+
+    s3_client = boto3.client('s3')
+    s3_client.create_bucket(Bucket=bucket_name)
+
+    response = ec2_client.run_instances(
+        ImageId='ami-image-id',
+        MaxCount=1,
+        MinCount=1
+    )
+
+    instance_id = response['Instances'][0]['InstanceId']
+
+    event = create_ecs_container_instance_state_change(
+        instance_id,
+        cluster_arn,
+        container_instance_arn)
+
+    os.environ["BUCKET_NAME"] = bucket_name
+    os.environ["OBJECT_PATH"] = object_path
+
+    ecs_ec2_instance_tagger.main(json.loads(event), {})
+
+    response = ec2_client.describe_instances(
+        InstanceIds=[instance_id]
+    )
+
+    actual_tags = response['Reservations'][0]['Instances'][0]['Tags']
+
+    expected_tags = [
+        {
+            'Key': 'clusterArn',
+            'Value': cluster_arn
+        },
+        {
+            'Key': 'containerInstanceArn',
+            'Value': container_instance_arn
+        }
+    ]
+
+    assert expected_tags == actual_tags
+
+
+@mock_ec2
+@mock_s3
+def test_ecs_ec2_instance_tagger_creates_ec2_tags_only_once():
+    ec2_client = boto3.client('ec2')
+
+    s3_client = boto3.client('s3')
+    s3_client.create_bucket(Bucket=bucket_name)
+
+    response = ec2_client.run_instances(
+        ImageId='ami-image-id',
+        MaxCount=1,
+        MinCount=1
+    )
+
+    instance_id = response['Instances'][0]['InstanceId']
+
+    event = create_ecs_container_instance_state_change(
+        instance_id,
+        cluster_arn,
+        container_instance_arn)
+
+    os.environ["BUCKET_NAME"] = bucket_name
+    os.environ["OBJECT_PATH"] = object_path
+
+    ecs_ec2_instance_tagger.main(json.loads(event), {})
+
+    new_event = create_ecs_container_instance_state_change(
+        instance_id,
+        "foo",
+        "bar")
+
+    ecs_ec2_instance_tagger.main(json.loads(new_event), {})
+
+    response = ec2_client.describe_instances(
+        InstanceIds=[instance_id]
+    )
+
+    actual_tags = response['Reservations'][0]['Instances'][0]['Tags']
+
+    expected_tags = [
+        {
+            'Key': 'clusterArn',
+            'Value': cluster_arn
+        },
+        {
+            'Key': 'containerInstanceArn',
+            'Value': container_instance_arn
+        }
+    ]
+
+    assert expected_tags == actual_tags

--- a/terraform/iam_policy_document.tf
+++ b/terraform/iam_policy_document.tf
@@ -236,6 +236,20 @@ data "aws_iam_policy_document" "s3_put_dashboard_status" {
   }
 }
 
+data "aws_iam_policy_document" "s3_put_infra_tmp" {
+  statement {
+    actions = [
+      "s3:PutObject",
+      "s3:GetObjectACL",
+      "s3:PutObjectACL",
+    ]
+
+    resources = [
+      "${aws_s3_bucket.infra.arn}/tmp/*",
+    ]
+  }
+}
+
 data "aws_iam_policy_document" "s3_read_miro_images" {
   statement {
     actions = [

--- a/terraform/iam_role_policy.tf
+++ b/terraform/iam_role_policy.tf
@@ -142,12 +142,12 @@ EOF
 
 # Role policies for ecs_ec2_instance_tagger lambda
 
-resource "aws_iam_role_policy" "ecs_ec2_instance_tagger_thing" {
+resource "aws_iam_role_policy" "ecs_ec2_instance_tagger_write_tags" {
   role   = "${module.lambda_ecs_ec2_instance_tagger.role_name}"
   policy = "${data.aws_iam_policy_document.write_ec2_tags.json}"
 }
 
-resource "aws_iam_role_policy" "ecs_ec2_instance_tagger_thing" {
+resource "aws_iam_role_policy" "ecs_ec2_instance_tagger_use_tmp" {
   role   = "${module.lambda_ecs_ec2_instance_tagger.role_name}"
   policy = "${data.aws_iam_policy_document.s3_put_infra_tmp.json}"
 }

--- a/terraform/iam_role_policy.tf
+++ b/terraform/iam_role_policy.tf
@@ -147,6 +147,11 @@ resource "aws_iam_role_policy" "ecs_ec2_instance_tagger_thing" {
   policy = "${data.aws_iam_policy_document.write_ec2_tags.json}"
 }
 
+resource "aws_iam_role_policy" "ecs_ec2_instance_tagger_thing" {
+  role   = "${module.lambda_ecs_ec2_instance_tagger.role_name}"
+  policy = "${data.aws_iam_policy_document.s3_put_infra_tmp.json}"
+}
+
 # Role policies for service_deployment_status lambda
 
 resource "aws_iam_role_policy" "service_deployment_status_describe_services" {

--- a/terraform/lambdas.tf
+++ b/terraform/lambdas.tf
@@ -55,8 +55,8 @@ module "lambda_ecs_ec2_instance_tagger" {
   timeout     = 10
 
   environment_variables = {
-    BUCKET_NAME     = "${aws_s3_bucket.infra.id}"
-    OBJECT_PATH      = "tmp/ecs_ec2_instance_tagger"
+    BUCKET_NAME = "${aws_s3_bucket.infra.id}"
+    OBJECT_PATH = "tmp/ecs_ec2_instance_tagger"
   }
 
   alarm_topic_arn = "${module.lambda_error_alarm.arn}"

--- a/terraform/lambdas.tf
+++ b/terraform/lambdas.tf
@@ -54,6 +54,11 @@ module "lambda_ecs_ec2_instance_tagger" {
   source_dir  = "../lambdas/ecs_ec2_instance_tagger"
   timeout     = 10
 
+  environment_variables = {
+    BUCKET_NAME     = "${aws_s3_bucket.infra.id}"
+    OBJECT_PATH      = "tmp/ecs_ec2_instance_tagger"
+  }
+
   alarm_topic_arn = "${module.lambda_error_alarm.arn}"
 }
 

--- a/terraform/s3.tf
+++ b/terraform/s3.tf
@@ -35,6 +35,16 @@ resource "aws_s3_bucket" "infra" {
   lifecycle {
     prevent_destroy = true
   }
+
+  lifecycle_rule {
+    id      = "tmp"
+    prefix  = "tmp/"
+    enabled = true
+
+    expiration {
+      days = 30
+    }
+  }
 }
 
 resource "aws_s3_bucket" "dashboard" {


### PR DESCRIPTION
### What is this PR trying to achieve?

Currently the EC2 instance tagger tends to hit the rate limit - this tries to tag each instance only once by recording the instance id in S3.

### Who is this change for?

💻 

### Have the following been considered/are they needed?

- [ ] Run `terraform apply`.
