### PR TITLE
Adds volume to cloned task in lambda

### DIFF
--- a/lambdas/common/ecs_utils.py
+++ b/lambdas/common/ecs_utils.py
@@ -83,7 +83,8 @@ def clone_task_definition(client, task_definition):
     new_task = client.register_task_definition(
         family=taskDefinition['family'],
         taskRoleArn=taskDefinition['taskRoleArn'],
-        containerDefinitions=taskDefinition['containerDefinitions']
+        containerDefinitions=taskDefinition['containerDefinitions'],
+        volumes=taskDefinition['volumes']
     )
 
     return new_task['taskDefinition']['taskDefinitionArn']


### PR DESCRIPTION
### What is this PR trying to achieve?

When `update_task_for_config_change` lambda runs we do not clone the volumes in the task definition resulting in the following error:

```
An error occurred (ClientException) when calling the RegisterTaskDefinition operation: Unknown volume 'ephemera'.: ClientException
Traceback (most recent call last):
File "/var/task/update_task_for_config_change.py", line 78, in main
trigger_config_update(app_name=app_name)
File "/var/task/update_task_for_config_change.py", line 58, in trigger_config_update
service=app_name
File "/var/task/update_task_for_config_change.py", line 35, in clone_latest_task_definition
client=client, task_definition=task_definition
File "/var/task/ecs_utils.py", line 86, in clone_task_definition
containerDefinitions=taskDefinition['containerDefinitions']
File "/var/runtime/botocore/client.py", line 253, in _api_call
return self._make_api_call(operation_name, kwargs)
File "/var/runtime/botocore/client.py", line 557, in _make_api_call
raise error_class(parsed_response, operation_name)
botocore.errorfactory.ClientException: An error occurred (ClientException) when calling the RegisterTaskDefinition operation: Unknown volume 'ephemera'.
```

### Who is this change for?

💻 

### Have the following been considered/are they needed?

- [ ] Run `terraform apply`.
