### PR TITLE
Make the Terraform image build go faster

### DIFF
--- a/docker/terraform_ci/Dockerfile
+++ b/docker/terraform_ci/Dockerfile
@@ -1,28 +1,24 @@
-FROM golang:alpine
+FROM alpine
 
-ENV TERRAFORM_VERSION=0.9.11
-
+# Required for running git operations in the container
 RUN apk add --update git bash openssh
 
-ENV TF_DEV=true
-
-WORKDIR $GOPATH/src/github.com/hashicorp/terraform
-
-RUN git clone https://github.com/hashicorp/terraform.git ./ && \
-    git checkout v${TERRAFORM_VERSION} && \
-    /bin/bash scripts/build.sh
-
-VOLUME ["/data"]
-
 RUN apk --no-cache update && \
-    apk --no-cache add bash python py-pip py-setuptools ca-certificates curl groff less zip git && \
+    apk --no-cache add python py-pip py-setuptools ca-certificates curl groff less zip git && \
     pip --no-cache-dir install awscli && \
     rm -rf /var/cache/apk/*
+
+# Install terraform.  This is the last build step because it changes with
+# new Terraform releases, and we can cache the layers above.
+ENV TERRAFORM_VERSION=0.9.11
+COPY install_terraform.sh /install_terraform.sh
+RUN /install_terraform.sh
 
 COPY is_up_to_date_with_master.py /app/is_up_to_date_with_master.py
 COPY plan.sh /app/plan.sh
 COPY run.sh /app/run.sh
 
+VOLUME ["/data"]
 WORKDIR /data/terraform
 
 ENTRYPOINT /app/run.sh

--- a/docker/terraform_ci/install_terraform.sh
+++ b/docker/terraform_ci/install_terraform.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env sh
+
+set -o errexit
+set -o nounset
+
+apk update
+apk add unzip wget
+
+wget https://releases.hashicorp.com/terraform/"$TERRAFORM_VERSION"/terraform_"$TERRAFORM_VERSION"_linux_amd64.zip
+unzip terraform_"$TERRAFORM_VERSION"_linux_amd64.zip
+rm terraform_"$TERRAFORM_VERSION"_linux_amd64.zip
+
+mv terraform /usr/bin/terraform
+
+apk del unzip wget
+rm -rf /var/cache/apk/*


### PR DESCRIPTION
### What is this PR trying to achieve?

When you don’t have the Docker image in local cache, rebuilding is faster.

### Who is this change for?

Me, because I don’t want to have the hassle of waiting for the Go compiler!

Also I guess developers, but really me.