### PR TITLE
Thriftier use of CPU/memory in the service cluster

### DIFF
--- a/terraform/services.tf
+++ b/terraform/services.tf
@@ -22,6 +22,8 @@ module "miro_reindexer" {
   healthcheck_path   = "/miro_reindexer/management/healthcheck"
   infra_bucket       = "${var.infra_bucket}"
   config_key         = "config/${var.build_env}/miro_reindexer.ini"
+  cpu                = 256
+  memory             = 1024
 
   desired_count = "0"
 
@@ -51,6 +53,8 @@ module "ingestor" {
   healthcheck_path   = "/ingestor/management/healthcheck"
   infra_bucket       = "${var.infra_bucket}"
   config_key         = "config/${var.build_env}/ingestor.ini"
+  cpu                = 256
+  memory             = 1024
 
   config_vars = {
     es_host           = "${data.template_file.es_cluster_host.rendered}"
@@ -85,6 +89,8 @@ module "transformer" {
   healthcheck_path   = "/transformer/management/healthcheck"
   infra_bucket       = "${var.infra_bucket}"
   config_key         = "config/${var.build_env}/transformer.ini"
+  cpu                = 256
+  memory             = 1024
 
   config_vars = {
     sns_arn              = "${module.id_minter_topic.arn}"
@@ -113,6 +119,8 @@ module "id_minter" {
   healthcheck_path   = "/id_minter/management/healthcheck"
   infra_bucket       = "${var.infra_bucket}"
   config_key         = "config/${var.build_env}/id_minter.ini"
+  cpu                = 256
+  memory             = 1024
 
   config_vars = {
     rds_database_name   = "${module.identifiers_rds_cluster.database_name}"

--- a/terraform/services/ecs_tasks/data.tf
+++ b/terraform/services/ecs_tasks/data.tf
@@ -13,5 +13,8 @@ data "template_file" "definition" {
     volume_name              = "${var.volume_name}"
     container_path           = "${var.container_path}"
     environment_vars         = "[${join(",", concat(var.service_vars,var.extra_vars))}]"
+
+    cpu    = "${var.cpu}"
+    memory = "${var.memory}"
   }
 }

--- a/terraform/services/ecs_tasks/templates/default.json.template
+++ b/terraform/services/ecs_tasks/templates/default.json.template
@@ -21,10 +21,10 @@
     }
   },
   {
-    "cpu": "${cpu}",
+    "cpu": ${cpu},
     "essential": true,
     "image": "${app_uri}",
-    "memory": "${memory}",
+    "memory": ${memory},
     "name": "app",
     "environment": ${environment_vars},
     "portMappings": [

--- a/terraform/services/ecs_tasks/templates/default.json.template
+++ b/terraform/services/ecs_tasks/templates/default.json.template
@@ -21,10 +21,10 @@
     }
   },
   {
-    "cpu": 512,
+    "cpu": "${cpu}",
     "essential": true,
     "image": "${app_uri}",
-    "memory": 2048,
+    "memory": "${memory}",
     "name": "app",
     "environment": ${environment_vars},
     "portMappings": [

--- a/terraform/services/ecs_tasks/variables.tf
+++ b/terraform/services/ecs_tasks/variables.tf
@@ -61,10 +61,8 @@ variable "extra_vars" {
 
 variable "memory" {
   description = "How much memory to allocate to the app"
-  default     = 2048
 }
 
-variable "memory" {
+variable "cpu" {
   description = "How much CPU to allocate to the app"
-  default     = 512
 }

--- a/terraform/services/ecs_tasks/variables.tf
+++ b/terraform/services/ecs_tasks/variables.tf
@@ -58,3 +58,13 @@ variable "extra_vars" {
   description = "Environment variables to pass to the container"
   type        = "list"
 }
+
+variable "memory" {
+  description = "How much memory to allocate to the app"
+  default     = 2048
+}
+
+variable "memory" {
+  description = "How much CPU to allocate to the app"
+  default     = 512
+}

--- a/terraform/services/main.tf
+++ b/terraform/services/main.tf
@@ -29,6 +29,8 @@ module "task" {
   app_uri          = "${var.app_uri}"
   nginx_uri        = "${var.nginx_uri}"
   template_name    = "${var.template_name}"
+  cpu              = "${var.cpu}"
+  memory           = "${var.memory}"
 
   primary_container_port   = "${var.primary_container_port}"
   secondary_container_port = "${var.secondary_container_port}"

--- a/terraform/services/variables.tf
+++ b/terraform/services/variables.tf
@@ -128,3 +128,13 @@ variable "server_error_alarm_topic_arn" {
 variable "client_error_alarm_topic_arn" {
   description = "ARN of the topic where to send notification for 4xx ALB state"
 }
+
+variable "memory" {
+  description = "How much memory to allocate to the app"
+  default     = 2048
+}
+
+variable "cpu" {
+  description = "How much CPU to allocate to the app"
+  default     = 512
+}


### PR DESCRIPTION
### What is this PR trying to achieve?

Reduce the allocation of CPU and memory to our services. We’re midway through a reindex, and not even touching the sides:

![screen shot 2017-07-25 at 13 29 22](https://user-images.githubusercontent.com/301220/28572093-6f6dbca6-713d-11e7-9a0d-340062b2602b.png)

I reckon we can safely cut our allocated resources in half without affecting performance.

### Who is this change for?

The platform team. Either we keep the same ASG size and double reindex performance, or drop an instance and save $40 a month. Inclined to do the latter and turn it up only during reindexes.

### Have the following been considered/are they needed?

- [x] Run `terraform apply`.