### PR TITLE
Transformer should not fail for transform errors

### DIFF
--- a/common/src/main/scala/uk/ac/wellcome/models/MiroTransformable.scala
+++ b/common/src/main/scala/uk/ac/wellcome/models/MiroTransformable.scala
@@ -17,7 +17,7 @@ case class MiroTransformableData(
   @JsonProperty("image_copyright_cleared") copyright_cleared: Option[String]
 )
 
-case class shouldNotTransformException(message: String)
+case class ShouldNotTransformException(message: String)
     extends Exception(message)
 
 case class MiroTransformable(MiroID: String,
@@ -45,12 +45,14 @@ case class MiroTransformable(MiroID: String,
       // this image in the public API.
       // See https://github.com/wellcometrust/platform-api/issues/356
       if (miroData.cleared.getOrElse("N") != "Y") {
-        throw new shouldNotTransformException("image_cleared field is not Y")
+        throw new ShouldNotTransformException("image_cleared field is not Y")
       }
       if (miroData.copyright_cleared.getOrElse("N") != "Y") {
-        throw new shouldNotTransformException(
+        throw new ShouldNotTransformException(
           "image_copyright_cleared field is not Y")
       }
+
+      //TODO: Ensure we throw ShouldNotTransformException in the correct places
 
       // In at least the V collection, many of the titles are truncated
       // versions of the description.  In this case, we drop the description

--- a/common/src/main/scala/uk/ac/wellcome/models/MiroTransformable.scala
+++ b/common/src/main/scala/uk/ac/wellcome/models/MiroTransformable.scala
@@ -18,7 +18,7 @@ case class MiroTransformableData(
 )
 
 case class ShouldNotTransformException(message: String)
-    extends Exception(message)
+  extends Exception(message)
 
 case class MiroTransformable(MiroID: String,
                              MiroCollection: String,

--- a/common/src/main/scala/uk/ac/wellcome/models/MiroTransformable.scala
+++ b/common/src/main/scala/uk/ac/wellcome/models/MiroTransformable.scala
@@ -52,8 +52,6 @@ case class MiroTransformable(MiroID: String,
           "image_copyright_cleared field is not Y")
       }
 
-      //TODO: Ensure we throw ShouldNotTransformException in the correct places
-
       // In at least the V collection, many of the titles are truncated
       // versions of the description.  In this case, we drop the description
       // field and put the full description in the label instead.

--- a/common/src/main/scala/uk/ac/wellcome/models/MiroTransformable.scala
+++ b/common/src/main/scala/uk/ac/wellcome/models/MiroTransformable.scala
@@ -18,7 +18,7 @@ case class MiroTransformableData(
 )
 
 case class ShouldNotTransformException(message: String)
-  extends Exception(message)
+    extends Exception(message)
 
 case class MiroTransformable(MiroID: String,
                              MiroCollection: String,

--- a/common/src/main/scala/uk/ac/wellcome/sns/SNSWriter.scala
+++ b/common/src/main/scala/uk/ac/wellcome/sns/SNSWriter.scala
@@ -9,7 +9,7 @@ import uk.ac.wellcome.utils.GlobalExecutionContext.context
 
 import scala.concurrent.{Future, blocking}
 
-case class PublishAttempt(id: Either[String,String])
+case class PublishAttempt(id: Either[Throwable,String])
 
 class SNSWriter @Inject()(snsClient: AmazonSNS, snsConfig: SNSConfig)
     extends Logging {

--- a/common/src/main/scala/uk/ac/wellcome/sns/SNSWriter.scala
+++ b/common/src/main/scala/uk/ac/wellcome/sns/SNSWriter.scala
@@ -9,7 +9,7 @@ import uk.ac.wellcome.utils.GlobalExecutionContext.context
 
 import scala.concurrent.{Future, blocking}
 
-case class PublishAttempt(id: String)
+case class PublishAttempt(id: Either[String,String])
 
 class SNSWriter @Inject()(snsClient: AmazonSNS, snsConfig: SNSConfig)
     extends Logging {
@@ -25,7 +25,7 @@ class SNSWriter @Inject()(snsClient: AmazonSNS, snsConfig: SNSConfig)
       }
     }.map { publishResult =>
         info(s"Published message ${publishResult.getMessageId}")
-        PublishAttempt(publishResult.getMessageId)
+        PublishAttempt(Right(publishResult.getMessageId))
       }
       .recover {
         case e: Throwable =>

--- a/common/src/main/scala/uk/ac/wellcome/sns/SNSWriter.scala
+++ b/common/src/main/scala/uk/ac/wellcome/sns/SNSWriter.scala
@@ -9,7 +9,7 @@ import uk.ac.wellcome.utils.GlobalExecutionContext.context
 
 import scala.concurrent.{Future, blocking}
 
-case class PublishAttempt(id: Either[Throwable,String])
+case class PublishAttempt(id: Either[Throwable, String])
 
 class SNSWriter @Inject()(snsClient: AmazonSNS, snsConfig: SNSConfig)
     extends Logging {

--- a/common/src/main/scala/uk/ac/wellcome/sqs/SQSReader.scala
+++ b/common/src/main/scala/uk/ac/wellcome/sqs/SQSReader.scala
@@ -15,7 +15,7 @@ import scala.collection.JavaConversions._
 import scala.concurrent.{Future, blocking}
 
 case class SQSReaderGracefulException(e: Exception)
-  extends Exception(e.getMessage)
+    extends Exception(e.getMessage)
 
 class SQSReader @Inject()(sqsClient: AmazonSQS, sqsConfig: SQSConfig)
     extends Logging {
@@ -69,10 +69,14 @@ class SQSReader @Inject()(sqsClient: AmazonSQS, sqsConfig: SQSConfig)
         })
         .recover {
           case e: SQSReaderGracefulException =>
-            info(s"Recoverable error processing message ${message.getMessageId}", e)
+            info(
+              s"Recoverable error processing message ${message.getMessageId}",
+              e)
             throw e
           case e: Throwable =>
-            error(s"Unrecoverable error processing message ${message.getMessageId}", e)
+            error(
+              s"Unrecoverable error processing message ${message.getMessageId}",
+              e)
             throw e
         }
         .flatMap(_ => deleteMessage(message))

--- a/common/src/main/scala/uk/ac/wellcome/sqs/SQSReader.scala
+++ b/common/src/main/scala/uk/ac/wellcome/sqs/SQSReader.scala
@@ -68,15 +68,8 @@ class SQSReader @Inject()(sqsClient: AmazonSQS, sqsConfig: SQSConfig)
           process(message)
         })
         .recover {
-          case e: SQSReaderGracefulException =>
-            info(
-              s"Recoverable error processing message ${message.getMessageId}",
-              e)
-            throw e
           case e: Throwable =>
-            error(
-              s"Unrecoverable error processing message ${message.getMessageId}",
-              e)
+            error(s"Error processing message ${message.getMessageId}", e)
             throw e
         }
         .flatMap(_ => deleteMessage(message))

--- a/common/src/test/scala/uk/ac/wellcome/sns/SNSWriterTest.scala
+++ b/common/src/test/scala/uk/ac/wellcome/sns/SNSWriterTest.scala
@@ -27,7 +27,7 @@ class SNSWriterTest
       messages should have size (1)
       messages.head.message shouldBe "someMessage"
       messages.head.subject shouldBe "subject"
-      publishAttempt.id should be(messages.head.messageId)
+      publishAttempt.id should be(Right(messages.head.messageId))
     }
   }
 

--- a/transformer/src/main/scala/uk/ac/wellcome/transformer/receive/SQSMessageReceiver.scala
+++ b/transformer/src/main/scala/uk/ac/wellcome/transformer/receive/SQSMessageReceiver.scala
@@ -34,7 +34,7 @@ class SQSMessageReceiver(
             publishMessage(work)
           case Failure(SQSReaderGracefulException(e)) =>
             info("Recoverable failure extracting unified item from record", e)
-            Future.successful(PublishAttempt(Left("graceful-failure")))
+            Future.successful(PublishAttempt(Left(e)))
           case Failure(e) =>
             info("Unrecoverable failure extracting unified item from record",
                  e)

--- a/transformer/src/main/scala/uk/ac/wellcome/transformer/receive/SQSMessageReceiver.scala
+++ b/transformer/src/main/scala/uk/ac/wellcome/transformer/receive/SQSMessageReceiver.scala
@@ -33,11 +33,10 @@ class SQSMessageReceiver(
           case Success(work) =>
             publishMessage(work)
           case Failure(SQSReaderGracefulException(e)) =>
-            info("Recoverable failure extracting unified item from record", e)
+            info("Recoverable failure extracting workfrom record", e)
             Future.successful(PublishAttempt(Left(e)))
           case Failure(e) =>
-            info("Unrecoverable failure extracting unified item from record",
-                 e)
+            info("Unrecoverable failure extracting work from record", e)
             Future.failed(e)
         }
       }

--- a/transformer/src/main/scala/uk/ac/wellcome/transformer/receive/SQSMessageReceiver.scala
+++ b/transformer/src/main/scala/uk/ac/wellcome/transformer/receive/SQSMessageReceiver.scala
@@ -36,7 +36,8 @@ class SQSMessageReceiver(
             info("Recoverable failure extracting unified item from record", e)
             Future.successful(PublishAttempt("graceful-failure"))
           case Failure(e) =>
-            info("Unrecoverable failure extracting unified item from record", e)
+            info("Unrecoverable failure extracting unified item from record",
+                 e)
             Future.failed(e)
         }
       }

