### PR TITLE
Expose genres from Miro in the Catalogue API

### DIFF
--- a/api/src/main/scala/uk/ac/wellcome/platform/api/models/DisplayWork.scala
+++ b/api/src/main/scala/uk/ac/wellcome/platform/api/models/DisplayWork.scala
@@ -12,7 +12,8 @@ case class DisplayWork(id: String,
                        lettering: Option[String] = None,
                        createdDate: Option[Period] = None,
                        creators: List[Agent] = List(),
-                       identifiers: Option[List[DisplayIdentifier]] = None) {
+                       identifiers: Option[List[DisplayIdentifier]] = None,
+                       genres: List[Concept] = List()) {
   @JsonProperty("type") val ontologyType: String = "Work"
 }
 
@@ -41,6 +42,7 @@ case object DisplayWork {
       createdDate = identifiedWork.work.createdDate,
       // Wrapping this in Option to catch null value from Jackson
       creators = Option(identifiedWork.work.creators).getOrElse(Nil),
+      genres = Option(identifiedWork.work.genres).getOrElse(Nil),
       identifiers =
         if (includes.identifiers)
           Some(identifiedWork.work.identifiers.map(DisplayIdentifier(_)))

--- a/api/src/test/scala/uk/ac/wellcome/platform/api/ApiWorksTest.scala
+++ b/api/src/test/scala/uk/ac/wellcome/platform/api/ApiWorksTest.scala
@@ -67,7 +67,8 @@ class ApiWorksTest
             |     "creators": [{
             |       "type": "Agent",
             |       "label": "${works(0).work.creators(0).label}"
-            |     }]
+            |     }],
+            |     "genres": [ ]
             |   },
             |   {
             |     "type": "Work",
@@ -82,7 +83,8 @@ class ApiWorksTest
             |     "creators": [{
             |       "type": "Agent",
             |       "label": "${works(1).work.creators(0).label}"
-            |     }]
+            |     }],
+            |     "genres": [ ]
             |   },
             |   {
             |     "type": "Work",
@@ -97,7 +99,8 @@ class ApiWorksTest
             |     "creators": [{
             |       "type": "Agent",
             |       "label": "${works(2).work.creators(0).label}"
-            |     }]
+            |     }],
+            |     "genres": [ ]
             |   }
             |  ]
             |}
@@ -137,7 +140,8 @@ class ApiWorksTest
             | "creators": [{
             |   "type": "Agent",
             |   "label": "${agent.label}"
-            | }]
+            | }],
+            | "genres": [ ]
             |}
           """.stripMargin
       )
@@ -177,7 +181,8 @@ class ApiWorksTest
                           |     "creators": [{
                           |       "type": "Agent",
                           |       "label": "${works(1).work.creators(0).label}"
-                          |     }]
+                          |     }],
+                          |     "genres": [ ]
                           |   }]
                           |   }
                           |  ]
@@ -210,7 +215,8 @@ class ApiWorksTest
                           |     "creators": [{
                           |       "type": "Agent",
                           |       "label": "${works(0).work.creators(0).label}"
-                          |     }]
+                          |     }],
+                          |     "genres": [ ]
                           |   }]
                           |   }
                           |  ]
@@ -243,7 +249,8 @@ class ApiWorksTest
                           |     "creators": [{
                           |       "type": "Agent",
                           |       "label": "${works(2).work.creators(0).label}"
-                          |     }]
+                          |     }],
+                          |     "genres": [ ]
                           |   }]
                           |   }
                           |  ]
@@ -397,7 +404,53 @@ class ApiWorksTest
              |     "type": "Work",
              |     "id": "${work1.canonicalId}",
              |     "title": "${work1.work.title}",
-             |     "creators": []
+             |     "creators": [],
+             |     "genres": [ ]
+             |   }
+             |  ]
+             |}""".stripMargin
+      )
+    }
+  }
+
+  it("should include genre information in API responses") {
+    val workWithGenres = IdentifiedWork(
+      canonicalId = "test_genre1",
+      Work(
+        identifiers = List(),
+        title = "A guppy in a greenhouse",
+        genres = List(Concept("fish"), Concept("gardening"))
+      )
+    )
+    insertIntoElasticSearch(workWithGenres)
+
+    eventually {
+      server.httpGet(
+        path = s"/$apiPrefix/works",
+        andExpect = Status.Ok,
+        withJsonBody = s"""
+             |{
+             |  "@context": "https://localhost:8888/$apiPrefix/context.json",
+             |  "type": "ResultList",
+             |  "pageSize": 10,
+             |  "totalPages": 1,
+             |  "totalResults": 1,
+             |  "results": [
+             |   {
+             |     "type": "Work",
+             |     "id": "g1234",
+             |     "title": "A guppy in a greenhouse",
+             |     "creators": [],
+             |     "genres": [
+             |      {
+             |        "type": "Concept",
+             |        "label": "fish",
+             |      },
+             |      {
+             |        "type": "Concept",
+             |        "label": "gardening",
+             |      }
+             |     ]
              |   }
              |  ]
              |}""".stripMargin
@@ -457,7 +510,8 @@ class ApiWorksTest
                           |         "name": "${identifier1.sourceId}",
                           |         "value": "${identifier1.value}"
                           |       }
-                          |     ]
+                          |     ],
+                          |     "genres": [ ]
                           |   },
                           |   {
                           |     "type": "Work",
@@ -471,7 +525,8 @@ class ApiWorksTest
                           |         "name": "${identifier2.sourceId}",
                           |         "value": "${identifier2.value}"
                           |       }
