### PR TITLE
Genres take two

### DIFF
--- a/api/src/main/resources/context.json
+++ b/api/src/main/resources/context.json
@@ -6,11 +6,15 @@
       "id": "@id",
       "type": "@type",
       "creators": {
-        "@id": "hasCreator",
         "@container": "@list"
       },
       "identifiers": {
-        "@id": "hasIdentifier",
+        "@container": "@list"
+      },
+      "genres": {
+        "@container": "@list"
+      },
+      "subjects": {
         "@container": "@list"
       }
     },

--- a/api/src/main/scala/uk/ac/wellcome/platform/api/models/DisplayWork.scala
+++ b/api/src/main/scala/uk/ac/wellcome/platform/api/models/DisplayWork.scala
@@ -13,7 +13,8 @@ case class DisplayWork(id: String,
                        createdDate: Option[Period] = None,
                        creators: List[Agent] = List(),
                        identifiers: Option[List[DisplayIdentifier]] = None,
-                       subjects: List[Concept] = List()) {
+                       subjects: List[Concept] = List(),
+                       genres: List[Concept] = List()) {
   @JsonProperty("type") val ontologyType: String = "Work"
 }
 
@@ -43,6 +44,7 @@ case object DisplayWork {
       // Wrapping this in Option to catch null value from Jackson
       creators = Option(identifiedWork.work.creators).getOrElse(Nil),
       subjects = Option(identifiedWork.work.subjects).getOrElse(Nil),
+      genres = Option(identifiedWork.work.genres).getOrElse(Nil),
       identifiers =
         if (includes.identifiers)
           Some(identifiedWork.work.identifiers.map(DisplayIdentifier(_)))

--- a/api/src/test/scala/uk/ac/wellcome/platform/api/ApiWorksTest.scala
+++ b/api/src/test/scala/uk/ac/wellcome/platform/api/ApiWorksTest.scala
@@ -473,7 +473,7 @@ class ApiWorksTest
       Work(
         identifiers = List(),
         title = "A guppy in a greenhouse",
-        subjects = List(Concept("woodwork"), Concept("etching"))
+        genres = List(Concept("woodwork"), Concept("etching"))
       )
     )
     insertIntoElasticSearch(workWithSubjects)
@@ -499,11 +499,11 @@ class ApiWorksTest
              |     "genres": [
              |       {
              |         "type": "Concept",
-             |         "label": "fish"
+             |         "label": "woodwork"
              |       },
              |       {
              |         "type": "Concept",
-             |         "label": "gardening"
+             |         "label": "etching"
              |       }
              |     ]
              |   }

--- a/api/src/test/scala/uk/ac/wellcome/platform/api/ApiWorksTest.scala
+++ b/api/src/test/scala/uk/ac/wellcome/platform/api/ApiWorksTest.scala
@@ -68,7 +68,8 @@ class ApiWorksTest
             |       "type": "Agent",
             |       "label": "${works(0).work.creators(0).label}"
             |     }],
-            |     "subjects": [ ]
+            |     "subjects": [ ],
+            |     "genres": [ ]
             |   },
             |   {
             |     "type": "Work",
@@ -84,7 +85,8 @@ class ApiWorksTest
             |       "type": "Agent",
             |       "label": "${works(1).work.creators(0).label}"
             |     }],
-            |     "subjects": [ ]
+            |     "subjects": [ ],
+            |     "genres": [ ]
             |   },
             |   {
             |     "type": "Work",
@@ -100,7 +102,8 @@ class ApiWorksTest
             |       "type": "Agent",
             |       "label": "${works(2).work.creators(0).label}"
             |     }],
-            |     "subjects": [ ]
+            |     "subjects": [ ],
+            |     "genres": [ ]
             |   }
             |  ]
             |}
@@ -141,7 +144,8 @@ class ApiWorksTest
             |   "type": "Agent",
             |   "label": "${agent.label}"
             | }],
