### PR TITLE
Add aws_cloudfront_distribution for Loris

### DIFF
--- a/terraform/cloudfront.tf
+++ b/terraform/cloudfront.tf
@@ -4,15 +4,15 @@ resource "aws_cloudfront_distribution" "loris" {
     origin_id   = "loris"
 
     custom_origin_config {
-      https_port = 443
-      http_port = 80
+      https_port             = 443
+      http_port              = 80
       origin_protocol_policy = "match-viewer"
-      origin_ssl_protocols = ["TLSv1.2"]
+      origin_ssl_protocols   = ["TLSv1.2"]
     }
   }
 
-  enabled             = true
-  is_ipv6_enabled     = true
+  enabled         = true
+  is_ipv6_enabled = true
 
   aliases = ["iiif.wellcomecollection.org"]
 
@@ -31,17 +31,17 @@ resource "aws_cloudfront_distribution" "loris" {
 
     viewer_protocol_policy = "redirect-to-https"
 
-    min_ttl                = 0
-    default_ttl            = 3600
-    max_ttl                = 86400
+    min_ttl     = 0
+    default_ttl = 3600
+    max_ttl     = 86400
   }
 
   price_class = "PriceClass_100"
 
   viewer_certificate {
-    acm_certificate_arn = "${var.iiif_acm_cert_arn}"
+    acm_certificate_arn      = "${var.iiif_acm_cert_arn}"
     minimum_protocol_version = "TLSv1"
-    ssl_support_method = "sni-only"
+    ssl_support_method       = "sni-only"
   }
 
   restrictions {

--- a/terraform/cloudfront.tf
+++ b/terraform/cloudfront.tf
@@ -1,0 +1,52 @@
+resource "aws_cloudfront_distribution" "loris" {
+  origin {
+    domain_name = "${module.api_alb.dns_name}"
+    origin_id   = "loris"
+
+    custom_origin_config {
+      https_port = 443
+      http_port = 80
+      origin_protocol_policy = "match-viewer"
+      origin_ssl_protocols = ["TLSv1.2"]
+    }
+  }
+
+  enabled             = true
+  is_ipv6_enabled     = true
+
+  aliases = ["iiif.wellcomecollection.org"]
+
+  default_cache_behavior {
+    allowed_methods  = ["GET", "HEAD", "OPTIONS"]
+    cached_methods   = ["GET", "HEAD"]
+    target_origin_id = "loris"
+
+    forwarded_values {
+      query_string = true
+
+      cookies {
+        forward = "none"
+      }
+    }
+
+    viewer_protocol_policy = "redirect-to-https"
+
+    min_ttl                = 0
+    default_ttl            = 3600
+    max_ttl                = 86400
+  }
+
+  price_class = "PriceClass_100"
+
+  viewer_certificate {
+    acm_certificate_arn = "${var.iiif_acm_cert_arn}"
+    minimum_protocol_version = "TLSv1"
+    ssl_support_method = "sni-only"
+  }
+
+  restrictions {
+    geo_restriction {
+      restriction_type = "none"
+    }
+  }
+}

--- a/terraform/ecs_alb/outputs.tf
+++ b/terraform/ecs_alb/outputs.tf
@@ -9,3 +9,8 @@ output "listener_http_arn" {
 output "cloudwatch_id" {
   value = "${aws_alb.ecs_service.arn_suffix}"
 }
+
+output "dns_name" {
+  value = "${aws_alb.ecs_service.dns_name}"
+}
+

--- a/terraform/ecs_alb/outputs.tf
+++ b/terraform/ecs_alb/outputs.tf
@@ -13,4 +13,3 @@ output "cloudwatch_id" {
 output "dns_name" {
   value = "${aws_alb.ecs_service.dns_name}"
 }
-

--- a/terraform/services/outputs.tf
+++ b/terraform/services/outputs.tf
@@ -9,3 +9,7 @@ output "target_group_arn" {
 output "role_name" {
   value = "${module.service.role_name}"
 }
+
+output "host_name" {
+  value = "${var.host_name}"
+}

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -82,3 +82,7 @@ variable "dashboard_assumable_roles" {
   description = "Assumable roles for the ECS dashboard"
   type        = "list"
 }
+
+variable "iiif_acm_cert_arn" {
+  description = "ARN of ACM cert for iiif API (in us-east-1) for CloudFront"
+}


### PR DESCRIPTION
### What is this PR trying to achieve?

Serving images via CloudFront will reduce load on the image server and speed up serving images.

### Who is this change for?

Folk who want to see images, quick!

### Have the following been considered/are they needed?

<!-- Delete bullets if they don't apply to this patch -->

- [ ] Run `terraform apply`.