-                          |     ]
+                          |     ],
+                          |     "genres": [ ]
                           |   }
                           |  ]
                           |}
@@ -543,7 +598,8 @@ class ApiWorksTest
                           | "type": "Work",
                           | "id": "${work.canonicalId}",
                           | "title": "${work.work.title}",
-                          | "creators": [ ]
+                          | "creators": [ ],
+                          | "genres": [ ]
                           |}
           """.stripMargin
       )
@@ -559,7 +615,8 @@ class ApiWorksTest
                           | "type": "Work",
                           | "id": "${work_alt.canonicalId}",
                           | "title": "${work_alt.work.title}",
-                          | "creators": [ ]
+                          | "creators": [ ],
+                          | "genres": [ ]
                           |}
           """.stripMargin
       )
@@ -596,7 +653,8 @@ class ApiWorksTest
                           |     "type": "Work",
                           |     "id": "${work.canonicalId}",
                           |     "title": "${work.work.title}",
-                          |     "creators": [ ]
+                          |     "creators": [ ],
+                          |     "genres": [ ]
                           |   }
                           |  ]
                           |}
@@ -620,7 +678,8 @@ class ApiWorksTest
                           |     "type": "Work",
                           |     "id": "${work_alt.canonicalId}",
                           |     "title": "${work_alt.work.title}",
-                          |     "creators": [ ]
+                          |     "creators": [ ],
+                          |     "genres": [ ]
                           |   }
                           |  ]
                           |}

--- a/api/src/test/scala/uk/ac/wellcome/platform/api/ApiWorksTest.scala
+++ b/api/src/test/scala/uk/ac/wellcome/platform/api/ApiWorksTest.scala
@@ -438,17 +438,17 @@ class ApiWorksTest
              |  "results": [
              |   {
              |     "type": "Work",
-             |     "id": "g1234",
-             |     "title": "A guppy in a greenhouse",
+             |     "id": "${workWithGenres.canonicalId}",
+             |     "title": "${workWithGenres.work.title}",
              |     "creators": [],
              |     "genres": [
              |      {
              |        "type": "Concept",
-             |        "label": "fish",
+             |        "label": "fish"
              |      },
              |      {
              |        "type": "Concept",
-             |        "label": "gardening",
+             |        "label": "gardening"
              |      }
              |     ]
              |   }
@@ -539,12 +539,12 @@ class ApiWorksTest
     "should include a list of identifiers on a single work endpoint if we pass ?includes=identifiers") {
     val identifier = SourceIdentifier(
       source = "TestSource",
-      sourceId = "The ID field within the TestSource",
+      sourceId = "An Insectoid Identifier",
       value = "Test1234"
     )
     val work = identifiedWorkWith(
       canonicalId = "1234",
-      title = "An image of an iguana",
+      title = "An insect huddled in an igloo",
       identifiers = List(identifier)
     )
     insertIntoElasticSearch(work)
@@ -567,7 +567,8 @@ class ApiWorksTest
                           |     "name": "${identifier.sourceId}",
                           |     "value": "${identifier.value}"
                           |   }
-                          | ]
+                          | ],
+                          | "genres": [ ]
                           |}
           """.stripMargin
       )
@@ -627,7 +628,7 @@ class ApiWorksTest
     "should be able to search different Elasticsearch indices based on the ?index query parameter") {
     val work = identifiedWorkWith(
       canonicalId = "1234",
-      title = "A whale on a wave"
+      title = "A wombat wallowing under a willow"
     )
     insertIntoElasticSearch(work)
 
@@ -639,7 +640,7 @@ class ApiWorksTest
 
     eventually {
       server.httpGet(
-        path = s"/$apiPrefix/works?query=whale",
+        path = s"/$apiPrefix/works?query=wombat",
         andExpect = Status.Ok,
         withJsonBody = s"""
                           |{

--- a/common/src/main/scala/uk/ac/wellcome/elasticsearch/mappings/WorksIndex.scala
+++ b/common/src/main/scala/uk/ac/wellcome/elasticsearch/mappings/WorksIndex.scala
@@ -41,6 +41,10 @@ class WorksIndex @Inject()(client: HttpClient,
         objectField("creators").fields(
           textField("label"),
           keywordField("type")
+        ),
+        objectField("genres").fields(
+          textField("label"),
+          keywordField("type")
         )
       )
     )

