### PR TITLE
Don't reinstall the Lambdas on every Terraform run

### DIFF
--- a/docker/terraform_ci/Dockerfile
+++ b/docker/terraform_ci/Dockerfile
@@ -4,7 +4,7 @@ FROM alpine
 RUN apk add --update git bash openssh
 
 RUN apk --no-cache update && \
-    apk --no-cache add jq python py-pip py-setuptools ca-certificates curl groff less zip git && \
+    apk --no-cache add findutils jq python py-pip py-setuptools ca-certificates curl groff less zip git && \
     pip --no-cache-dir install awscli && \
     rm -rf /var/cache/apk/*
 

--- a/docker/terraform_ci/plan.sh
+++ b/docker/terraform_ci/plan.sh
@@ -35,6 +35,13 @@ echo "}" >> "$RELEASE_IDS_FILE"
 terraform init
 terraform get
 
+# These compiled pyc files are ephemeral, but because they're rebuilt on
+# a regular basis, they can confuse Terraform about whether the Lambda code
+# has changed.  They can be rebuilt easily (and automatically), so just
+# delete them before running `plan`.
+find /data/lambdas -name '*.pyc' -delete
+find /data/lambdas -path '*.dist-info/*' -delete
+
 terraform plan -var-file="$RELEASE_IDS_FILE" -out terraform.plan
 
 echo "Please review the above plan. If you are happy then run 'make terraform-apply"

--- a/lambdas/install_lambda_deps.sh
+++ b/lambdas/install_lambda_deps.sh
@@ -24,7 +24,7 @@ build_lambda() {
   if [[ -f "$lambda_dir/requirements.txt" ]]
   then
     echo "*** Found a requirements.txt"
-    pip3 install --upgrade --requirement "$lambda_dir/requirements.txt" --target "$lambda_dir"
+    pip3 install --requirement "$lambda_dir/requirements.txt" --target "$lambda_dir" >> pip_install.log
   else
     echo "*** No requirements.txt found, skipping"
   fi
@@ -32,7 +32,7 @@ build_lambda() {
   if [[ -f "$COMMON_LIB/requirements.txt" ]]
   then
     echo "*** Found a requirements.txt in common"
-    pip3 install --upgrade --requirement "$COMMON_LIB/requirements.txt" --target "$lambda_dir"
+    pip3 install --requirement "$COMMON_LIB/requirements.txt" --target "$lambda_dir" >> pip_install.log
   else
     echo "*** No common requirements.txt, skipping"
   fi


### PR DESCRIPTION
### What is this PR trying to achieve?

Make sure that our Lambdas aren’t reinstalled on every Terraform run. This makes our Terraform output cleaner, our builds faster, and reduces unnecessary churn.

Resolves #690.

### Who is this change for?

Developers and their quality-of-life.

### Have the following been considered/are they needed?

- [x] Run `terraform apply`.
