### PR TITLE
Use desc_academic if the other fields don't have more useful data

### DIFF
--- a/common/src/main/scala/uk/ac/wellcome/models/MiroTransformable.scala
+++ b/common/src/main/scala/uk/ac/wellcome/models/MiroTransformable.scala
@@ -10,6 +10,7 @@ case class MiroTransformableData(
   @JsonProperty("image_title") title: Option[String],
   @JsonProperty("image_creator") creator: Option[List[String]],
   @JsonProperty("image_image_desc") description: Option[String],
+  @JsonProperty("image_image_desc_academic") academicDescription: Option[String],
   @JsonProperty("image_secondary_creator") secondaryCreator: Option[
     List[String]],
   @JsonProperty("image_artwork_date") artworkDate: Option[String],
@@ -52,6 +53,21 @@ case class MiroTransformable(MiroID: String,
           "image_copyright_cleared field is not Y")
       }
 
+      // In Miro, the <image_image_desc> and <image_image_title> fields are
+      // filled in by the cataloguer at point of import.  There's also an
+      // <image_image_desc_academic> field which contains a description
+      // taken from Sierra.  In some cases, the cataloguer hasn't copied any
+      // of this field over the desc/title, just leaving them as "--"/"-".
+      //
+      // Since desc_academic is exposed publicly via Sierra, we can use it
+      // here if there's nothing more useful in the other fields.
+      val candidateDescription = miroData.description match {
+        case Some(s) => {
+          if (s == "--") miroData.academicDescription.getOrElse("") else s
+        }
+        case None => ""
+      }
+
       // Populate the label and description.  The rules are as follows:
       //
       //  1.  For V images, if the first line of <image_image_desc> is a
@@ -69,12 +85,12 @@ case class MiroTransformable(MiroID: String,
       // non-empty title.  This is _not_ true for the MIRO records in general.
       // TODO: Work out what label to use for those records.
       //
-      val candidateLabel = miroData.description.getOrElse("").split("\n").head
+      val candidateLabel = candidateDescription.split("\n").head
       val titleIsTruncatedDescription = candidateLabel
         .startsWith(miroData.title.get)
 
       val useDescriptionAsLabel = (titleIsTruncatedDescription &&
-        MiroCollection == "Images-V")
+        MiroCollection == "Images-V") || (miroData.title.get == "-")
 
       val label =
         if (useDescriptionAsLabel) candidateLabel
@@ -83,16 +99,17 @@ case class MiroTransformable(MiroID: String,
       val description = if (useDescriptionAsLabel) {
         // Remove the first line from the description, and trim any extra
         // whitespace (leading newlines)
-        val candidateDescription = miroData.description.get
+        Some(candidateDescription
           .replace(candidateLabel, "")
-          .trim
-        if (candidateDescription.length > 0) Some(candidateDescription)
-        else None
+          .trim)
       } else {
-        miroData.description match {
-          case Some(d) => if (d.trim.length > 0) Some(d) else None
-          case None => None
-        }
+        miroData.description
+      }
+
+      // If the description is an empty string, use a proper None type instead
+      val trimmedDescription = description match {
+        case Some(d) => if (d.trim.length > 0) Some(d.trim) else None
+        case None => None
       }
 
       // <image_creator>: the Creator, which maps to our property "hasCreator"
@@ -118,7 +135,7 @@ case class MiroTransformable(MiroID: String,
       Work(
         identifiers = identifiers,
         label = label,
-        description = description,
+        description = trimmedDescription,
         createdDate = createdDate,
         creators = creators ++ secondaryCreators
       )

--- a/common/src/main/scala/uk/ac/wellcome/models/MiroTransformable.scala
+++ b/common/src/main/scala/uk/ac/wellcome/models/MiroTransformable.scala
@@ -10,7 +10,8 @@ case class MiroTransformableData(
   @JsonProperty("image_title") title: Option[String],
   @JsonProperty("image_creator") creator: Option[List[String]],
   @JsonProperty("image_image_desc") description: Option[String],
-  @JsonProperty("image_image_desc_academic") academicDescription: Option[String],
+  @JsonProperty("image_image_desc_academic") academicDescription: Option[
+    String],
   @JsonProperty("image_secondary_creator") secondaryCreator: Option[
     List[String]],
   @JsonProperty("image_artwork_date") artworkDate: Option[String],
@@ -99,9 +100,10 @@ case class MiroTransformable(MiroID: String,
       val description = if (useDescriptionAsLabel) {
         // Remove the first line from the description, and trim any extra
         // whitespace (leading newlines)
-        Some(candidateDescription
-          .replace(candidateLabel, "")
-          .trim)
+        Some(
+          candidateDescription
+            .replace(candidateLabel, "")
+            .trim)
       } else {
         miroData.description
       }

--- a/common/src/test/scala/uk/ac/wellcome/models/MiroTransformableTest.scala
+++ b/common/src/test/scala/uk/ac/wellcome/models/MiroTransformableTest.scala
@@ -86,6 +86,39 @@ class MiroTransformableLabelTest extends FunSpec with Matchers {
     )
   }
 
+  it("""
+    should use the image_image_desc_academic if the image_image_desc field
+    doesn't contain useful data (one-line description)
+  """) {
+    val academicDescription = "An alibi for an academic"
+    transformRecordAndCheckLabel(
+      data = s"""
+        "image_title": "-",
+        "image_image_desc": "--",
+        "image_image_desc_academic": "$academicDescription"
+      """,
+      expectedLabel = academicDescription
+    )
+  }
+
+  it("""
+    should use the image_image_desc_academic if the image_image_desc field
+    doesn't contain useful data (multi-line description)
+  """) {
+    val academicLabel = "A lithograph of a lecturer"
+    val academicBody = "The corpus of a chancellor"
+    val academicDescription = s"$academicLabel\\n\\n$academicBody"
+    transformRecordAndCheckLabel(
+      data = s"""
+        "image_title": "-",
+        "image_image_desc": "--",
+        "image_image_desc_academic": "$academicDescription"
+      """,
+      expectedLabel = academicLabel,
+      expectedDescription = Some(academicBody)
+    )
+  }
+
   private def transformRecordAndCheckLabel(
     data: String,
     expectedLabel: String,


### PR DESCRIPTION
### What is this PR trying to achieve?

Improve the quality of the API results by using desc_academic if the other fields don't have more useful data. Related: #699.

After this is merged, we’ll need to run a reindex to pick up this and #697.

### Who is this change for?

Users of the API.

### Have the following been considered/are they needed?

- [x] Reviewed by @jtweed
- [ ] Deployed new versions