--- a/common/src/main/scala/uk/ac/wellcome/models/Concept.scala
+++ b/common/src/main/scala/uk/ac/wellcome/models/Concept.scala
@@ -1,0 +1,9 @@
+package uk.ac.wellcome.models
+
+import com.fasterxml.jackson.annotation.JsonProperty
+
+case class Concept(
+  label: String
+) {
+  @JsonProperty("type") val ldType: String = "Concept"
+}

--- a/common/src/main/scala/uk/ac/wellcome/models/MiroTransformable.scala
+++ b/common/src/main/scala/uk/ac/wellcome/models/MiroTransformable.scala
@@ -149,7 +149,7 @@ case class MiroTransformable(MiroID: String,
 
       val keywordsUnauth: List[Concept] = miroData.keywordsUnauth match {
         case Some(k) => k.map { Concept(_) }
-        case None => List
+        case None => List()
       }
 
       val genres = keywords ++ keywordsUnauth

--- a/common/src/main/scala/uk/ac/wellcome/models/MiroTransformable.scala
+++ b/common/src/main/scala/uk/ac/wellcome/models/MiroTransformable.scala
@@ -17,7 +17,9 @@ case class MiroTransformableData(
     List[String]],
   @JsonProperty("image_artwork_date") artworkDate: Option[String],
   @JsonProperty("image_cleared") cleared: Option[String],
-  @JsonProperty("image_copyright_cleared") copyright_cleared: Option[String]
+  @JsonProperty("image_copyright_cleared") copyright_cleared: Option[String],
+  @JsonProperty("image_keywords") keywords: Option[List[String]],
+  @JsonProperty("image_keywords_unauth") keywordsUnauth: Option[List[String]],
 )
 
 case class ShouldNotTransformException(message: String)
@@ -131,6 +133,27 @@ case class MiroTransformable(MiroID: String,
         case None => List()
       }
 
+      // Populate the genres field.  This is based on two fields in the XML,
+      // <image_keywords> and <image_keywords_unauth>.  Both of these were
+      // defined in part or whole by the human cataloguers, and in general do
+      // not correspond to a controlled vocabulary.  (The latter was imported
+      // directly from PhotoSoft.)
+      //
+      // In some cases, these actually do correspond to controlled vocabs,
+      // e.g. where keywords were pulled directly from Sierra -- but we don't
+      // have enough information in Miro to determine which ones those are.
+      val keywords: List[Concept] = miroData.keywords match {
+        case Some(k) => k.map { Concept(_) }
+        case None => List()
+      }
+
+      val keywordsUnauth: List[Concept] = miroData.keywordsUnauth match {
+        case Some(k) => k.map { Concept(_) }
+        case None => List
+      }
+
+      val genres = keywords ++ keywordsUnauth
+
       // Determining the creation date depends on several factors, so we do
       // it on a per-collection basis.
       val createdDate: Option[Period] = MiroCollection match {
@@ -143,7 +166,8 @@ case class MiroTransformable(MiroID: String,
         title = title,
         description = trimmedDescription,
         createdDate = createdDate,
-        creators = creators ++ secondaryCreators
+        creators = creators ++ secondaryCreators,
+        genres = genres
       )
     }
   }

--- a/common/src/main/scala/uk/ac/wellcome/models/MiroTransformable.scala
+++ b/common/src/main/scala/uk/ac/wellcome/models/MiroTransformable.scala
@@ -19,7 +19,7 @@ case class MiroTransformableData(
   @JsonProperty("image_cleared") cleared: Option[String],
   @JsonProperty("image_copyright_cleared") copyright_cleared: Option[String],
   @JsonProperty("image_keywords") keywords: Option[List[String]],
-  @JsonProperty("image_keywords_unauth") keywordsUnauth: Option[List[String]],
+  @JsonProperty("image_keywords_unauth") keywordsUnauth: Option[List[String]]
 )
 
 case class ShouldNotTransformException(message: String)

--- a/common/src/main/scala/uk/ac/wellcome/models/Work.scala
+++ b/common/src/main/scala/uk/ac/wellcome/models/Work.scala
@@ -18,6 +18,7 @@ case class Work(
   description: Option[String] = None,
   lettering: Option[String] = None,
   createdDate: Option[Period] = None,
+  genres: List[Concept] = List(),
   creators: List[Agent] = List()
 ) {
   @JsonProperty("type") val ldType: String = "Work"


### PR DESCRIPTION
### What is this PR trying to achieve?

Start to expose data about genres in the Catalogue API. Right now the data is raw and unfiltered – strings will be shown exactly as they appear in Miro, uppercased and all.

Fixes #619, related to #618.

Once this is merged, I’ll make follow-up issues to track improving the data quality.

### Who is this change for?

* The Experience team, who want genre data exposed in the API
* Silver and Chris, who want to see what this data looks like

### Have the following been considered/are they needed?

- [ ] Reviewed by @jtweed
- [ ] Updated the Swagger documentation
- [ ] Deployed new versions