### PR TITLE
Adds AWS_REGION to gatling script task env vars

### DIFF
--- a/terraform/scripts.tf
+++ b/terraform/scripts.tf
@@ -26,5 +26,6 @@ module "gatling" {
 
   env_vars = [
     "{\"name\": \"SIMULATION\", \"value\": \"testing.load.LorisSimulation\"}",
+    "{\"name\": \"AWS_REGION\", \"value\": \"${var.aws_region}}\"}",
   ]
 }


### PR DESCRIPTION
### What is this PR trying to achieve?
Push load test stats to CloudWatch successfully.

### Who is this change for?
💻 

### Have the following been considered/are they needed?
- [ ] Run `terraform apply`.
