### PR TITLE
Adds simple load test for the catalogue API

### DIFF
--- a/docker/gatling/user-files/simulations/CatalogueApiSimulation.scala
+++ b/docker/gatling/user-files/simulations/CatalogueApiSimulation.scala
@@ -1,0 +1,39 @@
+package testing.load
+
+import io.gatling.core.Predef._
+import io.gatling.http.Predef._
+import scala.concurrent.duration._
+
+class CatalogueApiSimulation extends Simulation {
+
+  val defaultUsersPerSec = 100
+  val defaultDuration = 120
+
+  val usersPerSec = sys.env.get("USERS_PER_SEC").map(_.toInt)
+    .getOrElse(defaultUsersPerSec)
+
+  val duration = sys.env.get("DEFAULT_DURATION").map(_.toInt)
+    .getOrElse(defaultDuration)
+
+  val httpConf = http
+    .baseURL("https://api.wellcomecollection.org/catalogue/v0")
+    .inferHtmlResources()
+
+  val searchFeeder = csv("terms.csv").random
+
+  val searchScn = scenario("simple-search")
+    .feed(searchFeeder)
+    .exec(http("works")
+      .get("/works?query=${term}")
+      .check(status.in(200, 304))
+    )
+
+  setUp(
+    searchScn.inject(constantUsersPerSec(usersPerSec) during(duration seconds) randomized)
+  ).protocols(
+    httpConf
+  ).assertions(
+    global.responseTime.max.lt(500),
+    global.successfulRequests.percent.gt(99)
+  )
+}

--- a/terraform/scripts.tf
+++ b/terraform/scripts.tf
@@ -33,6 +33,24 @@ module "gatling_loris" {
   ]
 }
 
+module "gatling_catalogue_api" {
+  source        = "./ecs_script_task"
+  task_name     = "gatling_loris"
+  app_uri       = "${module.ecr_repository_gatling.repository_url}:${var.release_ids["gatling"]}"
+  task_role_arn = "${module.ecs_gatling_iam.task_role_arn}"
+
+  cpu    = 1024
+  memory = 1024
+
+  env_vars = [
+    "{\"name\": \"SIMULATION\", \"value\": \"testing.load.CatalogueApiSimulation\"}",
+    "{\"name\": \"AWS_DEFAULT_REGION\", \"value\": \"${var.aws_region}\"}",
+    "{\"name\": \"FAILED_TOPIC_ARN\", \"value\": \"${module.load_test_failure_alarm.arn}\"}",
+    "{\"name\": \"RESULTS_TOPIC_ARN\", \"value\": \"${module.load_test_results.arn}\"}",
+    "{\"name\": \"S3_BUCKET\", \"value\": \"${aws_s3_bucket.dashboard.id}\"}",
+  ]
+}
+
 module "gatling_digital_experience" {
   source        = "./ecs_script_task"
   task_name     = "gatling_digital_experience"


### PR DESCRIPTION
### What is this PR trying to achieve?

As we have the infrastructure set up, add a simple load test for the API to do some preliminary load testing. 

### Who is this change for?

Folk who want a performant API.

### Have the following been considered/are they needed?

- [ ] Run `terraform apply`.