--- a/transformer/src/test/scala/uk/ac/wellcome/transformer/receive/SQSMessageReceiverTest.scala
+++ b/transformer/src/test/scala/uk/ac/wellcome/transformer/receive/SQSMessageReceiverTest.scala
@@ -81,7 +81,7 @@ class SQSMessageReceiverTest
                          metricsSender)
     val future = recordReceiver.receiveMessage(failingTransformCalmSqsMessage)
 
-    whenReady(future.failed) { x =>
+    whenReady(future) { x =>
       x shouldBe a [SQSReaderGracefulException]
       x.asInstanceOf[SQSReaderGracefulException].e shouldBe a [JsonParseException]
     }

--- a/transformer/src/test/scala/uk/ac/wellcome/transformer/receive/SQSMessageReceiverTest.scala
+++ b/transformer/src/test/scala/uk/ac/wellcome/transformer/receive/SQSMessageReceiverTest.scala
@@ -101,7 +101,7 @@ class SQSMessageReceiverTest
   private def mockSNSWriter = {
     val mockSNS = mock[SNSWriter]
     when(mockSNS.writeMessage(anyString(), any[Option[String]]))
-      .thenReturn(Future { PublishAttempt("1234") })
+      .thenReturn(Future { PublishAttempt(Right("1234")) })
     mockSNS
   }
 

--- a/transformer/src/test/scala/uk/ac/wellcome/transformer/receive/SQSMessageReceiverTest.scala
+++ b/transformer/src/test/scala/uk/ac/wellcome/transformer/receive/SQSMessageReceiverTest.scala
@@ -11,6 +11,7 @@ import uk.ac.wellcome.metrics.MetricsSender
 import uk.ac.wellcome.models.aws.SQSMessage
 import uk.ac.wellcome.models.{SourceIdentifier, Work}
 import uk.ac.wellcome.sns.{PublishAttempt, SNSWriter}
+import uk.ac.wellcome.sqs.SQSReaderGracefulException
 import uk.ac.wellcome.transformer.parsers.CalmParser
 import uk.ac.wellcome.transformer.utils.TransformableSQSMessageUtils
 import uk.ac.wellcome.utils.GlobalExecutionContext.context
@@ -81,7 +82,8 @@ class SQSMessageReceiverTest
     val future = recordReceiver.receiveMessage(failingTransformCalmSqsMessage)
 
     whenReady(future.failed) { x =>
-      x shouldBe a [JsonParseException]
+      x shouldBe a [SQSReaderGracefulException]
+      x.asInstanceOf[SQSReaderGracefulException].e shouldBe a [JsonParseException]
     }
   }
 