-            | "subjects": [ ]
+            | "subjects": [ ],
+            | "genres": [ ]
             |}
           """.stripMargin
       )
@@ -182,7 +186,8 @@ class ApiWorksTest
                           |       "type": "Agent",
                           |       "label": "${works(1).work.creators(0).label}"
                           |     }],
-                          |     "subjects": [ ]
+                          |     "subjects": [ ],
+                          |     "genres": [ ]
                           |   }]
                           |   }
                           |  ]
@@ -216,7 +221,8 @@ class ApiWorksTest
                           |       "type": "Agent",
                           |       "label": "${works(0).work.creators(0).label}"
                           |     }],
-                          |     "subjects": [ ]
+                          |     "subjects": [ ],
+                          |     "genres": [ ]
                           |   }]
                           |   }
                           |  ]
@@ -250,7 +256,8 @@ class ApiWorksTest
                           |       "type": "Agent",
                           |       "label": "${works(2).work.creators(0).label}"
                           |     }],
-                          |     "subjects": [ ]
+                          |     "subjects": [ ],
+                          |     "genres": [ ]
                           |   }]
                           |   }
                           |  ]
@@ -405,7 +412,8 @@ class ApiWorksTest
              |     "id": "${work1.canonicalId}",
              |     "title": "${work1.work.title}",
              |     "creators": [],
-             |     "subjects": [ ]
+             |     "subjects": [ ],
+             |     "genres": [ ]
              |   }
              |  ]
              |}""".stripMargin
@@ -418,7 +426,7 @@ class ApiWorksTest
       canonicalId = "test_subject1",
       Work(
         identifiers = List(),
-        title = "A guppy in a greenhouse",
+        title = "A seal selling seaweed sandwiches in Scotland",
         subjects = List(Concept("fish"), Concept("gardening"))
       )
     )
@@ -450,6 +458,53 @@ class ApiWorksTest
              |        "type": "Concept",
              |        "label": "gardening"
              |      }
+             |     ],
+             |     "genres": [ ]
+             |   }
+             |  ]
+             |}""".stripMargin
+      )
+    }
+  }
+
+  it("should include genre information in API responses") {
+    val workWithSubjects = IdentifiedWork(
+      canonicalId = "test_subject1",
+      Work(
+        identifiers = List(),
+        title = "A guppy in a greenhouse",
+        subjects = List(Concept("woodwork"), Concept("etching"))
+      )
+    )
+    insertIntoElasticSearch(workWithSubjects)
+
+    eventually {
+      server.httpGet(
+        path = s"/$apiPrefix/works",
+        andExpect = Status.Ok,
+        withJsonBody = s"""
+             |{
+             |  "@context": "https://localhost:8888/$apiPrefix/context.json",
+             |  "type": "ResultList",
+             |  "pageSize": 10,
+             |  "totalPages": 1,
+             |  "totalResults": 1,
+             |  "results": [
+             |   {
+             |     "type": "Work",
+             |     "id": "${workWithSubjects.canonicalId}",
+             |     "title": "${workWithSubjects.work.title}",
+             |     "creators": [],
+             |     "subjects": [ ],
+             |     "genres": [
+             |       {
+             |         "type": "Concept",
+             |         "label": "fish"
+             |       },
+             |       {
+             |         "type": "Concept",
+             |         "label": "gardening"
+             |       }
              |     ]
              |   }
              |  ]
@@ -511,7 +566,8 @@ class ApiWorksTest
                           |         "value": "${identifier1.value}"
                           |       }
                           |     ],
-                          |     "subjects": [ ]
+                          |     "subjects": [ ],
+                          |     "genres": [ ]
                           |   },
                           |   {
                           |     "type": "Work",
@@ -526,7 +582,8 @@ class ApiWorksTest
                           |         "value": "${identifier2.value}"
                           |       }
                           |     ],
-                          |     "subjects": [ ]
+                          |     "subjects": [ ],
+                          |     "genres": [ ]
                           |   }
                           |  ]
                           |}
@@ -568,7 +625,8 @@ class ApiWorksTest
                           |     "value": "${identifier.value}"
                           |   }
                           | ],
-                          | "subjects": [ ]
+                          | "subjects": [ ],
+                          | "genres": [ ]
                           |}
           """.stripMargin
       )
@@ -600,7 +658,8 @@ class ApiWorksTest
                           | "id": "${work.canonicalId}",
                           | "title": "${work.work.title}",
                           | "creators": [ ],
-                          | "subjects": [ ]
+                          | "subjects": [ ],
+                          | "genres": [ ]
                           |}
           """.stripMargin
       )
