### PR TITLE
Increases dynamo-to-sns lambda timeout to 10s

### DIFF
--- a/terraform/lambdas.tf
+++ b/terraform/lambdas.tf
@@ -275,6 +275,7 @@ module "lambda_dynamo_to_sns" {
   name        = "dynamo_to_sns"
   description = "Push new images form DynamoDB updates to SNS"
   source_dir  = "../lambdas/dynamo_to_sns"
+  timeout     = 10
 
   environment_variables = {
     STREAM_TOPIC_MAP = <<EOF


### PR DESCRIPTION
### What is this PR trying to achieve?

Avoid errors when under high load for the dynamo-to-sns lambda 

### Who is this change for?

💻 

### Have the following been considered/are they needed?

- [ ] Run `terraform apply`.