--- a/transformer/src/test/scala/uk/ac/wellcome/transformer/utils/TransformableSQSMessageUtils.scala
+++ b/transformer/src/test/scala/uk/ac/wellcome/transformer/utils/TransformableSQSMessageUtils.scala
@@ -17,6 +17,12 @@ trait TransformableSQSMessageUtils {
     sqsMessage(JsonUtil.toJson(calmTransformable).get)
   }
 
+  def createValidMiroSQSMessage(data: String): SQSMessage = {
+    val miroTransformable = MiroTransformable("id","collection", data)
+
+    sqsMessage(JsonUtil.toJson(miroTransformable).get)
+  }
+
   def createValidMiroRecord(MiroID: String,
                             MiroCollection: String,
                             data: String): SQSMessage = {
@@ -28,6 +34,6 @@ trait TransformableSQSMessageUtils {
   def createInvalidRecord: SQSMessage = sqsMessage("not a json string")
 
   private def sqsMessage(message: String) = {
-    SQSMessage(None, message, "test-calm_transformer_topic", "notification", "")
+    SQSMessage(None, message, "test_transformer_topic", "notification", "")
   }
 }


### PR DESCRIPTION
### What is this PR trying to achieve?

At present errors in transforming data result in exceptions bubbling up to the trybackoff and resulting in a terminal failure.

### Who is this change for?

💻 

### Have the following been considered/are they needed?

- [ ] Run `terraform apply`.
