### PR TITLE
Put all the Loris caches in EFS

### DIFF
--- a/docker/loris/Dockerfile
+++ b/docker/loris/Dockerfile
@@ -7,18 +7,8 @@ RUN apt-get install -y python python-pip python-setuptools python-dev \
 
 RUN pip install awscli
 
-RUN apt-get install -y libjpeg-turbo8-dev libfreetype6-dev zlib1g-dev \
-    liblcms2-dev liblcms2-utils libtiff5-dev libwebp-dev apache2 \
-    libapache2-mod-wsgi
-
-RUN apt-get install -y unzip wget
-RUN wget https://github.com/loris-imageserver/loris/archive/v2.1.0-final.zip
-RUN unzip v2.1.0-final.zip
-
-RUN useradd -d /var/www/loris -s /sbin/false loris
-
-RUN cd loris-2.1.0-final && pip install -r requirements.txt
-RUN cd loris-2.1.0-final && python setup.py install
+COPY install_loris.sh /install_loris.sh
+RUN /install_loris.sh
 
 RUN apt-get install -y uwsgi
 

--- a/docker/loris/install_loris.sh
+++ b/docker/loris/install_loris.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+# Install Loris on Ubuntu
+
+set -o errexit
+set -o nounset
+
+# Install dependencies.  We don't include Apache because we're running
+# Loris with UWSGI and nginx, not Apache.
+apt-get install -y libjpeg-turbo8-dev libfreetype6-dev zlib1g-dev \
+    liblcms2-dev liblcms2-utils libtiff5-dev libwebp-dev
+
+# Download and install the Loris code itself
+apt-get install -y unzip wget
+wget https://github.com/loris-imageserver/loris/archive/v2.1.0-final.zip
+unzip v2.1.0-final.zip
+rm v2.1.0-final.zip
+apt-get uninstall -y unzip wget
+
+# Required or setup.py complains
+useradd -d /var/www/loris -s /sbin/false loris
+
+cd loris-2.1.0-final
+pip install -r requirements.txt
+python setup.py install --image-cache=/mnt/efs/image_cache --info-cache=/mnt/efs/info_cache

--- a/docker/loris/install_loris.sh
+++ b/docker/loris/install_loris.sh
@@ -14,7 +14,7 @@ apt-get install -y unzip wget
 wget https://github.com/loris-imageserver/loris/archive/v2.1.0-final.zip
 unzip v2.1.0-final.zip
 rm v2.1.0-final.zip
-apt-get uninstall -y unzip wget
+apt-get remove -y unzip wget
 
 # Required or setup.py complains
 useradd -d /var/www/loris -s /sbin/false loris

--- a/terraform/services.tf
+++ b/terraform/services.tf
@@ -221,7 +221,7 @@ module "loris" {
 
   volume_name      = "loris"
   volume_host_path = "${module.api_userdata.efs_mount_directory}/loris"
-  container_path   = "/usr/local/share/images/loris"
+  container_path   = "/mnt/loris"
 
   loadbalancer_cloudwatch_id   = "${module.api_alb.cloudwatch_id}"
   server_error_alarm_topic_arn = "${module.alb_server_error_alarm.arn}"

--- a/terraform/services/config/templates/loris.ini.template
+++ b/terraform/services/config/templates/loris.ini.template
@@ -39,7 +39,7 @@ log_level = 'INFO'  # 'DEBUG'|'INFO'|'WARNING'|'ERROR'|'CRITICAL'
 
 [resolver]
 impl = 'loris.resolver.TemplateHTTPResolver'
-cache_root = '/usr/local/share/images/loris'
+cache_root = '/mnt/loris/resolver_cache'
 templates = 'wordpress,s3,prismic'
 
     [[wordpress]]
@@ -52,10 +52,10 @@ templates = 'wordpress,s3,prismic'
     url = 'https://prismic-io.s3.amazonaws.com/wellcomecollection/%s'
 
 [img.ImageCache]
-cache_dp = '/var/cache/loris' # rwx
+cache_dp = '/mnt/loris/image_cache' # rwx
 
 [img_info.InfoCache]
-cache_dp = '/var/cache/loris' # rwx
+cache_dp = '/mnt/loris/info_cache' # rwx
 
 [transforms]
 dither_bitonal_images = False

--- a/terraform/services/config/templates/loris.ini.template
+++ b/terraform/services/config/templates/loris.ini.template
@@ -36,10 +36,6 @@ max_size_above_full = 0
 [logging]
 log_to = 'file'    # 'console'|'file'
 log_level = 'INFO'  # 'DEBUG'|'INFO'|'WARNING'|'ERROR'|'CRITICAL'
-log_dir = '/var/log/loris2' # rw-
-max_size = 5242880 # 5 MB
-max_backups = 5
-format = '%(asctime)s (%(name)s) [%(levelname)s]: %(message)s'
 
 [resolver]
 impl = 'loris.resolver.TemplateHTTPResolver'


### PR DESCRIPTION
### What is this PR trying to achieve?

Put all the Loris caches in EFS, which means they’ll never fill up the host disk, even under intense load tests. Resolves #732.

### Who is this change for?

A Platform team who don’t like full disks.

### Have the following been considered/are they needed?

- [ ] Deployed new versions
- [ ] Run `terraform apply`.