### PR TITLE
Allow arbitrary resizing of images in Loris

### DIFF
--- a/terraform/services/config/templates/loris.ini.template
+++ b/terraform/services/config/templates/loris.ini.template
@@ -28,6 +28,11 @@ enable_caching = True
 redirect_canonical_image_request = False
 redirect_id_slash_to_info = True
 
+# Allow arbitrary resizing of images.  This means that when next.wc.org request
+# different sizes of image, if they inadvertently request an image that's too
+# large, Loris doesn't 404.
+max_size_above_full = 0
+
 [logging]
 log_to = 'file'    # 'console'|'file'
 log_level = 'INFO'  # 'DEBUG'|'INFO'|'WARNING'|'ERROR'|'CRITICAL'


### PR DESCRIPTION
See https://github.com/loris-imageserver/loris/blob/development/doc/configuration.md#lorisloris

Resolves #698.

### What is this PR trying to achieve?

Allow us to request big images. Really big images. Images that are arbitrarily big, even.

### Who is this change for?

The experience team, who don’t want broken images if they request one that’s too big.

### Have the following been considered/are they needed?

- [ ] Deployed new versions
- [ ] Run `terraform apply`.