### PR TITLE
/s/label/title in the ingest pipeline

### DIFF
--- a/api/src/main/scala/uk/ac/wellcome/platform/api/models/DisplayWork.scala
+++ b/api/src/main/scala/uk/ac/wellcome/platform/api/models/DisplayWork.scala
@@ -7,7 +7,7 @@ import uk.ac.wellcome.models._
 import uk.ac.wellcome.utils.JsonUtil
 
 case class DisplayWork(id: String,
-                       label: String,
+                       title: String,
                        description: Option[String] = None,
                        lettering: Option[String] = None,
                        createdDate: Option[Period] = None,
@@ -35,7 +35,7 @@ case object DisplayWork {
 
     DisplayWork(
       id = identifiedWork.canonicalId,
-      label = identifiedWork.work.label,
+      title = identifiedWork.work.title,
       description = identifiedWork.work.description,
       lettering = identifiedWork.work.lettering,
       createdDate = identifiedWork.work.createdDate,

--- a/api/src/test/scala/uk/ac/wellcome/platform/api/ApiWorksTest.scala
+++ b/api/src/test/scala/uk/ac/wellcome/platform/api/ApiWorksTest.scala
@@ -57,46 +57,46 @@ class ApiWorksTest
             |   {
             |     "type": "Work",
             |     "id": "${works(0).canonicalId}",
-            |     "label": "${works(0).work.label}",
+            |     "title": "${works(0).work.title}",
             |     "description": "${works(0).work.description.get}",
             |     "lettering": "${works(0).work.lettering.get}",
             |     "createdDate": {
             |       "type": "Period",
-            |       "label": "${works(0).work.createdDate.get.label}"
+            |       "title": "${works(0).work.createdDate.get.title}"
             |     },
             |     "creators": [{
             |       "type": "Agent",
-            |       "label": "${works(0).work.creators(0).label}"
+            |       "title": "${works(0).work.creators(0).title}"
             |     }]
             |   },
             |   {
             |     "type": "Work",
             |     "id": "${works(1).canonicalId}",
-            |     "label": "${works(1).work.label}",
+            |     "title": "${works(1).work.title}",
             |     "description": "${works(1).work.description.get}",
             |     "lettering": "${works(1).work.lettering.get}",
             |     "createdDate": {
             |       "type": "Period",
-            |       "label": "${works(1).work.createdDate.get.label}"
+            |       "title": "${works(1).work.createdDate.get.title}"
             |     },
             |     "creators": [{
             |       "type": "Agent",
-            |       "label": "${works(1).work.creators(0).label}"
+            |       "title": "${works(1).work.creators(0).title}"
             |     }]
             |   },
             |   {
             |     "type": "Work",
             |     "id": "${works(2).canonicalId}",
-            |     "label": "${works(2).work.label}",
+            |     "title": "${works(2).work.title}",
             |     "description": "${works(2).work.description.get}",
             |     "lettering": "${works(2).work.lettering.get}",
             |     "createdDate": {
             |       "type": "Period",
-            |       "label": "${works(2).work.createdDate.get.label}"
+            |       "title": "${works(2).work.createdDate.get.title}"
             |     },
             |     "creators": [{
             |       "type": "Agent",
-            |       "label": "${works(2).work.creators(0).label}"
+            |       "title": "${works(2).work.creators(0).title}"
             |     }]
             |   }
             |  ]
@@ -110,7 +110,7 @@ class ApiWorksTest
     val identifiedWork =
       identifiedWorkWith(
         canonicalId = canonicalId,
-        label = label,
+        title = title,
         description = description,
         lettering = lettering,
         createdDate = period,
@@ -127,16 +127,16 @@ class ApiWorksTest
             | "@context": "https://localhost:8888/$apiPrefix/context.json",
             | "type": "Work",
             | "id": "$canonicalId",
-            | "label": "$label",
+            | "title": "$title",
             | "description": "$description",
             | "lettering": "$lettering",
             | "createdDate": {
             |   "type": "Period",
-            |   "label": "${period.label}"
+            |   "title": "${period.title}"
             | },
             | "creators": [{
             |   "type": "Agent",
-            |   "label": "${agent.label}"
+            |   "title": "${agent.title}"
             | }]
             |}
           """.stripMargin
@@ -167,16 +167,16 @@ class ApiWorksTest
                           |   {
                           |     "type": "Work",
                           |     "id": "${works(1).canonicalId}",
-                          |     "label": "${works(1).work.label}",
+                          |     "title": "${works(1).work.title}",
                           |     "description": "${works(1).work.description.get}",
                           |     "lettering": "${works(1).work.lettering.get}",
                           |     "createdDate": {
                           |       "type": "Period",
-                          |       "label": "${works(1).work.createdDate.get.label}"
+                          |       "title": "${works(1).work.createdDate.get.title}"
                           |     },
                           |     "creators": [{
                           |       "type": "Agent",
-                          |       "label": "${works(1).work.creators(0).label}"
+                          |       "title": "${works(1).work.creators(0).title}"
                           |     }]
                           |   }]
                           |   }
@@ -200,16 +200,16 @@ class ApiWorksTest
                           |   {
                           |     "type": "Work",
                           |     "id": "${works(0).canonicalId}",
-                          |     "label": "${works(0).work.label}",
+                          |     "title": "${works(0).work.title}",
                           |     "description": "${works(0).work.description.get}",
                           |     "lettering": "${works(0).work.lettering.get}",
                           |     "createdDate": {
                           |       "type": "Period",
-                          |       "label": "${works(0).work.createdDate.get.label}"
+                          |       "title": "${works(0).work.createdDate.get.title}"
                           |     },
                           |     "creators": [{
                           |       "type": "Agent",
-                          |       "label": "${works(0).work.creators(0).label}"
+                          |       "title": "${works(0).work.creators(0).title}"
                           |     }]
                           |   }]
                           |   }
@@ -233,16 +233,16 @@ class ApiWorksTest
                           |   {
                           |     "type": "Work",
                           |     "id": "${works(2).canonicalId}",
-                          |     "label": "${works(2).work.label}",
+                          |     "title": "${works(2).work.title}",
                           |     "description": "${works(2).work.description.get}",
                           |     "lettering": "${works(2).work.lettering.get}",
                           |     "createdDate": {
                           |       "type": "Period",
-                          |       "label": "${works(2).work.createdDate.get.label}"
+                          |       "title": "${works(2).work.createdDate.get.title}"
                           |     },
                           |     "creators": [{
                           |       "type": "Agent",
-                          |       "label": "${works(2).work.creators(0).label}"
+                          |       "title": "${works(2).work.creators(0).title}"
                           |     }]
                           |   }]
                           |   }
@@ -365,11 +365,11 @@ class ApiWorksTest
   it("should return matching results if doing a full-text search") {
     val work1 = identifiedWorkWith(
       canonicalId = "1234",
-      label = "A drawing of a dodo"
+      title = "A drawing of a dodo"
     )
     val work2 = identifiedWorkWith(
       canonicalId = "5678",
-      label = "A mezzotint of a mouse"
+      title = "A mezzotint of a mouse"
     )
     insertIntoElasticSearch(work1, work2)
 
@@ -396,7 +396,7 @@ class ApiWorksTest
              |   {
              |     "type": "Work",
              |     "id": "${work1.canonicalId}",
-             |     "label": "${work1.work.label}",
+             |     "title": "${work1.work.title}",
              |     "creators": []
              |   }
              |  ]
@@ -414,7 +414,7 @@ class ApiWorksTest
     )
     val work1 = identifiedWorkWith(
       canonicalId = "1234",
-      label = "An image of an iguana",
+      title = "An image of an iguana",
       identifiers = List(identifier1)
     )
 
@@ -425,7 +425,7 @@ class ApiWorksTest
     )
     val work2 = identifiedWorkWith(
       canonicalId = "5678",
-      label = "An impression of an igloo",
+      title = "An impression of an igloo",
       identifiers = List(identifier2)
     )
 
@@ -448,7 +448,7 @@ class ApiWorksTest
                           |   {
                           |     "type": "Work",
                           |     "id": "${work1.canonicalId}",
-                          |     "label": "${work1.work.label}",
+                          |     "title": "${work1.work.title}",
                           |     "creators": [ ],
                           |     "identifiers": [
                           |       {
@@ -462,7 +462,7 @@ class ApiWorksTest
                           |   {
                           |     "type": "Work",
                           |     "id": "${work2.canonicalId}",
-                          |     "label": "${work2.work.label}",
+                          |     "title": "${work2.work.title}",
                           |     "creators": [ ],
                           |     "identifiers": [
                           |       {
@@ -489,7 +489,7 @@ class ApiWorksTest
     )
     val work = identifiedWorkWith(
       canonicalId = "1234",
-      label = "An image of an iguana",
+      title = "An image of an iguana",
       identifiers = List(identifier)
     )
     insertIntoElasticSearch(work)
@@ -503,7 +503,7 @@ class ApiWorksTest
                           | "@context": "https://localhost:8888/$apiPrefix/context.json",
                           | "type": "Work",
                           | "id": "${work.canonicalId}",
-                          | "label": "${work.work.label}",
+                          | "title": "${work.work.title}",
                           | "creators": [ ],
                           | "identifiers": [
                           |   {
@@ -523,13 +523,13 @@ class ApiWorksTest
     "should be able to look at different Elasticsearch indices based on the ?index query parameter") {
     val work = identifiedWorkWith(
       canonicalId = "1234",
-      label = "A whale on a wave"
+      title = "A whale on a wave"
     )
     insertIntoElasticSearch(work)
 
     val work_alt = identifiedWorkWith(
       canonicalId = "5678",
-      label = "An impostor in an igloo"
+      title = "An impostor in an igloo"
     )
     insertIntoElasticSearchWithIndex("alt_records", work_alt)
 
@@ -542,7 +542,7 @@ class ApiWorksTest
                           | "@context": "https://localhost:8888/$apiPrefix/context.json",
                           | "type": "Work",
                           | "id": "${work.canonicalId}",
-                          | "label": "${work.work.label}",
+                          | "title": "${work.work.title}",
                           | "creators": [ ]
                           |}
           """.stripMargin
@@ -558,7 +558,7 @@ class ApiWorksTest
                           | "@context": "https://localhost:8888/$apiPrefix/context.json",
                           | "type": "Work",
                           | "id": "${work_alt.canonicalId}",
-                          | "label": "${work_alt.work.label}",
+                          | "title": "${work_alt.work.title}",
                           | "creators": [ ]
                           |}
           """.stripMargin
@@ -570,13 +570,13 @@ class ApiWorksTest
     "should be able to search different Elasticsearch indices based on the ?index query parameter") {
     val work = identifiedWorkWith(
       canonicalId = "1234",
-      label = "A whale on a wave"
+      title = "A whale on a wave"
     )
     insertIntoElasticSearch(work)
 
     val work_alt = identifiedWorkWith(
       canonicalId = "5678",
-      label = "An impostor in an igloo"
+      title = "An impostor in an igloo"
     )
     insertIntoElasticSearchWithIndex("alt_records", work_alt)
 
@@ -595,7 +595,7 @@ class ApiWorksTest
                           |   {
                           |     "type": "Work",
                           |     "id": "${work.canonicalId}",
-                          |     "label": "${work.work.label}",
+                          |     "title": "${work.work.title}",
                           |     "creators": [ ]
                           |   }
                           |  ]
@@ -619,7 +619,7 @@ class ApiWorksTest
                           |   {
                           |     "type": "Work",
                           |     "id": "${work_alt.canonicalId}",
-                          |     "label": "${work_alt.work.label}",
+                          |     "title": "${work_alt.work.title}",
                           |     "creators": [ ]
                           |   }
                           |  ]
@@ -668,7 +668,7 @@ class ApiWorksTest
     "should return a Bad Request error if asked for an invalid include on an individual work") {
     val work = identifiedWorkWith(
       canonicalId = "1234",
-      label = "A emu and an elephant"
+      title = "A emu and an elephant"
     )
     insertIntoElasticSearch(work)
 

--- a/api/src/test/scala/uk/ac/wellcome/platform/api/ApiWorksTest.scala
+++ b/api/src/test/scala/uk/ac/wellcome/platform/api/ApiWorksTest.scala
@@ -62,11 +62,11 @@ class ApiWorksTest
             |     "lettering": "${works(0).work.lettering.get}",
             |     "createdDate": {
             |       "type": "Period",
-            |       "title": "${works(0).work.createdDate.get.title}"
+            |       "label": "${works(0).work.createdDate.get.label}"
             |     },
             |     "creators": [{
             |       "type": "Agent",
-            |       "title": "${works(0).work.creators(0).title}"
+            |       "label": "${works(0).work.creators(0).label}"
             |     }]
             |   },
             |   {
@@ -77,11 +77,11 @@ class ApiWorksTest
             |     "lettering": "${works(1).work.lettering.get}",
             |     "createdDate": {
             |       "type": "Period",
-            |       "title": "${works(1).work.createdDate.get.title}"
+            |       "label": "${works(1).work.createdDate.get.label}"
             |     },
             |     "creators": [{
             |       "type": "Agent",
-            |       "title": "${works(1).work.creators(0).title}"
+            |       "label": "${works(1).work.creators(0).label}"
             |     }]
             |   },
             |   {
@@ -92,11 +92,11 @@ class ApiWorksTest
             |     "lettering": "${works(2).work.lettering.get}",
             |     "createdDate": {
             |       "type": "Period",
-            |       "title": "${works(2).work.createdDate.get.title}"
+            |       "label": "${works(2).work.createdDate.get.label}"
             |     },
             |     "creators": [{
             |       "type": "Agent",
-            |       "title": "${works(2).work.creators(0).title}"
+            |       "label": "${works(2).work.creators(0).label}"
             |     }]
             |   }
             |  ]
@@ -132,11 +132,11 @@ class ApiWorksTest
             | "lettering": "$lettering",
             | "createdDate": {
             |   "type": "Period",
-            |   "title": "${period.title}"
+            |   "label": "${period.label}"
             | },
             | "creators": [{
             |   "type": "Agent",
-            |   "title": "${agent.title}"
+            |   "label": "${agent.label}"
             | }]
             |}
           """.stripMargin
@@ -172,11 +172,11 @@ class ApiWorksTest
                           |     "lettering": "${works(1).work.lettering.get}",
                           |     "createdDate": {
                           |       "type": "Period",
-                          |       "title": "${works(1).work.createdDate.get.title}"
+                          |       "label": "${works(1).work.createdDate.get.label}"
                           |     },
                           |     "creators": [{
                           |       "type": "Agent",
-                          |       "title": "${works(1).work.creators(0).title}"
+                          |       "label": "${works(1).work.creators(0).label}"
                           |     }]
                           |   }]
                           |   }
