### PR TITLE
Enable/Disable ALB alarms for API

### DIFF
--- a/terraform/services.tf
+++ b/terraform/services.tf
@@ -178,6 +178,8 @@ module "api_romulus" {
   alb_priority       = "112"
   host_name          = "${var.production_api == "romulus" ? var.api_host : var.api_host_stage}"
 
+  enable_alb_alarm = "${var.production_api == "romulus" ? true : false}"
+
   cpu    = 1792
   memory = 1840
 
@@ -226,6 +228,8 @@ module "api_remus" {
   config_key         = "config/${var.build_env}/api_remus.ini"
   alb_priority       = "111"
   host_name          = "${var.production_api == "remus" ? var.api_host : var.api_host_stage}"
+
+  enable_alb_alarm = "${var.production_api == "remus" ? true : false}"
 
   cpu    = 1792
   memory = 1840

--- a/terraform/services.tf
+++ b/terraform/services.tf
@@ -178,7 +178,7 @@ module "api_romulus" {
   alb_priority       = "112"
   host_name          = "${var.production_api == "romulus" ? var.api_host : var.api_host_stage}"
 
-  enable_alb_alarm = "${var.production_api == "romulus" ? true : false}"
+  enable_alb_alarm = "${var.production_api == "romulus" ? 1 : 0}"
 
   cpu    = 1792
   memory = 1840
@@ -229,7 +229,7 @@ module "api_remus" {
   alb_priority       = "111"
   host_name          = "${var.production_api == "remus" ? var.api_host : var.api_host_stage}"
 
-  enable_alb_alarm = "${var.production_api == "remus" ? true : false}"
+  enable_alb_alarm = "${var.production_api == "remus" ? 1 : 0}"
 
   cpu    = 1792
   memory = 1840

--- a/terraform/services/ecs_service/alarms.tf
+++ b/terraform/services/ecs_service/alarms.tf
@@ -1,4 +1,6 @@
 module "alb_target_500_errors" {
+  count = "${var.enable_alb_alarm}"
+
   source = "./alarms"
   name   = "${var.service_name}-alb-target-500-errors"
 
@@ -10,6 +12,8 @@ module "alb_target_500_errors" {
 }
 
 module "alb_target_400_errors" {
+  count = "${var.enable_alb_alarm}"
+
   source = "./alarms"
   name   = "${var.service_name}-alb-target-400-errors"
 

--- a/terraform/services/ecs_service/alarms.tf
+++ b/terraform/services/ecs_service/alarms.tf
@@ -1,5 +1,5 @@
 module "alb_target_500_errors" {
-  count = "${var.enable_alb_alarm}"
+  enable_alarm = "${var.enable_alb_alarm}"
 
   source = "./alarms"
   name   = "${var.service_name}-alb-target-500-errors"
@@ -12,7 +12,7 @@ module "alb_target_500_errors" {
 }
 
 module "alb_target_400_errors" {
-  count = "${var.enable_alb_alarm}"
+  enable_alarm = "${var.enable_alb_alarm}"
 
   source = "./alarms"
   name   = "${var.service_name}-alb-target-400-errors"

--- a/terraform/services/ecs_service/alarms/main.tf
+++ b/terraform/services/ecs_service/alarms/main.tf
@@ -1,5 +1,5 @@
 resource "aws_cloudwatch_metric_alarm" "alb_alarm" {
-  count = "${var.enable_alb_alarm}"
+  count = "${var.enable_alarm}"
 
   alarm_name          = "${var.name}"
   comparison_operator = "GreaterThanOrEqualToThreshold"

--- a/terraform/services/ecs_service/alarms/main.tf
+++ b/terraform/services/ecs_service/alarms/main.tf
@@ -1,4 +1,6 @@
 resource "aws_cloudwatch_metric_alarm" "alb_alarm" {
+  count = "${var.enable_alb_alarm}"
+
   alarm_name          = "${var.name}"
   comparison_operator = "GreaterThanOrEqualToThreshold"
   evaluation_periods  = "1"

--- a/terraform/services/ecs_service/alarms/main.tf
+++ b/terraform/services/ecs_service/alarms/main.tf
@@ -1,5 +1,5 @@
 resource "aws_cloudwatch_metric_alarm" "alb_alarm" {
-  count = "${var.enable_alarm}"
+  count = "${var.enable_alarm == true ? 1 : 0}"
 
   alarm_name          = "${var.name}"
   comparison_operator = "GreaterThanOrEqualToThreshold"

--- a/terraform/services/ecs_service/alarms/main.tf
+++ b/terraform/services/ecs_service/alarms/main.tf
@@ -1,5 +1,5 @@
 resource "aws_cloudwatch_metric_alarm" "alb_alarm" {
-  count = "${var.enable_alarm == true ? 1 : 0}"
+  count = "${var.enable_alarm}"
 
   alarm_name          = "${var.name}"
   comparison_operator = "GreaterThanOrEqualToThreshold"

--- a/terraform/services/ecs_service/alarms/variables.tf
+++ b/terraform/services/ecs_service/alarms/variables.tf
@@ -14,4 +14,8 @@ variable "topic_arn" {
   description = "SNS Topic to publish alarm state changes"
 }
 
+variable "enable_alb_alarm" {
+  default = true
+}
+
 variable "metric" {}

--- a/terraform/services/ecs_service/alarms/variables.tf
+++ b/terraform/services/ecs_service/alarms/variables.tf
@@ -14,8 +14,6 @@ variable "topic_arn" {
   description = "SNS Topic to publish alarm state changes"
 }
 
-variable "enable_alarm" {
-  default = true
-}
+variable "enable_alarm" {}
 
 variable "metric" {}

--- a/terraform/services/ecs_service/alarms/variables.tf
+++ b/terraform/services/ecs_service/alarms/variables.tf
@@ -14,7 +14,7 @@ variable "topic_arn" {
   description = "SNS Topic to publish alarm state changes"
 }
 
-variable "enable_alb_alarm" {
+variable "enable_alarm" {
   default = true
 }
 

--- a/terraform/services/ecs_service/variables.tf
+++ b/terraform/services/ecs_service/variables.tf
@@ -70,5 +70,9 @@ variable "loadbalancer_cloudwatch_id" {
   description = "LoadBalancer ARN Suffix"
 }
 
+variable "enable_alb_alarm" {
+  default = true
+}
+
 variable "deployment_minimum_healthy_percent" {}
 variable "deployment_maximum_percent" {}

--- a/terraform/services/ecs_service/variables.tf
+++ b/terraform/services/ecs_service/variables.tf
@@ -71,7 +71,7 @@ variable "loadbalancer_cloudwatch_id" {
 }
 
 variable "enable_alb_alarm" {
-  default = true
+  default = 1
 }
 
 variable "deployment_minimum_healthy_percent" {}

--- a/terraform/services/main.tf
+++ b/terraform/services/main.tf
@@ -21,6 +21,8 @@ module "service" {
 
   deployment_minimum_healthy_percent = "${var.deployment_minimum_healthy_percent}"
   deployment_maximum_percent         = "${var.deployment_maximum_percent}"
+
+  enable_alb_alarm = "${var.enable_alb_alarm}"
 }
 
 module "task" {

--- a/terraform/services/variables.tf
+++ b/terraform/services/variables.tf
@@ -148,5 +148,5 @@ variable "deployment_maximum_percent" {
 }
 
 variable "enable_alb_alarm" {
-  default = true
+  default = 1
 }

--- a/terraform/services/variables.tf
+++ b/terraform/services/variables.tf
@@ -146,3 +146,7 @@ variable "deployment_minimum_healthy_percent" {
 variable "deployment_maximum_percent" {
   default = "200"
 }
+
+variable "enable_alb_alarm" {
+  default = true
+}


### PR DESCRIPTION
 ... depending on whether its assigned as prod

### What is this PR trying to achieve?

We don't want to have to consider the noise from the non-prod API alarms.

### Who is this change for?

Developers who want to be able to ascertain quickly when there are problems with the public facing API.

### Have the following been considered/are they needed?

- [ ] Run `terraform apply`.