@@ -617,7 +676,8 @@ class ApiWorksTest
                           | "id": "${work_alt.canonicalId}",
                           | "title": "${work_alt.work.title}",
                           | "creators": [ ],
-                          | "subjects": [ ]
+                          | "subjects": [ ],
+                          | "genres": [ ]
                           |}
           """.stripMargin
       )
@@ -655,7 +715,8 @@ class ApiWorksTest
                           |     "id": "${work.canonicalId}",
                           |     "title": "${work.work.title}",
                           |     "creators": [ ],
-                          |     "subjects": [ ]
+                          |     "subjects": [ ],
+                          |     "genres": [ ]
                           |   }
                           |  ]
                           |}
@@ -680,7 +741,8 @@ class ApiWorksTest
                           |     "id": "${work_alt.canonicalId}",
                           |     "title": "${work_alt.work.title}",
                           |     "creators": [ ],
-                          |     "subjects": [ ]
+                          |     "subjects": [ ],
+                          |     "genres": [ ]
                           |   }
                           |  ]
                           |}

--- a/common/src/main/scala/uk/ac/wellcome/elasticsearch/mappings/WorksIndex.scala
+++ b/common/src/main/scala/uk/ac/wellcome/elasticsearch/mappings/WorksIndex.scala
@@ -45,6 +45,10 @@ class WorksIndex @Inject()(client: HttpClient,
         objectField("subjects").fields(
           textField("label"),
           keywordField("type")
+        ),
+        objectField("genres").fields(
+          textField("label"),
+          keywordField("type")
         )
       )
     )

--- a/common/src/main/scala/uk/ac/wellcome/models/MiroTransformable.scala
+++ b/common/src/main/scala/uk/ac/wellcome/models/MiroTransformable.scala
@@ -19,7 +19,9 @@ case class MiroTransformableData(
   @JsonProperty("image_cleared") cleared: Option[String],
   @JsonProperty("image_copyright_cleared") copyright_cleared: Option[String],
   @JsonProperty("image_keywords") keywords: Option[List[String]],
-  @JsonProperty("image_keywords_unauth") keywordsUnauth: Option[List[String]]
+  @JsonProperty("image_keywords_unauth") keywordsUnauth: Option[List[String]],
+  @JsonProperty("image_phys_format") physFormat: Option[String],
+  @JsonProperty("image_lc_genre") lcGenre: Option[String]
 )
 
 case class ShouldNotTransformException(message: String)
@@ -154,6 +156,20 @@ case class MiroTransformable(MiroID: String,
 
       val subjects = keywords ++ keywordsUnauth
 
+      // Populate the subjects field.  This is based on two fields in the XML,
+      // <image_phys_format> and <image_lc_genre>.
+      val physFormat: List[Concept] = miroData.physFormat match {
+        case Some(f) => List(Concept(f))
+        case None => List()
+      }
+
+      val lcGenre: List[Concept] = miroData.lcGenre match {
+        case Some(g) => List(Concept(g))
+        case None => List()
+      }
+
+      val genres = physFormat ++ lcGenre
+
       // Determining the creation date depends on several factors, so we do
       // it on a per-collection basis.
       val createdDate: Option[Period] = MiroCollection match {
@@ -167,7 +183,8 @@ case class MiroTransformable(MiroID: String,
         description = trimmedDescription,
         createdDate = createdDate,
         creators = creators ++ secondaryCreators,
-        subjects = subjects
+        subjects = subjects,
+        genres = genres
       )
     }
   }

--- a/common/src/main/scala/uk/ac/wellcome/models/Work.scala
+++ b/common/src/main/scala/uk/ac/wellcome/models/Work.scala
@@ -19,7 +19,8 @@ case class Work(
   lettering: Option[String] = None,
   createdDate: Option[Period] = None,
   subjects: List[Concept] = List(),
-  creators: List[Agent] = List()
+  creators: List[Agent] = List(),
+  genres: List[Concept] = List()
 ) {
   @JsonProperty("type") val ldType: String = "Work"
 }

--- a/common/src/test/scala/uk/ac/wellcome/models/MiroTransformableTest.scala
+++ b/common/src/test/scala/uk/ac/wellcome/models/MiroTransformableTest.scala
@@ -498,3 +498,71 @@ class MiroTransformableSubjectsTest extends FunSpec with Matchers {
     miroTransformable.transform.get.subjects shouldBe expectedSubjects
   }
 }
+
+
+
+
+class MiroTransformableGenresTest extends FunSpec with Matchers {
+
+  it("should have an empty genre list on records without keywords") {
+    transformRecordAndCheckGenres(
+      data = s""""image_title": "The giraffe's genre is gone'"""",
+      expectedGenres = List[Concept]()
+    )
+  }
+
+  it("should use the image_phys_format field if present") {
+    transformRecordAndCheckGenres(
+      data = s"""
+        "image_title": "A goat grazes on some grass",
+        "image_phys_format": ["painting", "watercolour"]
+      """,
+      expectedGenres = List(
+        Concept("painting"), Concept("watercolour")
+      )
+    )
+  }
+
+  it("should use the image_lc_genre field if present") {
+    transformRecordAndCheckGenres(
+      data = s"""
+        "image_title": "Grouchy geese are good as guards",
+        "image_lc_genre": ["sculpture"]
+      """,
+      expectedGenres = List(
+        Concept("sculpture")
+      )
+    )
+  }
+
+  it("should use the image_phys_format and image_lc_genre fields if both present") {
+    transformRecordAndCheckGenres(
+      data = s"""
+        "image_title": "A gorilla and a gibbon in a garden",
+        "image_phys_format": ["etching"],
+        "image_lc_genre": ["woodwork"]
+      """,
+      expectedGenres = List(
+        Concept("etching"), Concept("woodwork")
+      )
+    )
+  }
+
+  private def transformRecordAndCheckGenres(
+    data: String,
+    expectedGenres: List[Concept] = List()
+  ) = {
+    val miroTransformable = MiroTransformable(
+      MiroID = "M0000001",
+      MiroCollection = "Images-V",
+      data = s"""{
+        "image_cleared": "Y",
+        "image_copyright_cleared": "Y",
+        $data
+      }"""
+    )
+
+    miroTransformable.transform.isSuccess shouldBe true
+    miroTransformable.transform.get.genres shouldBe expectedGenres
+  }
+}

--- a/common/src/test/scala/uk/ac/wellcome/models/MiroTransformableTest.scala
+++ b/common/src/test/scala/uk/ac/wellcome/models/MiroTransformableTest.scala
@@ -501,7 +501,6 @@ class MiroTransformableSubjectsTest extends FunSpec with Matchers {
 
 
 
-
 class MiroTransformableGenresTest extends FunSpec with Matchers {
 
   it("should have an empty genre list on records without keywords") {
@@ -515,10 +514,10 @@ class MiroTransformableGenresTest extends FunSpec with Matchers {
     transformRecordAndCheckGenres(
       data = s"""
         "image_title": "A goat grazes on some grass",
