### PR TITLE
Drop the dependency on docker.py for builds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -42,7 +42,7 @@ loris-deploy: loris-build
 
 
 install-docker-build-deps:
-	pip3 install --upgrade boto3 docker docopt
+	pip3 install --upgrade boto3 docopt
 
 nginx-build-api: install-docker-build-deps
 	./scripts/build_docker_image.py --project=nginx --variant=api

--- a/scripts/build_docker_image.py
+++ b/scripts/build_docker_image.py
@@ -17,9 +17,9 @@ Options:
 """
 
 import os
+import subprocess
 
 import docopt
-import docker
 
 from tooling import write_release_id, CURRENT_COMMIT, ROOT
 
@@ -44,12 +44,17 @@ if __name__ == '__main__':
     print('*** Image will be tagged %s' % tag)
 
     print('*** Building the new image')
-    client = docker.from_env()
-    client.images.build(
-        path=os.path.join(ROOT, 'docker', project),
-        buildargs={'variant': variant},
-        tag=tag
-    )
+
+    cmd = [
+        'docker', 'build',
+        '--file', os.path.join(ROOT, 'docker', project, 'Dockerfile'),
+        '--tag', tag,
+    ]
+    if variant is not None:
+        cmd.extend(['--build-arg', 'variant=%s' % variant])
+    cmd.append(os.path.join(ROOT, 'docker', project))
+
+    subprocess.check_call(cmd)
 
     print('*** Saving the release ID to .releases')
     write_release_id(project=release_name, release_id=release_id)

--- a/scripts/build_sbt_image.py
+++ b/scripts/build_sbt_image.py
@@ -15,12 +15,11 @@ Options:
 
 """
 
-import subprocess
-
-import docker
-import docopt
 import os
 import shutil
+import subprocess
+
+import docopt
 
 from tooling import (
     write_release_id,
@@ -62,8 +61,13 @@ if __name__ == '__main__':
 
     print('*** Building the new Docker image')
     print('*** Dockerfile is at %s' % docker_root)
-    client = docker.from_env()
-    client.images.build(path=docker_root, buildargs={'project': project}, tag=tag)
+    subprocess.check_call([
+        'docker', 'build',
+        '--file', os.path.join(docker_root, 'Dockerfile'),
+        '--tag', tag,
+        '--build-arg', 'project=%s' % project,
+        docker_root
+    ])
 
     print('*** Saving the release ID to .releases')
     write_release_id(project=project, release_id=release_id)

--- a/scripts/tooling.py
+++ b/scripts/tooling.py
@@ -1,7 +1,7 @@
 # -*- encoding: utf-8 -*-
 
-import base64
 import os
+import shlex
 import subprocess
 
 
@@ -47,20 +47,14 @@ def ecr_repo_uri_from_name(ecr_client, name):
         raise RuntimeError('Unable to look up repo URI for %r: %s' % (name, e))
 
 
-def authenticate_for_ecr_pushes(ecr_client, docker_client, repo_uri):
+def ecr_login():
     """
-    Get a login token from ECR, and authenticate ourselves to do 'docker push'.
+    Authenticates for pushing to ECR.
     """
-    resp = ecr_client.get_authorization_token()
-    token = resp['authorizationData'][0]['authorizationToken']
-    username, password = base64.b64decode(token).decode().split(':')
-
-    resp = docker_client.login(
-        username=username,
-        password=password,
-        registry=repo_uri
-    )
-    print(resp)
+    command = subprocess.check_output([
+        'aws', 'ecr', 'get-login', '--no-include-email'
+    ]).decode('ascii')
+    subprocess.check_call(shlex.split(command))
 
 
 def write_release_id(project, release_id):


### PR DESCRIPTION
Benefits:

*   Slightly faster (less dependencies to install)
*   Output is dumped to stdout/stderr, not hidden by docker.py (easier debugging)
*   API calls are easier to write, because it's just shelling out
*   Fixed $(aws ecr get-login), which was mostly broken in Python

### What is this PR trying to achieve?

Improve the state of our builds.

### Who is this change for?

Right now, me – I was having issues updating the Loris image, and not having output from `docker build` was slowing me down.