### PR TITLE
Tweak cluster compute resource

### DIFF
--- a/terraform/asg.tf
+++ b/terraform/asg.tf
@@ -7,9 +7,12 @@ module "services_cluster_asg" {
   user_data             = "${module.services_userdata.rendered}"
   vpc_id                = "${module.vpc_services.vpc_id}"
   admin_cidr_ingress    = "${var.admin_cidr_ingress}"
-  asg_desired           = "2"
-  asg_max               = "4"
-  instance_type         = "t2.large"
+
+  asg_desired = "3"
+  asg_max     = "6"
+
+  instance_type = "t2.small"
+
   sns_topic_arn         = "${module.ec2_terminating_topic.arn}"
   publish_to_sns_policy = "${module.ec2_terminating_topic.publish_policy}"
   alarm_topic_arn       = "${module.ec2_instance_terminating_for_too_long_alarm.arn}"
@@ -23,7 +26,9 @@ module "monitoring_cluster_asg" {
   instance_profile_name = "${module.ecs_monitoring_iam.instance_profile_name}"
   user_data             = "${module.monitoring_userdata.rendered}"
   vpc_id                = "${module.vpc_monitoring.vpc_id}"
-  instance_type         = "t2.large"
+
+  instance_type = "t2.small"
+
   admin_cidr_ingress    = "${var.admin_cidr_ingress}"
   sns_topic_arn         = "${module.ec2_terminating_topic.arn}"
   publish_to_sns_policy = "${module.ec2_terminating_topic.publish_policy}"
@@ -38,6 +43,10 @@ module "api_cluster_asg" {
   instance_profile_name = "${module.ecs_api_iam.instance_profile_name}"
   user_data             = "${module.api_userdata.rendered}"
   vpc_id                = "${module.vpc_api.vpc_id}"
+
+  asg_desired = "2"
+  asg_max     = "4"
+
   instance_type         = "t2.large"
   sns_topic_arn         = "${module.ec2_terminating_topic.arn}"
   publish_to_sns_policy = "${module.ec2_terminating_topic.publish_policy}"

--- a/terraform/asg_schedule.tf
+++ b/terraform/asg_schedule.tf
@@ -2,7 +2,7 @@
   The monitoring cluster isn't accessible outside the office, so running it
   outside working hours is just wasting money.  Have it turn itself off when
   we're not working.
-*/
+
 
 resource "aws_autoscaling_schedule" "turn_off_monitoring" {
   scheduled_action_name  = "Turn off the monitoring cluster outside working hours"
@@ -20,11 +20,12 @@ resource "aws_autoscaling_schedule" "turn_on_monitoring" {
   autoscaling_group_name = "${module.monitoring_cluster_asg.asg_name}"
 }
 
+*/
 /*
   The services cluster needs extra capacity when we're doing deployments,
   but deployments usually only happen during working hours.  Reduce the slack
   when we're not working.
-*/
+
 
 resource "aws_autoscaling_schedule" "reduce_services" {
   scheduled_action_name  = "Turn off the services cluster outside working hours"
@@ -41,3 +42,6 @@ resource "aws_autoscaling_schedule" "increase_services" {
   recurrence             = "0 08 * * 1-5"
   autoscaling_group_name = "${module.services_cluster_asg.asg_name}"
 }
+
+*/
+

--- a/terraform/services.tf
+++ b/terraform/services.tf
@@ -23,7 +23,7 @@ module "miro_reindexer" {
   infra_bucket       = "${var.infra_bucket}"
   config_key         = "config/${var.build_env}/miro_reindexer.ini"
 
-  cpu    = 256
+  cpu    = 512
   memory = 1024
 
   desired_count = "0"

--- a/terraform/services.tf
+++ b/terraform/services.tf
@@ -22,8 +22,9 @@ module "miro_reindexer" {
   healthcheck_path   = "/miro_reindexer/management/healthcheck"
   infra_bucket       = "${var.infra_bucket}"
   config_key         = "config/${var.build_env}/miro_reindexer.ini"
-  cpu                = 256
-  memory             = 1024
+
+  cpu    = 256
+  memory = 1024
 
   desired_count = "0"
 
@@ -53,8 +54,9 @@ module "ingestor" {
   healthcheck_path   = "/ingestor/management/healthcheck"
   infra_bucket       = "${var.infra_bucket}"
   config_key         = "config/${var.build_env}/ingestor.ini"
-  cpu                = 256
-  memory             = 1024
+
+  cpu    = 256
+  memory = 1024
 
   config_vars = {
     es_host           = "${data.template_file.es_cluster_host.rendered}"
@@ -89,8 +91,9 @@ module "transformer" {
   healthcheck_path   = "/transformer/management/healthcheck"
   infra_bucket       = "${var.infra_bucket}"
   config_key         = "config/${var.build_env}/transformer.ini"
-  cpu                = 256
-  memory             = 1024
+
+  cpu    = 256
+  memory = 1024
 
   config_vars = {
     sns_arn              = "${module.id_minter_topic.arn}"
@@ -119,8 +122,9 @@ module "id_minter" {
   healthcheck_path   = "/id_minter/management/healthcheck"
   infra_bucket       = "${var.infra_bucket}"
   config_key         = "config/${var.build_env}/id_minter.ini"
-  cpu                = 256
-  memory             = 1024
+
+  cpu    = 256
+  memory = 1024
 
   config_vars = {
     rds_database_name   = "${module.identifiers_rds_cluster.database_name}"
@@ -187,6 +191,13 @@ module "loris" {
   alb_priority       = "109"
   host_name          = "iiif-origin.wellcomecollection.org"
 
+  cpu = 1280
+
+  desired_count = "2"
+
+  deployment_minimum_healthy_percent = "50"
+  deployment_maximum_percent         = "200"
+
   volume_name      = "loris"
   volume_host_path = "${module.api_userdata.efs_mount_directory}/loris"
   container_path   = "/usr/local/share/images/loris"
@@ -204,6 +215,9 @@ module "grafana" {
   vpc_id             = "${module.vpc_monitoring.vpc_id}"
   listener_https_arn = "${module.monitoring_alb.listener_https_arn}"
   listener_http_arn  = "${module.monitoring_alb.listener_http_arn}"
+
+  cpu    = 256
+  memory = 1024
 
   nginx_uri                = "${module.ecr_repository_nginx_grafana.repository_url}:${var.release_ids["nginx_grafana"]}"
   healthcheck_path         = "/api/health"

--- a/terraform/services/ecs_service/ecs.tf
+++ b/terraform/services/ecs_service/ecs.tf
@@ -5,6 +5,9 @@ resource "aws_ecs_service" "service" {
   desired_count   = "${var.desired_count}"
   iam_role        = "${aws_iam_role.ecs_service.name}"
 
+  deployment_minimum_healthy_percent = "${var.deployment_minimum_healthy_percent}"
+  deployment_maximum_percent         = "${var.deployment_maximum_percent}"
+
   load_balancer {
     target_group_arn = "${aws_alb_target_group.ecs_service.arn}"
     container_name   = "${var.container_name}"

--- a/terraform/services/ecs_service/variables.tf
+++ b/terraform/services/ecs_service/variables.tf
@@ -69,3 +69,6 @@ variable "client_error_alarm_topic_arn" {
 variable "loadbalancer_cloudwatch_id" {
   description = "LoadBalancer ARN Suffix"
 }
+
+variable "deployment_minimum_healthy_percent" {}
+variable "deployment_maximum_percent" {}

--- a/terraform/services/main.tf
+++ b/terraform/services/main.tf
@@ -18,6 +18,9 @@ module "service" {
   client_error_alarm_topic_arn = "${var.client_error_alarm_topic_arn}"
   server_error_alarm_topic_arn = "${var.server_error_alarm_topic_arn}"
   loadbalancer_cloudwatch_id   = "${var.loadbalancer_cloudwatch_id}"
+
+  deployment_minimum_healthy_percent = "${var.deployment_minimum_healthy_percent}"
+  deployment_maximum_percent         = "${var.deployment_maximum_percent}"
 }
 
 module "task" {

--- a/terraform/services/variables.tf
+++ b/terraform/services/variables.tf
@@ -138,3 +138,11 @@ variable "cpu" {
   description = "How much CPU to allocate to the app"
   default     = 512
 }
+
+variable "deployment_minimum_healthy_percent" {
+  default = "100"
+}
+
+variable "deployment_maximum_percent" {
+  default = "200"
+}


### PR DESCRIPTION
### What is this PR trying to achieve?

While keeping costs the same, trim some unused compute resource from the clusters and add it to Loris.

### Who is this change for?

💻 

### Have the following been considered/are they needed?

- [x] Run `terraform apply`.
