### PR TITLE
Upload results from a Gatling test to S3

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -208,6 +208,7 @@ check-format: format
 ## Run JSON linting over the ontologies directory
 gatling-loris: docker-build-gatling
 	docker run \
+		-v $$HOME/.aws:/root/.aws \
 		-v $$(pwd)/gatling/user-files:/opt/gatling/user-files \
 		-v $$(pwd)/gatling/results:/opt/gatling/results \
 		-v $$(pwd)/gatling/data:/opt/gatling/data \

--- a/docker/gatling/Dockerfile
+++ b/docker/gatling/Dockerfile
@@ -18,7 +18,7 @@ RUN mkdir -p gatling
 
 # install some base packages
 RUN apk --no-cache update && \
-    apk --no-cache add wget bash python py-pip py-setuptools ca-certificates curl groff less zip git && \
+    apk --no-cache add findutils wget bash python py-pip py-setuptools ca-certificates curl groff less zip git && \
     pip --no-cache-dir install awscli && \
     rm -rf /var/cache/apk/*
 
@@ -42,5 +42,6 @@ ENV PATH /opt/gatling/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbi
 ENV GATLING_HOME /opt/gatling
 
 COPY run.sh /opt/gatling/run.sh
+COPY upload_results_to_s3.sh /opt/gatling/upload_results_to_s3.sh
 
 ENTRYPOINT ["/opt/gatling/run.sh"]

--- a/docker/gatling/run.sh
+++ b/docker/gatling/run.sh
@@ -5,3 +5,4 @@ set -o nounset
 set -o verbose
 
 $GATLING_HOME/bin/gatling.sh -s $SIMULATION
+/opt/gatling/upload_results_to_s3.sh

--- a/docker/gatling/upload_results_to_s3.sh
+++ b/docker/gatling/upload_results_to_s3.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+
+set -o errexit
+set -o nounset
+
+LAST_RESULT="$(find /opt/gatling/results -maxdepth 1 -type d | sort | tail -n 1)"
+
+aws s3 cp --acl=public-read --recursive "$LAST_RESULT" "s3://wellcome-platform-dash/gatling/$(basename $LAST_RESULT)"


### PR DESCRIPTION
Put our Gatling tests in a central location. Easier sharing and viewing. Longer term, this is a useful step for running Gatling in ECS.