@@ -205,11 +205,11 @@ class ApiWorksTest
                           |     "lettering": "${works(0).work.lettering.get}",
                           |     "createdDate": {
                           |       "type": "Period",
-                          |       "title": "${works(0).work.createdDate.get.title}"
+                          |       "label": "${works(0).work.createdDate.get.label}"
                           |     },
                           |     "creators": [{
                           |       "type": "Agent",
-                          |       "title": "${works(0).work.creators(0).title}"
+                          |       "label": "${works(0).work.creators(0).label}"
                           |     }]
                           |   }]
                           |   }
@@ -238,11 +238,11 @@ class ApiWorksTest
                           |     "lettering": "${works(2).work.lettering.get}",
                           |     "createdDate": {
                           |       "type": "Period",
-                          |       "title": "${works(2).work.createdDate.get.title}"
+                          |       "label": "${works(2).work.createdDate.get.label}"
                           |     },
                           |     "creators": [{
                           |       "type": "Agent",
-                          |       "title": "${works(2).work.creators(0).title}"
+                          |       "label": "${works(2).work.creators(0).label}"
                           |     }]
                           |   }]
                           |   }

--- a/api/src/test/scala/uk/ac/wellcome/platform/api/WorksUtil.scala
+++ b/api/src/test/scala/uk/ac/wellcome/platform/api/WorksUtil.scala
@@ -30,8 +30,8 @@ trait WorksUtil {
           title = s"${idx}-${title}",
           description = s"${idx}-${description}",
           lettering = s"${idx}-${lettering}",
-          createdDate = period.copy(title = s"${idx}-${period.title}"),
-          creator = agent.copy(title = s"${idx}-${agent.title}")
+          createdDate = Period(s"${idx}-${period.label}"),
+          creator = Agent(s"${idx}-${agent.label}")
       ))
 
   def identifiedWorkWith(canonicalId: String, title: String): IdentifiedWork =

