### PR TITLE
Terminal failure alarms

### DIFF
--- a/ingestor/src/main/scala/uk/ac/wellcome/platform/ingestor/modules/IngestorWorkerModule.scala
+++ b/ingestor/src/main/scala/uk/ac/wellcome/platform/ingestor/modules/IngestorWorkerModule.scala
@@ -2,14 +2,14 @@ package uk.ac.wellcome.platform.ingestor.modules
 
 import akka.actor.ActorSystem
 import com.twitter.inject.{Injector, TwitterModule}
-import uk.ac.wellcome.platform.ingestor.services.IdMinterWorkerService
+import uk.ac.wellcome.platform.ingestor.services.IngestorWorkerService
 
 object IngestorWorkerModule extends TwitterModule {
   private val esIndex = flag[String]("es.index", "records", "ES index name")
   private val esType = flag[String]("es.type", "item", "ES document type")
 
   override def singletonStartup(injector: Injector) {
-    val workerService = injector.instance[IdMinterWorkerService]
+    val workerService = injector.instance[IngestorWorkerService]
 
     workerService.runSQSWorker()
 
@@ -20,7 +20,7 @@ object IngestorWorkerModule extends TwitterModule {
     info("Terminating SQS worker")
 
     val system = injector.instance[ActorSystem]
-    val workerService = injector.instance[IdMinterWorkerService]
+    val workerService = injector.instance[IngestorWorkerService]
 
     workerService.cancelRun()
     system.terminate()

--- a/ingestor/src/main/scala/uk/ac/wellcome/platform/ingestor/services/IngestorWorkerService.scala
+++ b/ingestor/src/main/scala/uk/ac/wellcome/platform/ingestor/services/IngestorWorkerService.scala
@@ -9,7 +9,7 @@ import uk.ac.wellcome.utils.GlobalExecutionContext.context
 
 import scala.concurrent.Future
 
-class IdMinterWorkerService @Inject()(
+class IngestorWorkerService @Inject()(
   identifiedWorkIndexer: IdentifiedWorkIndexer,
   reader: SQSReader,
   system: ActorSystem,

--- a/terraform/alarms.tf
+++ b/terraform/alarms.tf
@@ -15,3 +15,27 @@ resource "aws_cloudwatch_metric_alarm" "notify_old_deploys" {
   alarm_description = "This metric monitors alerts for old deploys"
   alarm_actions     = []
 }
+
+module "transformer_trybackoff" {
+  source  = "./dimensionless_critical_alarm"
+  metric_name = "TransformerWorkerService_TerminalFailure"
+  name = "TransformerWorkerService_TerminalFailure"
+  namespace = "miro-transformer"
+  alarm_action_arn = "${module.terminal_failure_alarm.arn}"
+}
+
+module "ingestor_trybackoff" {
+  source  = "./dimensionless_critical_alarm"
+  metric_name = "IngestorWorkerService_TerminalFailure"
+  name = "IngestorWorkerService_TerminalFailure"
+  namespace = "ingestor"
+  alarm_action_arn = "${module.terminal_failure_alarm.arn}"
+}
+
+module "ingestor_trybackoff" {
+  source  = "./dimensionless_critical_alarm"
+  metric_name = "IdMinterWorkerService_TerminalFailure"
+  name = "IngestorWorkerService_TerminalFailure"
+  namespace = "id-minter"
+  alarm_action_arn = "${module.terminal_failure_alarm.arn}"
+}

--- a/terraform/alarms.tf
+++ b/terraform/alarms.tf
@@ -17,25 +17,25 @@ resource "aws_cloudwatch_metric_alarm" "notify_old_deploys" {
 }
 
 module "transformer_trybackoff" {
-  source  = "./dimensionless_critical_alarm"
-  metric_name = "TransformerWorkerService_TerminalFailure"
-  name = "TransformerWorkerService_TerminalFailure"
-  namespace = "miro-transformer"
+  source           = "./dimensionless_critical_alarm"
+  metric_name      = "TransformerWorkerService_TerminalFailure"
+  name             = "TransformerWorkerService_TerminalFailure"
+  namespace        = "miro-transformer"
   alarm_action_arn = "${module.terminal_failure_alarm.arn}"
 }
 
 module "ingestor_trybackoff" {
-  source  = "./dimensionless_critical_alarm"
-  metric_name = "IngestorWorkerService_TerminalFailure"
-  name = "IngestorWorkerService_TerminalFailure"
-  namespace = "ingestor"
+  source           = "./dimensionless_critical_alarm"
+  metric_name      = "IngestorWorkerService_TerminalFailure"
+  name             = "IngestorWorkerService_TerminalFailure"
+  namespace        = "ingestor"
   alarm_action_arn = "${module.terminal_failure_alarm.arn}"
 }
 
-module "ingestor_trybackoff" {
-  source  = "./dimensionless_critical_alarm"
-  metric_name = "IdMinterWorkerService_TerminalFailure"
-  name = "IngestorWorkerService_TerminalFailure"
-  namespace = "id-minter"
+module "id-minter_trybackoff" {
+  source           = "./dimensionless_critical_alarm"
+  metric_name      = "IdMinterWorkerService_TerminalFailure"
+  name             = "IdMinterWorkerService_TerminalFailure"
+  namespace        = "id-minter"
   alarm_action_arn = "${module.terminal_failure_alarm.arn}"
 }

--- a/terraform/dimensionless_critical_alarm/main.tf
+++ b/terraform/dimensionless_critical_alarm/main.tf
@@ -1,0 +1,14 @@
+resource "aws_cloudwatch_metric_alarm" "dimensionless_critical" {
+  alarm_name          = "${var.name}"
+  comparison_operator = "GreaterThanOrEqualToThreshold"
+  evaluation_periods  = "1"
+  metric_name         = "${var.metric_name}"
+  namespace           = "${var.namespace}"
+  period              = "60"
+  statistic           = "Sum"
+  threshold           = "1"
+
+  alarm_description = "This metric monitors  service for terminal failure"
+  alarm_actions     = ["${var.alarm_action_arn}"]
+}
+

--- a/terraform/dimensionless_critical_alarm/main.tf
+++ b/terraform/dimensionless_critical_alarm/main.tf
@@ -11,4 +11,3 @@ resource "aws_cloudwatch_metric_alarm" "dimensionless_critical" {
   alarm_description = "This metric monitors  service for terminal failure"
   alarm_actions     = ["${var.alarm_action_arn}"]
 }
-

--- a/terraform/dimensionless_critical_alarm/variables.tf
+++ b/terraform/dimensionless_critical_alarm/variables.tf
@@ -1,0 +1,4 @@
+variable "name" {}
+variable "metric_name" {}
+variable "namespace" {}
+variable "alarm_action_arn" {}

--- a/terraform/dimensionless_critical_alarm/variables.tf
+++ b/terraform/dimensionless_critical_alarm/variables.tf
@@ -1,4 +1,15 @@
-variable "name" {}
-variable "metric_name" {}
-variable "namespace" {}
-variable "alarm_action_arn" {}
+variable "name" {
+  description = "Name of the alarm"
+}
+
+variable "metric_name" {
+  description = "Cloudwatch metric name"
+}
+
+variable "namespace" {
+  description = "Cloudwatch namspace"
+}
+
+variable "alarm_action_arn" {
+  description = "ARN of Cloudwatch action to take e.g. SNS topic"
+}

--- a/terraform/lambdas.tf
+++ b/terraform/lambdas.tf
@@ -268,6 +268,13 @@ module "trigger_post_to_slack_lambda_error" {
   sns_trigger_arn      = "${module.lambda_error_alarm.arn}"
 }
 
+module "trigger_post_to_slack_lambda_error" {
+  source               = "./lambda/trigger_sns"
+  lambda_function_name = "${module.lambda_post_to_slack.function_name}"
+  lambda_function_arn  = "${module.lambda_post_to_slack.arn}"
+  sns_trigger_arn      = "${module.terminal_failure_alarm.arn}"
+}
+
 # Lambda for pushing updates to dynamo tables into sqs queues
 
 module "lambda_dynamo_to_sns" {

--- a/terraform/lambdas.tf
+++ b/terraform/lambdas.tf
@@ -268,7 +268,7 @@ module "trigger_post_to_slack_lambda_error" {
   sns_trigger_arn      = "${module.lambda_error_alarm.arn}"
 }
 
-module "trigger_post_to_slack_lambda_error" {
+module "trigger_post_to_slack_terminal_failure" {
   source               = "./lambda/trigger_sns"
   lambda_function_name = "${module.lambda_post_to_slack.function_name}"
   lambda_function_arn  = "${module.lambda_post_to_slack.arn}"

--- a/terraform/topics.tf
+++ b/terraform/topics.tf
@@ -74,4 +74,3 @@ module "terminal_failure_alarm" {
   source = "./sns"
   name   = "terminal_failure_alarm"
 }
-

--- a/terraform/topics.tf
+++ b/terraform/topics.tf
@@ -69,3 +69,9 @@ module "lambda_error_alarm" {
   source = "./sns"
   name   = "lambda_error_alarm"
 }
+
+module "terminal_failure_alarm" {
+  source = "./sns"
+  name   = "terminal_failure_alarm"
+}
+


### PR DESCRIPTION
### What is this PR trying to achieve?

The SQSWorker based services can fail terminally - i.e. give up after trying N times. This adds an alarm that will show up in slack.

### Who is this change for?

💻 

### Have the following been considered/are they needed?

- [ ] Run `terraform apply`.
