### PR TITLE
Bump our installed Loris version

### DIFF
--- a/docker/loris/install_loris.sh
+++ b/docker/loris/install_loris.sh
@@ -6,8 +6,6 @@ set -o nounset
 
 LORIS_COMMIT="2ba933cbddad7f322c2d1d483b11f1445ba6204c"
 
-https://github.com/loris-imageserver/loris/archive/2ba933cbddad7f322c2d1d483b11f1445ba6204c.zip
-
 # Install dependencies.  We don't include Apache because we're running
 # Loris with UWSGI and nginx, not Apache.
 apt-get install -y libjpeg-turbo8-dev libfreetype6-dev zlib1g-dev \


### PR DESCRIPTION
This fixes the NoneType errors we’ve been seeing occasionally.