--- a/api/src/test/scala/uk/ac/wellcome/platform/api/WorksUtil.scala
+++ b/api/src/test/scala/uk/ac/wellcome/platform/api/WorksUtil.scala
@@ -6,7 +6,7 @@ import uk.ac.wellcome.platform.api.models.DisplayWork
 trait WorksUtil {
 
   val canonicalId = "1234"
-  val label = "this is the first image title"
+  val title = "this is the first image title"
   val description = "this is a description"
   val lettering = "some lettering"
 
@@ -15,7 +15,7 @@ trait WorksUtil {
 
   def convertWorkToDisplayWork(work: IdentifiedWork) = DisplayWork(
     work.canonicalId,
-    work.work.label,
+    work.work.title,
     work.work.description,
     work.work.lettering,
     work.work.createdDate,
@@ -27,26 +27,26 @@ trait WorksUtil {
       (idx: Int) =>
         identifiedWorkWith(
           canonicalId = s"${idx}-${canonicalId}",
-          label = s"${idx}-${label}",
+          title = s"${idx}-${title}",
           description = s"${idx}-${description}",
           lettering = s"${idx}-${lettering}",
-          createdDate = period.copy(label = s"${idx}-${period.label}"),
-          creator = agent.copy(label = s"${idx}-${agent.label}")
+          createdDate = period.copy(title = s"${idx}-${period.title}"),
+          creator = agent.copy(title = s"${idx}-${agent.title}")
       ))
 
-  def identifiedWorkWith(canonicalId: String, label: String): IdentifiedWork =
+  def identifiedWorkWith(canonicalId: String, title: String): IdentifiedWork =
     IdentifiedWork(canonicalId,
                    Work(identifiers =
                           List(SourceIdentifier("Miro", "MiroID", "5678")),
-                        label = label))
+                        title = title))
 
   def identifiedWorkWith(canonicalId: String,
-                         label: String,
+                         title: String,
                          identifiers: List[SourceIdentifier]): IdentifiedWork =
-    IdentifiedWork(canonicalId, Work(identifiers = identifiers, label = label))
+    IdentifiedWork(canonicalId, Work(identifiers = identifiers, title = title))
 
   def identifiedWorkWith(canonicalId: String,
-                         label: String,
+                         title: String,
                          description: String,
                          lettering: String,
                          createdDate: Period,
@@ -54,7 +54,7 @@ trait WorksUtil {
     canonicalId = canonicalId,
     work = Work(
       identifiers = List(SourceIdentifier("Miro", "MiroID", "5678")),
-      label = label,
+      title = title,
       description = Some(description),
       lettering = Some(lettering),
       createdDate = Some(createdDate),

--- a/api/src/test/scala/uk/ac/wellcome/platform/api/services/ElasticsearchServiceTest.scala
+++ b/api/src/test/scala/uk/ac/wellcome/platform/api/services/ElasticsearchServiceTest.scala
@@ -22,15 +22,15 @@ class ElasticsearchServiceTest
   it("should sort results from Elasticsearch in the correct order") {
     val work1 = identifiedWorkWith(
       canonicalId = "000Z",
-      label = "Amid an Aegean"
+      title = "Amid an Aegean"
     )
     val work2 = identifiedWorkWith(
       canonicalId = "000Y",
-      label = "Before a Bengal"
+      title = "Before a Bengal"
     )
     val work3 = identifiedWorkWith(
       canonicalId = "000X",
-      label = "Circling a Cheetah"
+      title = "Circling a Cheetah"
     )
 
     insertIntoElasticSearch(work1, work2, work3)
@@ -40,8 +40,8 @@ class ElasticsearchServiceTest
     )
     whenReady(sortedSearchResultByCanonicalId) { result =>
       val works = result.hits.hits.map { DisplayWork(_) }
-      works.head shouldBe DisplayWork(work3.canonicalId, work3.work.label)
-      works.last shouldBe DisplayWork(work1.canonicalId, work1.work.label)
+      works.head shouldBe DisplayWork(work3.canonicalId, work3.work.title)
+      works.last shouldBe DisplayWork(work1.canonicalId, work1.work.title)
     }
 
     // TODO: canonicalID is the only user-defined field that we can sort on.

--- a/api/src/test/scala/uk/ac/wellcome/platform/api/services/WorksServiceTest.scala
+++ b/api/src/test/scala/uk/ac/wellcome/platform/api/services/WorksServiceTest.scala
@@ -37,9 +37,9 @@ class WorksServiceTest
     displayWorksFuture map { displayWork =>
       displayWork.results should have size 2
       displayWork.results.head shouldBe DisplayWork(works(0).canonicalId,
-                                                    works(0).work.label)
+                                                    works(0).work.title)
       displayWork.results.tail.head shouldBe DisplayWork(works(1).canonicalId,
-                                                         works(1).work.label)
+                                                         works(1).work.title)
     }
   }
 
@@ -59,11 +59,11 @@ class WorksServiceTest
   it("should only find results that match a query if doing a full-text search") {
     val workDodo = identifiedWorkWith(
       canonicalId = "1234",
-      label = "A drawing of a dodo"
+      title = "A drawing of a dodo"
     )
     val workMouse = identifiedWorkWith(
       canonicalId = "5678",
-      label = "A mezzotint of a mouse"
+      title = "A mezzotint of a mouse"
     )
 
     insertIntoElasticSearch(workDodo, workMouse)
@@ -78,7 +78,7 @@ class WorksServiceTest
     whenReady(searchForDodo) { works =>
       works.results should have size 1
       works.results.head shouldBe DisplayWork(workDodo.canonicalId,
-                                              workDodo.work.label)
+                                              workDodo.work.title)
     }
   }
 
