### PR TITLE
Install Loris from development version, not last release

### DIFF
--- a/docker/loris/install_loris.sh
+++ b/docker/loris/install_loris.sh
@@ -11,7 +11,7 @@ apt-get install -y libjpeg-turbo8-dev libfreetype6-dev zlib1g-dev \
 
 # Download and install the Loris code itself
 apt-get install -y unzip wget
-wget https://github.com/loris-imageserver/loris/archive/v2.1.0-final.zip
+wget https://github.com/loris-imageserver/loris/archive/development.zip
 unzip v2.1.0-final.zip
 rm v2.1.0-final.zip
 apt-get remove -y unzip wget


### PR DESCRIPTION
### What is this PR trying to achieve?

There are some bug fixes and small perf improvements in Loris trunk that aren’t in the 2.1.0 release (plus some fixes from our friends at ELife). I wonder if it’s worth running with that instead.

https://github.com/loris-imageserver/loris/compare/v2.1.0-final...development

@kenoir – let’s have a chat about this before we merge.

### Who is this change for?

A platform team who want possibly faster builds.

### Have the following been considered/are they needed?

- [ ] Deployed new versions