-        "image_phys_format": ["painting", "watercolour"]
+        "image_phys_format": "painting"
       """,
       expectedGenres = List(
-        Concept("painting"), Concept("watercolour")
+        Concept("painting")
       )
     )
   }
@@ -527,7 +526,7 @@ class MiroTransformableGenresTest extends FunSpec with Matchers {
     transformRecordAndCheckGenres(
       data = s"""
         "image_title": "Grouchy geese are good as guards",
-        "image_lc_genre": ["sculpture"]
+        "image_lc_genre": "sculpture"
       """,
       expectedGenres = List(
         Concept("sculpture")
@@ -539,8 +538,8 @@ class MiroTransformableGenresTest extends FunSpec with Matchers {
     transformRecordAndCheckGenres(
       data = s"""
         "image_title": "A gorilla and a gibbon in a garden",
-        "image_phys_format": ["etching"],
-        "image_lc_genre": ["woodwork"]
+        "image_phys_format": "etching",
+        "image_lc_genre": "woodwork"
       """,
       expectedGenres = List(
         Concept("etching"), Concept("woodwork")


### PR DESCRIPTION
### What is this PR trying to achieve?

Add genre to the Catalogue API, but for real this time. (Previously we had subjects masquerading as genres.)

Resolves #619, required for #618.

### Who is this change for?

The Experience team and Silver/Chris.

### Have the following been considered/are they needed?

- [x] Reviewed by @jtweed
- [ ] Deployed new versions