@@ -154,7 +154,7 @@ class WorksServiceTest
     "should not throw an exception if passed an invalid query string for full-text search") {
     val workEmu = identifiedWorkWith(
       canonicalId = "1234",
-      label = "An etching of an emu"
+      title = "An etching of an emu"
     )
     insertIntoElasticSearch(workEmu)
 
@@ -165,19 +165,19 @@ class WorksServiceTest
     whenReady(searchForEmu) { works =>
       works.results should have size 1
       works.results.head shouldBe DisplayWork(workEmu.canonicalId,
-                                              workEmu.work.label)
+                                              workEmu.work.title)
     }
   }
 
   it("should return identifiers if specified in the includes for findWorkById") {
     val canonicalId = "1234"
 
-    val label = "image label"
+    val title = "image title"
     val miroId = "abcdef"
     val sourceName = "Miro"
     val sourceId = "MiroID"
     val work = identifiedWorkWith(canonicalId,
-                                  label,
+                                  title,
                                   identifiers = List(
                                     SourceIdentifier(source = sourceName,
                                                      sourceId = sourceId,
@@ -203,12 +203,12 @@ class WorksServiceTest
   it("should return identifiers if specified in the includes for listWorks") {
     val canonicalId = "1234"
 
-    val label = "image label"
+    val title = "image title"
     val miroId = "abcdef"
     val sourceName = "Miro"
     val sourceId = "MiroID"
     val work = identifiedWorkWith(canonicalId,
-                                  label,
+                                  title,
                                   identifiers = List(
                                     SourceIdentifier(source = sourceName,
                                                      sourceId = sourceId,
@@ -230,12 +230,12 @@ class WorksServiceTest
   it("should return identifiers if specified in the includes for searchWorks") {
     val canonicalId = "1234"
 
-    val label = "A search for a snail"
+    val title = "A search for a snail"
     val miroId = "abcdef"
     val sourceName = "Miro"
     val sourceId = "MiroID"
     val work = identifiedWorkWith(canonicalId,
-                                  label,
+                                  title,
                                   identifiers = List(
                                     SourceIdentifier(source = sourceName,
                                                      sourceId = sourceId,

--- a/common/src/main/scala/uk/ac/wellcome/elasticsearch/mappings/WorksIndex.scala
+++ b/common/src/main/scala/uk/ac/wellcome/elasticsearch/mappings/WorksIndex.scala
@@ -28,7 +28,7 @@ class WorksIndex @Inject()(client: HttpClient,
         objectField("identifiers").fields(keywordField("source"),
                                           keywordField("sourceId"),
                                           keywordField("value")),
-        textField("label").fields(
+        textField("title").fields(
           textField("english").analyzer(EnglishLanguageAnalyzer)),
         textField("description").fields(
           textField("english").analyzer(EnglishLanguageAnalyzer)),

--- a/common/src/main/scala/uk/ac/wellcome/models/CalmTransformable.scala
+++ b/common/src/main/scala/uk/ac/wellcome/models/CalmTransformable.scala
@@ -10,7 +10,7 @@ case class CalmTransformableData(
   def transform: Try[Work] = Try {
     Work(
       identifiers = List(SourceIdentifier("source", "key", "value")),
-      label = "calm data label"
+      title = "Title for a Calm record"
     )
   }
 }

--- a/common/src/main/scala/uk/ac/wellcome/models/CalmTransformable.scala
+++ b/common/src/main/scala/uk/ac/wellcome/models/CalmTransformable.scala
@@ -8,9 +8,10 @@ case class CalmTransformableData(
   AccessStatus: Array[String]
 ) extends Transformable {
   def transform: Try[Work] = Try {
+    // TODO: Fill in proper data here
     Work(
       identifiers = List(SourceIdentifier("source", "key", "value")),
-      title = "Title for a Calm record"
+      title = "placeholder title for a Calm record"
     )
   }
 }

--- a/common/src/main/scala/uk/ac/wellcome/models/MiroTransformable.scala
+++ b/common/src/main/scala/uk/ac/wellcome/models/MiroTransformable.scala
@@ -77,7 +77,7 @@ case class MiroTransformable(MiroID: String,
         case None => ""
       }
 
-      // Populate the label and description.  The rules are as follows:
+      // Populate the title and description.  The rules are as follows:
       //
       //  1.  For V images, if the first line of <image_image_desc> is a
       //      prefix of <image_title>, we use that instead of the title, and
@@ -92,24 +92,24 @@ case class MiroTransformable(MiroID: String,
       //
       // Note: Every image in the V collection that has image_cleared == Y has
       // non-empty title.  This is _not_ true for the MIRO records in general.
-      // TODO: Work out what label to use for those records.
+      // TODO: Work out what title to use for those records.
       //
-      val candidateLabel = candidateDescription.split("\n").head
+      val candidateTitle = candidateDescription.split("\n").head
       val titleIsTruncatedDescription = candidateLabel
         .startsWith(miroData.title.get)
 
-      val useDescriptionAsLabel = (titleIsTruncatedDescription &&
+      val useDescriptionAsTitle = (titleIsTruncatedDescription &&
         MiroCollection == "Images-V") || (miroData.title.get == "-" || miroData.title.get == "--")
 
-      val label =
-        if (useDescriptionAsLabel) candidateLabel
+      val title =
+        if (useDescriptionAsTitle) candidateTitle
         else miroData.title.get
 
-      val description = if (useDescriptionAsLabel) {
+      val description = if (useDescriptionAsTitle) {
         // Remove the first line from the description, and trim any extra
         // whitespace (leading newlines)
         candidateDescription
-          .replace(candidateLabel, "")
+          .replace(candidateTitle, "")
       } else {
         candidateDescription
       }
@@ -140,7 +140,7 @@ case class MiroTransformable(MiroID: String,
 
       Work(
         identifiers = identifiers,
-        label = label,
+        title = title,
         description = trimmedDescription,
         createdDate = createdDate,
         creators = creators ++ secondaryCreators

--- a/common/src/main/scala/uk/ac/wellcome/models/MiroTransformable.scala
+++ b/common/src/main/scala/uk/ac/wellcome/models/MiroTransformable.scala
@@ -95,7 +95,7 @@ case class MiroTransformable(MiroID: String,
       // TODO: Work out what title to use for those records.
       //
       val candidateTitle = candidateDescription.split("\n").head
-      val titleIsTruncatedDescription = candidateLabel
+      val titleIsTruncatedDescription = candidateTitle
         .startsWith(miroData.title.get)
 
       val useDescriptionAsTitle = (titleIsTruncatedDescription &&

--- a/common/src/main/scala/uk/ac/wellcome/models/Work.scala
+++ b/common/src/main/scala/uk/ac/wellcome/models/Work.scala
@@ -14,7 +14,7 @@ case class IdentifiedWork(canonicalId: String, work: Work)
   */
 case class Work(
   identifiers: List[SourceIdentifier],
-  label: String,
+  title: String,
   description: Option[String] = None,
   lettering: Option[String] = None,
   createdDate: Option[Period] = None,

--- a/common/src/test/scala/uk/ac/wellcome/elasticsearch/mappings/WorksIndexTest.scala
+++ b/common/src/test/scala/uk/ac/wellcome/elasticsearch/mappings/WorksIndexTest.scala
@@ -42,7 +42,7 @@ class WorksIndexTest
                         SourceIdentifier(source = "Miro",
                                          sourceId = "MiroID",
                                          value = "4321")),
-                      label = "this is the miro image label")
+                      title = "A magical menagerie for magpies")
         ))
       .get
 

--- a/common/src/test/scala/uk/ac/wellcome/models/MiroTransformableTest.scala
+++ b/common/src/test/scala/uk/ac/wellcome/models/MiroTransformableTest.scala
@@ -68,7 +68,7 @@ class MiroTransformableTitleTest extends FunSpec with Matchers {
   }
 
   it("""
-    should use the first line of image_image_desc as the latitlebel on a V image
+    should use the first line of image_image_desc as the title on a V image
     if image_title is a prefix of said first line (multi-line description)
   """) {
     val title = "An icon of an iguana"

--- a/common/src/test/scala/uk/ac/wellcome/models/MiroTransformableTest.scala
+++ b/common/src/test/scala/uk/ac/wellcome/models/MiroTransformableTest.scala
@@ -3,12 +3,12 @@ package uk.ac.wellcome.models
 import org.scalatest.{FunSpec, Matchers}
 
 
-/** Tests that the Miro transformer extracts the "label" field correctly.
+/** Tests that the Miro transformer extracts the "title" field correctly.
  *
  *  The rules around this heuristic are somewhat fiddly, and we need to be
  *  careful that we're extracting the right fields from the Miro metadata.
  */
-class MiroTransformableLabelTest extends FunSpec with Matchers {
+class MiroTransformableTitleTest extends FunSpec with Matchers {
 
   it("should use the image_title field on non-V records") {
     val title = "A picture of a parrot"
@@ -33,7 +33,7 @@ class MiroTransformableLabelTest extends FunSpec with Matchers {
   }
 
   it("""
-    should use the image_title field as the label on a V image if the
+    should use the image_title field as the title on a V image if the
     image_title is not a prefix of image_image_desc
   """) {
     val title = "A tome about a turtle"
@@ -50,7 +50,7 @@ class MiroTransformableLabelTest extends FunSpec with Matchers {
   }
 
   it("""
-    should use the first line of image_image_desc as the label on a V image
+    should use the first line of image_image_desc as the title on a V image
     if image_title is a prefix of said first line, and omit a description
     entirely (one-line description)
   """) {
@@ -68,7 +68,7 @@ class MiroTransformableLabelTest extends FunSpec with Matchers {
   }
 
   it("""
-    should use the first line of image_image_desc as the label on a V image
+    should use the first line of image_image_desc as the latitlebel on a V image
     if image_title is a prefix of said first line (multi-line description)
   """) {
     val title = "An icon of an iguana"
@@ -166,7 +166,7 @@ class MiroTransformableLabelTest extends FunSpec with Matchers {
     )
 
     miroTransformable.transform.isSuccess shouldBe true
-    miroTransformable.transform.get.label shouldBe expectedLabel
+    miroTransformable.transform.get.title shouldBe expectedLabel
     miroTransformable.transform.get.description shouldBe expectedDescription
   }
 }
@@ -344,7 +344,7 @@ class MiroTransformableTest extends FunSpec with Matchers {
       }"""
     )
 
-    work.label shouldBe "A café for cats"
+    work.title shouldBe "A café for cats"
     work.creators shouldBe List(Agent("Gyokushō, a cät Ôwnêr"))
   }
 

--- a/common/src/test/scala/uk/ac/wellcome/test/ModelsTest.scala
+++ b/common/src/test/scala/uk/ac/wellcome/test/ModelsTest.scala
@@ -9,7 +9,7 @@ class WorkTest extends FunSpec with Matchers {
   it("should have an LD type 'Work' when serialised to JSON") {
     val work = Work(
       identifiers = List(),
-      label = "A book about a blue whale"
+      title = "A book about a blue whale"
     )
     val jsonString = JsonUtil.toJson(work).get
 
@@ -21,7 +21,7 @@ class JsonUtilTest extends FunSpec with Matchers {
   it("should not include fields where the value is empty or None") {
     val work = Work(
       identifiers = List(),
-      label = "A haiku about a heron"
+      title = "A haiku about a heron"
     )
     val jsonString = JsonUtil.toJson(work).get
 
@@ -30,7 +30,7 @@ class JsonUtilTest extends FunSpec with Matchers {
   }
 
   it("should round-trip an empty list back to an empty list") {
-    val jsonString = """{"accessStatus": [], "label": "A doodle of a dog"}"""
+    val jsonString = """{"accessStatus": [], "title": "A doodle of a dog"}"""
     val parsedWork = JsonUtil.fromJson[Work](jsonString).get
     val extrapolatedString = JsonUtil.toJson(parsedWork).get
 

--- a/id_minter/src/test/scala/uk/ac/wellcome/platform/idminter/IdMinterFeatureTest.scala
+++ b/id_minter/src/test/scala/uk/ac/wellcome/platform/idminter/IdMinterFeatureTest.scala
@@ -28,11 +28,11 @@ class IdMinterFeatureTest
   it(
     "should read a work from the SQS queue, generate a canonical ID, save it in dynamoDB and send a message to the SNS topic with the original work and the id") {
     val miroID = "M0001234"
-    val label = "A limerick about a lion"
+    val title = "A limerick about a lion"
 
     val work = Work(identifiers =
                       List(SourceIdentifier("Miro", "MiroID", miroID)),
-                    label = label)
+                    title = title)
     val sqsMessage = SQSMessage(Some("subject"),
                                 JsonUtil.toJson(work).get,
                                 "topic",
@@ -56,7 +56,7 @@ class IdMinterFeatureTest
 
       parsedIdentifiedWork.canonicalId shouldBe maybeIdentifier.get.CanonicalID
       parsedIdentifiedWork.work.identifiers.head.value shouldBe miroID
-      parsedIdentifiedWork.work.label shouldBe label
+      parsedIdentifiedWork.work.title shouldBe title
 
       messages.head.subject should be("identified-item")
     }

--- a/id_minter/src/test/scala/uk/ac/wellcome/platform/idminter/modules/IdMinterWorkerTest.scala
+++ b/id_minter/src/test/scala/uk/ac/wellcome/platform/idminter/modules/IdMinterWorkerTest.scala
@@ -85,7 +85,7 @@ class IdMinterWorkerTest
             .toJson(
               Work(
                 identifiers = List(SourceIdentifier("Miro", "MiroID", miroId)),
-                label = "some label"
+                title = "Some fresh fruit for a flamingo"
               ))
             .get,
           "topic",

--- a/id_minter/src/test/scala/uk/ac/wellcome/platform/idminter/steps/IdentifierGeneratorTest.scala
+++ b/id_minter/src/test/scala/uk/ac/wellcome/platform/idminter/steps/IdentifierGeneratorTest.scala
@@ -40,7 +40,7 @@ class IdentifierGeneratorTest
 
     val work =
       Work(identifiers = List(SourceIdentifier("Miro", "MiroID", "1234")),
-           label = "some label")
+           search = "Searching for a sea slug")
     val futureId = identifierGenerator.generateId(work)
 
     whenReady(futureId) { id =>
@@ -52,7 +52,7 @@ class IdentifierGeneratorTest
     "should generate an id and save it in the database if a record doesn't already exist") {
     val work =
       Work(identifiers = List(SourceIdentifier("Miro", "MiroID", "1234")),
-           label = "some label")
+           title = "A novel name for a nightingale")
     val futureId = identifierGenerator.generateId(work)
 
     whenReady(futureId) { id =>
@@ -70,7 +70,7 @@ class IdentifierGeneratorTest
     val work =
       Work(
         identifiers = List(SourceIdentifier("NotMiro", "NotMiroID", "1234")),
-        label = "some label")
+        title = "The rejection of a robin")
     val futureId = identifierGenerator.generateId(work)
 
     whenReady(futureId.failed) { exception =>
@@ -83,7 +83,7 @@ class IdentifierGeneratorTest
     val miroId = "1234"
     val work =
       Work(identifiers = List(SourceIdentifier("Miro", "MiroID", miroId)),
-           label = "some label")
+           title = "A fear of failing in a fox")
     val identifiersDao = mock[IdentifiersDao]
     val identifierGenerator =
       new IdentifierGenerator(identifiersDao, metricsSender)

--- a/id_minter/src/test/scala/uk/ac/wellcome/platform/idminter/steps/IdentifierGeneratorTest.scala
+++ b/id_minter/src/test/scala/uk/ac/wellcome/platform/idminter/steps/IdentifierGeneratorTest.scala
@@ -40,7 +40,7 @@ class IdentifierGeneratorTest
 
     val work =
       Work(identifiers = List(SourceIdentifier("Miro", "MiroID", "1234")),
-           search = "Searching for a sea slug")
+           title = "Searching for a sea slug")
     val futureId = identifierGenerator.generateId(work)
 
     whenReady(futureId) { id =>

--- a/id_minter/src/test/scala/uk/ac/wellcome/platform/idminter/steps/WorkExtractorTest.scala
+++ b/id_minter/src/test/scala/uk/ac/wellcome/platform/idminter/steps/WorkExtractorTest.scala
@@ -16,11 +16,11 @@ class WorkExtractorTest
   it("extracts the work included in the SQS message") {
 
     val miroID = "M0000001"
-    val label = "A note about a narwhal"
+    val title = "A note about a narwhal"
 
     val work = Work(
       identifiers = List(SourceIdentifier("Miro", "MiroId", miroID)),
-      label = label
+      title = title
     )
     val sqsMessage = SQSMessage(Some("subject"),
                                 JsonUtil.toJson(work).get,
@@ -32,7 +32,7 @@ class WorkExtractorTest
 
     whenReady(eventualWork) { extractedWork =>
       extractedWork.identifiers.head.value shouldBe miroID
-      extractedWork.label shouldBe label
+      extractedWork.title shouldBe title
     }
   }
 

--- a/id_minter/src/test/scala/uk/ac/wellcome/platform/idminter/utils/IdMinterTestUtils.scala
+++ b/id_minter/src/test/scala/uk/ac/wellcome/platform/idminter/utils/IdMinterTestUtils.scala
@@ -38,7 +38,7 @@ trait IdMinterTestUtils
   def generateSqsMessage(MiroID: String): SQSMessage = {
     val work = Work(identifiers =
                       List(SourceIdentifier("Miro", "MiroID", MiroID)),
-                    label = "some label")
+                    title = "A query about a queue of quails")
     SQSMessage(Some("subject"),
                JsonUtil.toJson(work).get,
                "topic",

--- a/ingestor/src/test/scala/uk/ac/wellcome/platform/ingestor/IngestorFeatureTest.scala
+++ b/ingestor/src/test/scala/uk/ac/wellcome/platform/ingestor/IngestorFeatureTest.scala
@@ -33,7 +33,7 @@ class IngestorFeatureTest
           canonicalId = "1234",
           work = Work(identifiers =
                         List(SourceIdentifier("Miro", "MiroID", "5678")),
-                      label = "some label")))
+                      title = "A type of a tame turtle")))
       .get
 
     sqsClient.sendMessage(

--- a/ingestor/src/test/scala/uk/ac/wellcome/platform/ingestor/services/IdentifiedWorkIndexerTest.scala
+++ b/ingestor/src/test/scala/uk/ac/wellcome/platform/ingestor/services/IdentifiedWorkIndexerTest.scala
@@ -32,21 +32,21 @@ class IdentifiedWorkIndexerTest
 
   def identifiedWorkJson(canonicalId: String,
                          sourceId: String,
-                         label: String): String = {
+                         title: String): String = {
     JsonUtil
       .toJson(
         IdentifiedWork(
           canonicalId = canonicalId,
           work = Work(identifiers =
                         List(SourceIdentifier("Miro", "MiroID", sourceId)),
-                      label = label)))
+                      title = title)))
       .get
   }
 
   it("should insert an identified unified item into Elasticsearch") {
 
     val identifiedWorkString =
-      identifiedWorkJson("5678", "1234", "some label")
+      identifiedWorkJson("5678", "1234", "An identified igloo")
 
     val future =
       identifiedWorkIndexer.indexIdentifiedWork(identifiedWorkString)
@@ -67,7 +67,7 @@ class IdentifiedWorkIndexerTest
   it(
     "should add only one record when multiple records with same id are ingested") {
     val identifiedWorkString =
-      identifiedWorkJson("5678", "1234", "some label")
+      identifiedWorkJson("5678", "1234", "A multiplicity of mice")
 
     val future = Future.sequence(
       (1 to 2).map(_ =>

--- a/terraform/services.tf
+++ b/terraform/services.tf
@@ -169,7 +169,7 @@ module "api_romulus" {
   cluster_id         = "${aws_ecs_cluster.api.id}"
   task_role_arn      = "${module.ecs_api_iam.task_role_arn}"
   vpc_id             = "${module.vpc_api.vpc_id}"
-  app_uri            = "${module.ecr_repository_api.repository_url}:${var.pinned_romulus_api != "" ? var.pinned_romulus_api : var.release_ids["api_romulus"]}"
+  app_uri            = "${module.ecr_repository_api.repository_url}:${var.pinned_romulus_api != "" ? var.pinned_romulus_api : var.release_ids["api"]}"
   nginx_uri          = "${module.ecr_repository_nginx_api.repository_url}:${var.pinned_romulus_api_nginx != "" ? var.pinned_romulus_api_nginx : var.release_ids["nginx_api"]}"
   listener_https_arn = "${module.api_alb.listener_https_arn}"
   listener_http_arn  = "${module.api_alb.listener_http_arn}"

--- a/terraform/variables_api.tf
+++ b/terraform/variables_api.tf
@@ -16,22 +16,22 @@ variable "production_api" {
 }
 
 variable "pinned_romulus_api" {
-  description = "Which version of the API imag to pin romulus to, if any"
-  default     = ""
+  description = "Which version of the API image to pin romulus to, if any"
+  default     = "0.0.1-1a7662f518b7af1149d736f78cafe440484e4630_prod"
 }
 
 variable "pinned_romulus_api_nginx" {
-  description = "Which version of the nginx API imag to pin romulus to, if any"
-  default     = ""
+  description = "Which version of the nginx API image to pin romulus to, if any"
+  default     = "1a7662f518b7af1149d736f78cafe440484e4630"
 }
 
 variable "pinned_remus_api" {
-  description = "Which version of the API imag to pin remus to, if any"
+  description = "Which version of the API image to pin remus to, if any"
   default     = ""
 }
 
 variable "pinned_remus_api_nginx" {
-  description = "Which version of the nginx API imag to pin remus to, if any"
+  description = "Which version of the nginx API image to pin remus to, if any"
   default     = ""
 }
 

--- a/transformer/src/test/scala/uk/ac/wellcome/transformer/CalmTransformerFeatureTest.scala
+++ b/transformer/src/test/scala/uk/ac/wellcome/transformer/CalmTransformerFeatureTest.scala
@@ -72,7 +72,7 @@ class  CalmTransformerFeatureTest
       .toJson(
         Work(
           identifiers = List(SourceIdentifier("source", "key", "value")),
-          label = "calm data label"
+          label = "Cats that can carry themselves calmly"
         ))
       .get
   }

--- a/transformer/src/test/scala/uk/ac/wellcome/transformer/CalmTransformerFeatureTest.scala
+++ b/transformer/src/test/scala/uk/ac/wellcome/transformer/CalmTransformerFeatureTest.scala
@@ -72,7 +72,7 @@ class  CalmTransformerFeatureTest
       .toJson(
         Work(
           identifiers = List(SourceIdentifier("source", "key", "value")),
-          label = "Cats that can carry themselves calmly"
+          title = "Cats that can carry themselves calmly"
         ))
       .get
   }

--- a/transformer/src/test/scala/uk/ac/wellcome/transformer/CalmTransformerFeatureTest.scala
+++ b/transformer/src/test/scala/uk/ac/wellcome/transformer/CalmTransformerFeatureTest.scala
@@ -72,7 +72,7 @@ class  CalmTransformerFeatureTest
       .toJson(
         Work(
           identifiers = List(SourceIdentifier("source", "key", "value")),
-          title = "Cats that can carry themselves calmly"
+          title = "placeholder title for a Calm record"
         ))
       .get
   }

--- a/transformer/src/test/scala/uk/ac/wellcome/transformer/MiroTransformerFeatureTest.scala
+++ b/transformer/src/test/scala/uk/ac/wellcome/transformer/MiroTransformerFeatureTest.scala
@@ -43,7 +43,7 @@ class MiroTransformerFeatureTest
 
       assertSNSMessageContains(snsMessages.head,
                                secondMiroID,
-                               secondLabel)
+                               secondTitle)
     }
   }
 

--- a/transformer/src/test/scala/uk/ac/wellcome/transformer/MiroTransformerFeatureTest.scala
+++ b/transformer/src/test/scala/uk/ac/wellcome/transformer/MiroTransformerFeatureTest.scala
@@ -29,13 +29,13 @@ class MiroTransformerFeatureTest
       """) {
 
     val miroID = "M0000001"
-    val label = "A guide for a giraffe"
+    val title = "A guide for a giraffe"
 
     val secondMiroID = "M0000002"
-    val secondLabel = "A song about a snake"
+    val secondTitle = "A song about a snake"
 
-    sendMiroImageToSQS(miroID, shouldNotTransformMessage(label))
-    sendMiroImageToSQS(secondMiroID, shouldTransformMessage(secondLabel))
+    sendMiroImageToSQS(miroID, shouldNotTransformMessage(title))
+    sendMiroImageToSQS(secondMiroID, shouldTransformMessage(secondTitle))
 
     eventually {
       val snsMessages = listMessagesReceivedFromSNS()
@@ -52,7 +52,7 @@ class MiroTransformerFeatureTest
                                        imageTitle: String) = {
     val parsedWork = JsonUtil.fromJson[Work](snsMessage.message).get
     parsedWork.identifiers.head.value shouldBe miroID
-    parsedWork.label shouldBe imageTitle
+    parsedWork.title shouldBe imageTitle
   }
 
 

--- a/transformer/src/test/scala/uk/ac/wellcome/transformer/receive/SQSMessageReceiverTest.scala
+++ b/transformer/src/test/scala/uk/ac/wellcome/transformer/receive/SQSMessageReceiverTest.scala
@@ -48,7 +48,7 @@ class SQSMessageReceiverTest
 
   val work = Work(identifiers =
                     List(SourceIdentifier("source", "key", "value")),
-                  label = "calm data label")
+                  title = "A calming camel")
 
   val metricsSender: MetricsSender = new MetricsSender(
     namespace = "record-receiver-tests",

--- a/transformer/src/test/scala/uk/ac/wellcome/transformer/receive/SQSMessageReceiverTest.scala
+++ b/transformer/src/test/scala/uk/ac/wellcome/transformer/receive/SQSMessageReceiverTest.scala
@@ -48,7 +48,7 @@ class SQSMessageReceiverTest
 
   val work = Work(identifiers =
                     List(SourceIdentifier("source", "key", "value")),
-                  title = "A calming camel")
+                  title = "placeholder title for a Calm record")
 
   val metricsSender: MetricsSender = new MetricsSender(
     namespace = "record-receiver-tests",


### PR DESCRIPTION
### What is this PR trying to achieve?

Everything now uses "title" in place of "label".

### Who is this change for?

The platform team, who want to rename this field.

### Have the following been considered/are they needed?

Here’s how I think we deploy this:

- [ ] Review and merge into master
- [ ] Deploy everything _except_ the API
- [ ] Point the ingestor at a different index (using #712)
- [ ] Trigger a complete reindex to populate the new index
- [ ] Change the API to point to the new field (coordinating with the Experience team)