### PR TITLE
Write outputs to SNS when we run a terraform apply

### DIFF
--- a/docker/terraform_ci/Dockerfile
+++ b/docker/terraform_ci/Dockerfile
@@ -4,7 +4,7 @@ FROM alpine
 RUN apk add --update git bash openssh
 
 RUN apk --no-cache update && \
-    apk --no-cache add python py-pip py-setuptools ca-certificates curl groff less zip git && \
+    apk --no-cache add jq python py-pip py-setuptools ca-certificates curl groff less zip git && \
     pip --no-cache-dir install awscli && \
     rm -rf /var/cache/apk/*
 

--- a/docker/terraform_ci/notify.sh
+++ b/docker/terraform_ci/notify.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+
+set -o errexit
+set -o nounset
+set -o verbose
+
+TOPIC_NAME=$1
+MESSAGE_FILE=$2
+
+TOPIC_ARN=$(aws sns list-topics | jq .Topics[].TopicArn -r | grep "$TOPIC_NAME" | tail -n 1)
+
+if [ -e $MESSAGE_FILE ]; then
+    aws sns publish \
+        --topic-arn "$TOPIC_ARN" \
+        --message "file://$MESSAGE_FILE"
+    echo "Notification sent to $TOPIC_ARN"
+else
+    echo "$MESSAGE_FILE result not found!"
+    exit 1
+fi

--- a/docker/terraform_ci/run.sh
+++ b/docker/terraform_ci/run.sh
@@ -8,6 +8,8 @@ export OP="${OP:-plan}"
 echo "Running terraform operation: $OP"
 echo "Terraform version: $(terraform version)"
 
+OUTPUT_LOCATION="/app/output.json"
+
 if [[ "$OP" == "plan" ]]
 then
   echo "Running plan operation."
@@ -18,6 +20,12 @@ then
   then
     echo "Running apply operation."
     terraform apply terraform.plan
+
+    echo "Extracting ouput to $OUTPUT_LOCATION"
+    terraform output --json > "$OUTPUT_LOCATION"
+
+    echo "Sending succesful apply notification."
+    /app/notify.sh terraform_apply "$OUTPUT_LOCATION"
   else
     echo "terraform.plan not found. Have you run a plan?"
     exit 1

--- a/terraform/outputs.tf
+++ b/terraform/outputs.tf
@@ -2,18 +2,6 @@ output "ecr_nginx" {
   value = "${module.ecr_repository_nginx.repository_url}"
 }
 
-output "miro_readonly_key_id" {
-  value = "${aws_iam_access_key.miro_images_readonly.id}"
-}
-
-output "miro_readonly_key_secret" {
-  value = "${aws_iam_access_key.miro_images_readonly.secret}"
-}
-
-output "mets_ingest_read_write_key_id" {
-  value = "${aws_iam_access_key.mets_ingest_read_write.id}"
-}
-
-output "mets_ingest_read_write_key_secret" {
-  value = "${aws_iam_access_key.mets_ingest_read_write.secret}"
+output "terraform_apply_topic" {
+  value = "${module.terminal_failure_alarm.arn}"
 }

--- a/terraform/topics.tf
+++ b/terraform/topics.tf
@@ -74,3 +74,8 @@ module "terminal_failure_alarm" {
   source = "./sns"
   name   = "terminal_failure_alarm"
 }
+
+module "terraform_apply_topic" {
+  source = "./sns"
+  name   = "terraform_apply"
+}


### PR DESCRIPTION
At the moment it's difficult to see when a `terrform apply` has been run. This change sends terraform outputs to an SNS topic when an apply is run successfully.

We can then push notifications elsewhere once we have this in place (e.g. slack, dashboards, etc)
