### PR TITLE
Academic titles if there's a single hyphen in the description

### DIFF
--- a/common/src/main/scala/uk/ac/wellcome/models/MiroTransformable.scala
+++ b/common/src/main/scala/uk/ac/wellcome/models/MiroTransformable.scala
@@ -3,7 +3,7 @@ package uk.ac.wellcome.models
 import scala.util.Try
 
 import com.fasterxml.jackson.annotation.JsonProperty
-import org.apache.commons.lang.StringEscapeUtils;
+import org.apache.commons.lang.StringEscapeUtils
 
 import uk.ac.wellcome.utils.JsonUtil
 
@@ -108,19 +108,14 @@ case class MiroTransformable(MiroID: String,
       val description = if (useDescriptionAsLabel) {
         // Remove the first line from the description, and trim any extra
         // whitespace (leading newlines)
-        Some(
-          candidateDescription
-            .replace(candidateLabel, "")
-            .trim)
+        candidateDescription
+          .replace(candidateLabel, "")
       } else {
         candidateDescription
       }
 
       // If the description is an empty string, use a proper None type instead
-      val trimmedDescription = description match {
-        case Some(d) => if (d.trim.length > 0) Some(d.trim) else None
-        case None => None
-      }
+      val trimmedDescription = if (description.trim.length > 0) Some(description.trim) else None
 
       // <image_creator>: the Creator, which maps to our property "hasCreator"
       val creators: List[Agent] = miroData.creator match {

--- a/common/src/main/scala/uk/ac/wellcome/models/MiroTransformable.scala
+++ b/common/src/main/scala/uk/ac/wellcome/models/MiroTransformable.scala
@@ -99,7 +99,7 @@ case class MiroTransformable(MiroID: String,
         .startsWith(miroData.title.get)
 
       val useDescriptionAsLabel = (titleIsTruncatedDescription &&
-        MiroCollection == "Images-V") || (miroData.title.get == "-")
+        MiroCollection == "Images-V") || (miroData.title.get == "-" || miroData.title.get == "--")
 
       val label =
         if (useDescriptionAsLabel) candidateLabel
@@ -113,7 +113,7 @@ case class MiroTransformable(MiroID: String,
             .replace(candidateLabel, "")
             .trim)
       } else {
-        miroData.description
+        candidateDescription
       }
 
       // If the description is an empty string, use a proper None type instead

--- a/common/src/main/scala/uk/ac/wellcome/models/MiroTransformable.scala
+++ b/common/src/main/scala/uk/ac/wellcome/models/MiroTransformable.scala
@@ -71,7 +71,8 @@ case class MiroTransformable(MiroID: String,
       // here if there's nothing more useful in the other fields.
       val candidateDescription = miroData.description match {
         case Some(s) => {
-          if (s == "--" || s == "-") miroData.academicDescription.getOrElse("") else s
+          if (s == "--" || s == "-") miroData.academicDescription.getOrElse("")
+          else s
         }
         case None => ""
       }

--- a/common/src/main/scala/uk/ac/wellcome/models/MiroTransformable.scala
+++ b/common/src/main/scala/uk/ac/wellcome/models/MiroTransformable.scala
@@ -71,7 +71,7 @@ case class MiroTransformable(MiroID: String,
       // here if there's nothing more useful in the other fields.
       val candidateDescription = miroData.description match {
         case Some(s) => {
-          if (s == "--") miroData.academicDescription.getOrElse("") else s
+          if (s == "--" || s == "-") miroData.academicDescription.getOrElse("") else s
         }
         case None => ""
       }

--- a/common/src/test/scala/uk/ac/wellcome/models/MiroTransformableTest.scala
+++ b/common/src/test/scala/uk/ac/wellcome/models/MiroTransformableTest.scala
@@ -118,6 +118,21 @@ class MiroTransformableLabelTest extends FunSpec with Matchers {
 
   it("""
     should use the image_image_desc_academic if the image_image_desc field
+    doesn't contain useful data (double hyphen in title and description)
+  """) {
+    val academicDescription = "Dirty doubling of dastardly data"
+    transformRecordAndCheckLabel(
+      data = s"""
+        "image_title": "--",
+        "image_image_desc": "--",
+        "image_image_desc_academic": "$academicDescription"
+      """,
+      expectedLabel = academicDescription
+    )
+  }
+
+  it("""
+    should use the image_image_desc_academic if the image_image_desc field
     doesn't contain useful data (multi-line description)
   """) {
     val academicLabel = "A lithograph of a lecturer"

--- a/common/src/test/scala/uk/ac/wellcome/models/MiroTransformableTest.scala
+++ b/common/src/test/scala/uk/ac/wellcome/models/MiroTransformableTest.scala
@@ -103,6 +103,21 @@ class MiroTransformableLabelTest extends FunSpec with Matchers {
 
   it("""
     should use the image_image_desc_academic if the image_image_desc field
+    doesn't contain useful data (single hyphen in the description)
+  """) {
+    val academicDescription = "Using an upside-down umbrella"
+    transformRecordAndCheckLabel(
+      data = s"""
+        "image_title": "-",
+        "image_image_desc": "-",
+        "image_image_desc_academic": "$academicDescription"
+      """,
+      expectedLabel = academicDescription
+    )
+  }
+
+  it("""
+    should use the image_image_desc_academic if the image_image_desc field
     doesn't contain useful data (multi-line description)
   """) {
     val academicLabel = "A lithograph of a lecturer"


### PR DESCRIPTION
### What is this PR trying to achieve?

Another go at #699, because _obviously_ some of the data used a single dash instead.

### Who is this change for?

Picky users who tell us that "-" isn't a helpful description.

### Have the following been considered/are they needed?

- [ ] Deployed new versions
