### PR TITLE
Assorted Gatling improvements

### DIFF
--- a/docker/gatling/run.sh
+++ b/docker/gatling/run.sh
@@ -28,7 +28,7 @@ aws s3 cp \
 /opt/gatling/notify.sh load_test_results "$LAST_RESULT/js/assertions.json"
 
 # On failure push results to load_test_failure_alarm topic so we can alarm
-if [ $GATLING_STATUS -ne 0 ]; then
+if (( GATLING_STATUS != 0 )); then
     echo "Load test failed, pushing to SNS."
 
     /opt/gatling/notify.sh load_test_failure_alarm "$LAST_RESULT/js/assertions.json"

--- a/docker/gatling/run.sh
+++ b/docker/gatling/run.sh
@@ -2,8 +2,18 @@
 
 set -o nounset
 
+# Parse test parameters, and then re-export them so the same variables
+# are available in the Scala test.
+export USE_CLOUDFRONT=${USE_CLOUDFRONT:-false}
+export IMAGES_PER_ARTICLE=${IMAGES_PER_ARTICLE:-15}
+export IMAGES_PER_SEARCH=${IMAGES_PER_SEARCH:-20}
+export USERS_TO_SIMULATE=${USERS_TO_SIMULATE:-5}
 
-$GATLING_HOME/bin/gatling.sh -s $SIMULATION
+SUMMARY=${SUMMARY:-Gatling run}
+
+export DESCRIPTION="$SUMMARY (CF=$USE_CLOUDFRONT, article=$IMAGES_PER_ARTICLE, search=$IMAGES_PER_SEARCH, users=$USERS_TO_SIMULATE)"
+
+$GATLING_HOME/bin/gatling.sh --simulation $SIMULATION --run-description="$DESCRIPTION"
 GATLING_STATUS=$?
 
 LAST_RESULT="$(find /opt/gatling/results -maxdepth 1 -type d | sort | tail -n 1)"

--- a/docker/gatling/user-files/simulations/LorisSimulation.scala
+++ b/docker/gatling/user-files/simulations/LorisSimulation.scala
@@ -6,12 +6,15 @@ import scala.concurrent.duration._
 
 class LorisSimulation extends Simulation {
 
-  val imagesPerArticle = 15
-  val imagesPerSearch = 20
-  val usersToSimulate = 20
+  val useCloudFront = (sys.env("USE_CLOUDFRONT") == "true")
+  val imagesPerArticle = sys.env("IMAGES_PER_ARTICLE").toInt
+  val imagesPerSearch = sys.env("IMAGES_PER_SEARCH").toInt
+  val usersToSimulate = sys.env("USERS_TO_SIMULATE").toInt
+
+  val hostname = if (useCloudFront) "iiif" else "iiif-origin"
 
   val httpConf = http
-    .baseURL("https://iiif-origin.wellcomecollection.org")
+    .baseURL(s"https://$hostname.wellcomecollection.org")
 
   // We expect a small subset of images to be requested repeatedly -- for
   // example, images that are embedded in an Explore article.  These images

--- a/docker/gatling/user-files/simulations/LorisSimulation.scala
+++ b/docker/gatling/user-files/simulations/LorisSimulation.scala
@@ -60,11 +60,12 @@ class LorisSimulation extends Simulation {
   val sizeFeeder = csv("size.csv").random
 
   // And a handful of requests that involve more image processing
+  // TODO Allow different rotation parameters
   val complexScn = scenario("complex")
     .feed(identFeeder)
     .feed(regionFeeder)
     .feed(sizeFeeder)
-    .exec(http("search-thumbnail")
+    .exec(http("complex-scenario")
       .get("/image/${ident}/${region}/${size}/0/default.jpg")
       .check(status.in(200, 304))
     )


### PR DESCRIPTION
### What is this PR trying to achieve?

Tweaks and improvements to the Gatling scripts. In particular:

* Record parameters and include them in the test report
* Make parameters env variables, so they can be set at runtime, e.g. through the RunTask API
* Make using CloudFront a configurable parameter
* Make sure we break out complex requests as a separate scenario

### Who is this change for?

Developers who want easier Gatling runs.

### Have the following been considered/are they needed?

- [ ] Deployed new versions