### PR TITLE
Decode HTML entities when running the Miro transformer

### DIFF
--- a/common/src/main/scala/uk/ac/wellcome/models/MiroTransformable.scala
+++ b/common/src/main/scala/uk/ac/wellcome/models/MiroTransformable.scala
@@ -3,6 +3,7 @@ package uk.ac.wellcome.models
 import scala.util.Try
 
 import com.fasterxml.jackson.annotation.JsonProperty
+import org.apache.commons.lang.StringEscapeUtils;
 
 import uk.ac.wellcome.utils.JsonUtil
 
@@ -35,8 +36,14 @@ case class MiroTransformable(MiroID: String,
     RangeKey("MiroCollection", MiroCollection)
   )
 
-  override def transform: Try[Work] =
-    JsonUtil.fromJson[MiroTransformableData](data).map { miroData =>
+  override def transform: Try[Work] = {
+
+    // Some of the Miro fields were imported from Sierra, and had special
+    // characters replaced by HTML-encoded entities when copied across.
+    // We need to fix them up before we decode as JSON.
+    val unencodedData = StringEscapeUtils.unescapeHtml(data)
+
+    JsonUtil.fromJson[MiroTransformableData](unencodedData).map { miroData =>
       // Identifier is passed straight through
       val identifiers = List(SourceIdentifier("Miro", "MiroID", MiroID))
 
@@ -142,4 +149,5 @@ case class MiroTransformable(MiroID: String,
         creators = creators ++ secondaryCreators
       )
     }
+  }
 }

--- a/common/src/test/scala/uk/ac/wellcome/models/MiroTransformableTest.scala
+++ b/common/src/test/scala/uk/ac/wellcome/models/MiroTransformableTest.scala
@@ -303,6 +303,21 @@ class MiroTransformableTest extends FunSpec with Matchers {
     work.creators shouldBe List(Agent(creator), Agent(secondaryCreator))
   }
 
+  it(
+    "should correct HTML-encoded entities in the input JSON") {
+    val work = transformMiroRecord(
+      data = s"""{
+        "image_title": "A caf&#233; for cats",
+        "image_creator": ["Gyokush&#333;, a c&#228;t &#212;wn&#234;r"],
+        "image_cleared": "Y",
+        "image_copyright_cleared": "Y"
+      }"""
+    )
+
+    work.label shouldBe "A café for cats"
+    work.creators shouldBe List(Agent("Gyokushō, a cät Ôwnêr"))
+  }
+
   it("should not pass through records with a missing image_cleared field") {
     assertTransformMiroRecordFails(data = """{
       "image_title": "Missives on museums",


### PR DESCRIPTION
### What is this PR trying to achieve?

Previously HTML entities such as `&#333;` would appear in API responses. These are yucky – let’s make them proper strings instead! Related: #704.

### Who is this change for?

Folks who haven’t memorised the entire ISO-8859-1 encoding set.

### Have the following been considered/are they needed?

- [ ] Deployed new versions
