### PR TITLE
Switch to using identifierScheme in the identifiers

### DIFF
--- a/api/src/main/scala/uk/ac/wellcome/platform/api/models/DisplayWork.scala
+++ b/api/src/main/scala/uk/ac/wellcome/platform/api/models/DisplayWork.scala
@@ -60,7 +60,7 @@ case class DisplayIdentifier(source: String, name: String, value: String) {
 
 object DisplayIdentifier {
   def apply(sourceIdentifier: SourceIdentifier): DisplayIdentifier =
-    DisplayIdentifier(source = sourceIdentifier.source,
-                      name = sourceIdentifier.sourceId,
+    DisplayIdentifier(source = sourceIdentifier.identifierScheme,
+                      name = "",
                       value = sourceIdentifier.value)
 }

--- a/api/src/main/scala/uk/ac/wellcome/platform/api/models/DisplayWork.scala
+++ b/api/src/main/scala/uk/ac/wellcome/platform/api/models/DisplayWork.scala
@@ -53,14 +53,13 @@ case object DisplayWork {
   }
 }
 
-case class DisplayIdentifier(source: String, name: String, value: String) {
+case class DisplayIdentifier(identifierScheme: String, value: String) {
   @JsonProperty("type")
   val ontologyType: String = "Identifier"
 }
 
 object DisplayIdentifier {
   def apply(sourceIdentifier: SourceIdentifier): DisplayIdentifier =
-    DisplayIdentifier(source = sourceIdentifier.identifierScheme,
-                      name = "",
+    DisplayIdentifier(identifierScheme = sourceIdentifier.identifierScheme,
                       value = sourceIdentifier.value)
 }

--- a/api/src/test/scala/uk/ac/wellcome/platform/api/ApiWorksTest.scala
+++ b/api/src/test/scala/uk/ac/wellcome/platform/api/ApiWorksTest.scala
@@ -516,8 +516,7 @@ class ApiWorksTest
   it(
     "should include a list of identifiers on a list endpoint if we pass ?includes=identifiers") {
     val identifier1 = SourceIdentifier(
-      source = "TestSource",
-      sourceId = "The ID field within the TestSource",
+      identifierScheme = "The ID field within the TestSource",
       value = "Test1234"
     )
     val work1 = identifiedWorkWith(
@@ -527,8 +526,7 @@ class ApiWorksTest
     )
 
     val identifier2 = SourceIdentifier(
-      source = "DifferentTestSource",
-      sourceId = "The ID field within the DifferentTestSource",
+      identifierScheme = "The ID field within the DifferentTestSource",
       value = "DTest5678"
     )
     val work2 = identifiedWorkWith(
@@ -561,8 +559,7 @@ class ApiWorksTest
                           |     "identifiers": [
                           |       {
                           |         "type": "Identifier",
-                          |         "source": "${identifier1.source}",
-                          |         "name": "${identifier1.sourceId}",
+                          |         "identifierScheme": "${identifier1.identifierScheme}",
                           |         "value": "${identifier1.value}"
                           |       }
                           |     ],
@@ -577,8 +574,7 @@ class ApiWorksTest
                           |     "identifiers": [
                           |       {
                           |         "type": "Identifier",
-                          |         "source": "${identifier2.source}",
-                          |         "name": "${identifier2.sourceId}",
+                          |         "identifierScheme": "${identifier2.identifierScheme}",
                           |         "value": "${identifier2.value}"
                           |       }
                           |     ],
@@ -595,8 +591,7 @@ class ApiWorksTest
   it(
     "should include a list of identifiers on a single work endpoint if we pass ?includes=identifiers") {
     val identifier = SourceIdentifier(
-      source = "TestSource",
-      sourceId = "An Insectoid Identifier",
+      identifierScheme = "An Insectoid Identifier",
       value = "Test1234"
     )
     val work = identifiedWorkWith(
@@ -620,8 +615,7 @@ class ApiWorksTest
                           | "identifiers": [
                           |   {
                           |     "type": "Identifier",
-                          |     "source": "${identifier.source}",
-                          |     "name": "${identifier.sourceId}",
+                          |     "identifierScheme": "${identifier.identifierScheme}",
                           |     "value": "${identifier.value}"
                           |   }
                           | ],

--- a/api/src/test/scala/uk/ac/wellcome/platform/api/WorksUtil.scala
+++ b/api/src/test/scala/uk/ac/wellcome/platform/api/WorksUtil.scala
@@ -37,7 +37,7 @@ trait WorksUtil {
   def identifiedWorkWith(canonicalId: String, title: String): IdentifiedWork =
     IdentifiedWork(canonicalId,
                    Work(identifiers =
-                          List(SourceIdentifier("Miro", "MiroID", "5678")),
+                          List(SourceIdentifier("test-miro-image-number", "5678")),
                         title = title))
 
   def identifiedWorkWith(canonicalId: String,
@@ -53,7 +53,7 @@ trait WorksUtil {
                          creator: Agent): IdentifiedWork = IdentifiedWork(
     canonicalId = canonicalId,
     work = Work(
-      identifiers = List(SourceIdentifier("Miro", "MiroID", "5678")),
+      identifiers = List(SourceIdentifier("test-miro-image-number", "5678")),
       title = title,
       description = Some(description),
       lettering = Some(lettering),

--- a/api/src/test/scala/uk/ac/wellcome/platform/api/services/ElasticsearchServiceTest.scala
+++ b/api/src/test/scala/uk/ac/wellcome/platform/api/services/ElasticsearchServiceTest.scala
@@ -2,7 +2,6 @@ package uk.ac.wellcome.platform.api.services
 
 import org.scalatest.{FunSpec, Matchers}
 import org.scalatest.concurrent.ScalaFutures
-import uk.ac.wellcome.models.{IdentifiedWork, SourceIdentifier, Work}
 import uk.ac.wellcome.platform.api.WorksUtil
 import uk.ac.wellcome.platform.api.models.DisplayWork
 import uk.ac.wellcome.test.utils.IndexedElasticSearchLocal

--- a/api/src/test/scala/uk/ac/wellcome/platform/api/services/WorksServiceTest.scala
+++ b/api/src/test/scala/uk/ac/wellcome/platform/api/services/WorksServiceTest.scala
@@ -174,8 +174,6 @@ class WorksServiceTest
 
     val title = "image title"
     val miroId = "abcdef"
-    val sourceName = "Miro"
-    val sourceId = "MiroID"
     val identifierScheme = "miro-image-number"
     val work = identifiedWorkWith(canonicalId,
                                   title,
@@ -193,8 +191,7 @@ class WorksServiceTest
       maybeDisplayWork.isDefined shouldBe true
       maybeDisplayWork.get.identifiers.isDefined shouldBe true
       maybeDisplayWork.get.identifiers.get shouldBe List(
-        DisplayIdentifier(source = sourceName,
-                          name = sourceId,
+        DisplayIdentifier(identifierScheme = identifierScheme,
                           value = miroId))
 
     }
@@ -205,8 +202,6 @@ class WorksServiceTest
 
     val title = "image title"
     val miroId = "abcdef"
-    val sourceName = "Miro"
-    val sourceId = "MiroID"
     val identifierScheme = "miro-image-number"
     val work = identifiedWorkWith(canonicalId,
                                   title,
@@ -220,8 +215,7 @@ class WorksServiceTest
 
     whenReady(listWorksResult) { (displayWork: DisplaySearch) =>
       displayWork.results.head.identifiers.get shouldBe List(
-        DisplayIdentifier(source = sourceName,
-                          name = sourceId,
+        DisplayIdentifier(identifierScheme = identifierScheme,
                           value = miroId))
 
     }
@@ -232,8 +226,6 @@ class WorksServiceTest
 
     val title = "A search for a snail"
     val miroId = "abcdef"
-    val sourceName = "Miro"
-    val sourceId = "MiroID"
     val identifierScheme = "miro-image-number"
     val work = identifiedWorkWith(canonicalId,
                                   title,
@@ -249,8 +241,7 @@ class WorksServiceTest
 
     whenReady(searchWorksResult) { (displayWork: DisplaySearch) =>
       displayWork.results.head.identifiers.get shouldBe List(
-        DisplayIdentifier(source = sourceName,
-                          name = sourceId,
+        DisplayIdentifier(identifierScheme = identifierScheme,
                           value = miroId))
 
     }

--- a/api/src/test/scala/uk/ac/wellcome/platform/api/services/WorksServiceTest.scala
+++ b/api/src/test/scala/uk/ac/wellcome/platform/api/services/WorksServiceTest.scala
@@ -176,11 +176,11 @@ class WorksServiceTest
     val miroId = "abcdef"
     val sourceName = "Miro"
     val sourceId = "MiroID"
+    val identifierScheme = "miro-image-number"
     val work = identifiedWorkWith(canonicalId,
                                   title,
                                   identifiers = List(
-                                    SourceIdentifier(source = sourceName,
-                                                     sourceId = sourceId,
+                                    SourceIdentifier(identifierScheme = identifierScheme,
                                                      value = miroId)))
     insertIntoElasticSearch(work)
 
@@ -207,11 +207,11 @@ class WorksServiceTest
     val miroId = "abcdef"
     val sourceName = "Miro"
     val sourceId = "MiroID"
+    val identifierScheme = "miro-image-number"
     val work = identifiedWorkWith(canonicalId,
                                   title,
                                   identifiers = List(
-                                    SourceIdentifier(source = sourceName,
-                                                     sourceId = sourceId,
+                                    SourceIdentifier(identifierScheme = identifierScheme,
                                                      value = miroId)))
     insertIntoElasticSearch(work)
 
@@ -234,11 +234,11 @@ class WorksServiceTest
     val miroId = "abcdef"
     val sourceName = "Miro"
     val sourceId = "MiroID"
+    val identifierScheme = "miro-image-number"
     val work = identifiedWorkWith(canonicalId,
                                   title,
                                   identifiers = List(
-                                    SourceIdentifier(source = sourceName,
-                                                     sourceId = sourceId,
+                                    SourceIdentifier(identifierScheme = identifierScheme,
                                                      value = miroId)))
     insertIntoElasticSearch(work)
 

--- a/common/src/main/scala/uk/ac/wellcome/elasticsearch/mappings/WorksIndex.scala
+++ b/common/src/main/scala/uk/ac/wellcome/elasticsearch/mappings/WorksIndex.scala
@@ -25,9 +25,9 @@ class WorksIndex @Inject()(client: HttpClient,
       keywordField("canonicalId"),
       objectField("work").fields(
         keywordField("type"),
-        objectField("identifiers").fields(keywordField("source"),
-                                          keywordField("sourceId"),
-                                          keywordField("value")),
+        objectField("identifiers").fields(keywordField("identifierScheme"),
+                                          keywordField("value"),
+                                          keywordField("type")),
         textField("title").fields(
           textField("english").analyzer(EnglishLanguageAnalyzer)),
         textField("description").fields(

--- a/common/src/main/scala/uk/ac/wellcome/finatra/modules/IdentifierSchemeModule.scala
+++ b/common/src/main/scala/uk/ac/wellcome/finatra/modules/IdentifierSchemeModule.scala
@@ -1,8 +1,8 @@
 package uk.ac.wellcome.finatra.modules
 
 /** This is the canonical version of our identifier schemes.  This contains
- *  the strings that will be presented to users of the API.
- */
+  *  the strings that will be presented to users of the API.
+  */
 object IdentifierSchemes {
 
   // Corresponds to the image number in Miro, e.g. V00127563.

--- a/common/src/main/scala/uk/ac/wellcome/models/CalmTransformable.scala
+++ b/common/src/main/scala/uk/ac/wellcome/models/CalmTransformable.scala
@@ -10,7 +10,7 @@ case class CalmTransformableData(
   def transform: Try[Work] = Try {
     // TODO: Fill in proper data here
     Work(
-      identifiers = List(SourceIdentifier("source", "key", "value")),
+      identifiers = List(SourceIdentifier("calm-placeholder-scheme", "value")),
       title = "placeholder title for a Calm record"
     )
   }

--- a/common/src/main/scala/uk/ac/wellcome/models/CalmTransformable.scala
+++ b/common/src/main/scala/uk/ac/wellcome/models/CalmTransformable.scala
@@ -11,7 +11,8 @@ case class CalmTransformableData(
   def transform: Try[Work] = Try {
     // TODO: Fill in proper data here
     Work(
-      identifiers = List(SourceIdentifier(IdentifierSchemes.calmPlaceholder, "value")),
+      identifiers =
+        List(SourceIdentifier(IdentifierSchemes.calmPlaceholder, "value")),
       title = "placeholder title for a Calm record"
     )
   }

--- a/common/src/main/scala/uk/ac/wellcome/models/MiroTransformable.scala
+++ b/common/src/main/scala/uk/ac/wellcome/models/MiroTransformable.scala
@@ -50,7 +50,8 @@ case class MiroTransformable(MiroID: String,
 
     JsonUtil.fromJson[MiroTransformableData](unencodedData).map { miroData =>
       // Identifier is passed straight through
-      val identifiers = List(SourceIdentifier(IdentifierSchemes.miroImageNumber, MiroID))
+      val identifiers =
+        List(SourceIdentifier(IdentifierSchemes.miroImageNumber, MiroID))
 
       // XML tags refer to fields within the Miro XML dumps.
 

--- a/common/src/main/scala/uk/ac/wellcome/models/MiroTransformable.scala
+++ b/common/src/main/scala/uk/ac/wellcome/models/MiroTransformable.scala
@@ -49,7 +49,7 @@ case class MiroTransformable(MiroID: String,
 
     JsonUtil.fromJson[MiroTransformableData](unencodedData).map { miroData =>
       // Identifier is passed straight through
-      val identifiers = List(SourceIdentifier("Miro", "MiroID", MiroID))
+      val identifiers = List(SourceIdentifier("miro-image-number", MiroID))
 
       // XML tags refer to fields within the Miro XML dumps.
 

--- a/common/src/main/scala/uk/ac/wellcome/models/Work.scala
+++ b/common/src/main/scala/uk/ac/wellcome/models/Work.scala
@@ -5,7 +5,7 @@ import com.sksamuel.elastic4s.Indexable
 import uk.ac.wellcome.utils.JsonUtil
 
 /** An identifier received from one of the original sources */
-case class SourceIdentifier(source: String, sourceId: String, value: String)
+case class SourceIdentifier(identifierScheme: String, value: String)
 
 case class IdentifiedWork(canonicalId: String, work: Work)
 

--- a/common/src/test/scala/uk/ac/wellcome/elasticsearch/mappings/WorksIndexTest.scala
+++ b/common/src/test/scala/uk/ac/wellcome/elasticsearch/mappings/WorksIndexTest.scala
@@ -39,8 +39,7 @@ class WorksIndexTest
         IdentifiedWork(
           canonicalId = "1234",
           work = Work(identifiers = List(
-                        SourceIdentifier(source = "Miro",
-                                         sourceId = "MiroID",
+                        SourceIdentifier(identifierScheme = "miro-image-number",
                                          value = "4321")),
                       title = "A magical menagerie for magpies")
         ))

--- a/common/src/test/scala/uk/ac/wellcome/models/MiroTransformableTest.scala
+++ b/common/src/test/scala/uk/ac/wellcome/models/MiroTransformableTest.scala
@@ -184,7 +184,7 @@ class MiroTransformableTest extends FunSpec with Matchers {
   it("should pass through the Miro identifier") {
     val miroID = "M0000005_test"
     val work = transformMiroRecord(miroID = miroID)
-    work.identifiers shouldBe List(SourceIdentifier("test-miro-image-number", miroID))
+    work.identifiers shouldBe List(SourceIdentifier("miro-image-number", miroID))
   }
 
   it("should have an empty list if no image_creator field is present") {

--- a/common/src/test/scala/uk/ac/wellcome/models/MiroTransformableTest.scala
+++ b/common/src/test/scala/uk/ac/wellcome/models/MiroTransformableTest.scala
@@ -184,7 +184,7 @@ class MiroTransformableTest extends FunSpec with Matchers {
   it("should pass through the Miro identifier") {
     val miroID = "M0000005_test"
     val work = transformMiroRecord(miroID = miroID)
-    work.identifiers shouldBe List(SourceIdentifier("Miro", "MiroID", miroID))
+    work.identifiers shouldBe List(SourceIdentifier("test-miro-image-number", miroID))
   }
 
   it("should have an empty list if no image_creator field is present") {

--- a/id_minter/src/main/scala/uk/ac/wellcome/platform/idminter/steps/IdentifierGenerator.scala
+++ b/id_minter/src/main/scala/uk/ac/wellcome/platform/idminter/steps/IdentifierGenerator.scala
@@ -46,9 +46,9 @@ class IdentifierGenerator @Inject()(identifiersDao: IdentifiersDao,
       }
     }
 
-  private def findMiroID(work: Work) = {
+  private def findMiroID(work: Work): Option[SourceIdentifier] = {
     val maybeSourceIdentifier =
-      work.identifiers.find(identifier => identifier.sourceId == "MiroID")
+      work.identifiers.find(identifier => identifier.identifierScheme == "miro-image-number")
     info(s"SourceIdentifier: $maybeSourceIdentifier")
     maybeSourceIdentifier
   }

--- a/id_minter/src/main/scala/uk/ac/wellcome/platform/idminter/steps/IdentifierGenerator.scala
+++ b/id_minter/src/main/scala/uk/ac/wellcome/platform/idminter/steps/IdentifierGenerator.scala
@@ -48,7 +48,8 @@ class IdentifierGenerator @Inject()(identifiersDao: IdentifiersDao,
 
   private def findMiroID(work: Work): Option[SourceIdentifier] = {
     val maybeSourceIdentifier =
-      work.identifiers.find(identifier => identifier.identifierScheme == "miro-image-number")
+      work.identifiers.find(identifier =>
+        identifier.identifierScheme == "miro-image-number")
     info(s"SourceIdentifier: $maybeSourceIdentifier")
     maybeSourceIdentifier
   }

--- a/id_minter/src/test/scala/uk/ac/wellcome/platform/idminter/IdMinterFeatureTest.scala
+++ b/id_minter/src/test/scala/uk/ac/wellcome/platform/idminter/IdMinterFeatureTest.scala
@@ -26,7 +26,7 @@ class IdMinterFeatureTest
   }
 
   it(
-    "should read a work from the SQS queue, generate a canonical ID, save it in dynamoDB and send a message to the SNS topic with the original work and the id") {
+    "should read a work from the SQS queue, generate a canonical ID, save it in SQL and send a message to the SNS topic with the original work and the id") {
     val miroID = "M0001234"
     val title = "A limerick about a lion"
 

--- a/id_minter/src/test/scala/uk/ac/wellcome/platform/idminter/IdMinterFeatureTest.scala
+++ b/id_minter/src/test/scala/uk/ac/wellcome/platform/idminter/IdMinterFeatureTest.scala
@@ -31,7 +31,7 @@ class IdMinterFeatureTest
     val title = "A limerick about a lion"
 
     val work = Work(identifiers =
-                      List(SourceIdentifier("Miro", "MiroID", miroID)),
+                      List(SourceIdentifier("miro-image-number", miroID)),
                     title = title)
     val sqsMessage = SQSMessage(Some("subject"),
                                 JsonUtil.toJson(work).get,

--- a/id_minter/src/test/scala/uk/ac/wellcome/platform/idminter/modules/IdMinterWorkerTest.scala
+++ b/id_minter/src/test/scala/uk/ac/wellcome/platform/idminter/modules/IdMinterWorkerTest.scala
@@ -84,7 +84,7 @@ class IdMinterWorkerTest
           JsonUtil
             .toJson(
               Work(
-                identifiers = List(SourceIdentifier("Miro", "MiroID", miroId)),
+                identifiers = List(SourceIdentifier("miro-image-number", miroId)),
                 title = "Some fresh fruit for a flamingo"
               ))
             .get,

--- a/id_minter/src/test/scala/uk/ac/wellcome/platform/idminter/steps/IdentifierGeneratorTest.scala
+++ b/id_minter/src/test/scala/uk/ac/wellcome/platform/idminter/steps/IdentifierGeneratorTest.scala
@@ -39,7 +39,7 @@ class IdentifierGeneratorTest
     }.update().apply()
 
     val work =
-      Work(identifiers = List(SourceIdentifier("Miro", "MiroID", "1234")),
+      Work(identifiers = List(SourceIdentifier("miro-image-number", "1234")),
            title = "Searching for a sea slug")
     val futureId = identifierGenerator.generateId(work)
 
@@ -51,7 +51,7 @@ class IdentifierGeneratorTest
   it(
     "should generate an id and save it in the database if a record doesn't already exist") {
     val work =
-      Work(identifiers = List(SourceIdentifier("Miro", "MiroID", "1234")),
+      Work(identifiers = List(SourceIdentifier("miro-image-number", "1234")),
            title = "A novel name for a nightingale")
     val futureId = identifierGenerator.generateId(work)
 
@@ -69,7 +69,7 @@ class IdentifierGeneratorTest
   it("should reject an item with no miroId in the list of Identifiers") {
     val work =
       Work(
-        identifiers = List(SourceIdentifier("NotMiro", "NotMiroID", "1234")),
+        identifiers = List(SourceIdentifier("rebmun-egami-orim", "1234")),
         title = "The rejection of a robin")
     val futureId = identifierGenerator.generateId(work)
 
@@ -82,7 +82,7 @@ class IdentifierGeneratorTest
     "should return a failed future if it fails inserting the identifier in the database") {
     val miroId = "1234"
     val work =
-      Work(identifiers = List(SourceIdentifier("Miro", "MiroID", miroId)),
+      Work(identifiers = List(SourceIdentifier("miro-image-number", miroId)),
            title = "A fear of failing in a fox")
     val identifiersDao = mock[IdentifiersDao]
     val identifierGenerator =

--- a/id_minter/src/test/scala/uk/ac/wellcome/platform/idminter/steps/WorkExtractorTest.scala
+++ b/id_minter/src/test/scala/uk/ac/wellcome/platform/idminter/steps/WorkExtractorTest.scala
@@ -19,7 +19,7 @@ class WorkExtractorTest
     val title = "A note about a narwhal"
 
     val work = Work(
-      identifiers = List(SourceIdentifier("Miro", "MiroId", miroID)),
+      identifiers = List(SourceIdentifier("test-miro-image-number", miroID)),
       title = title
     )
     val sqsMessage = SQSMessage(Some("subject"),

--- a/id_minter/src/test/scala/uk/ac/wellcome/platform/idminter/utils/IdMinterTestUtils.scala
+++ b/id_minter/src/test/scala/uk/ac/wellcome/platform/idminter/utils/IdMinterTestUtils.scala
@@ -37,7 +37,7 @@ trait IdMinterTestUtils
 
   def generateSqsMessage(MiroID: String): SQSMessage = {
     val work = Work(identifiers =
-                      List(SourceIdentifier("test-miro-image-number", MiroID)),
+                      List(SourceIdentifier("miro-image-number", MiroID)),
                     title = "A query about a queue of quails")
     SQSMessage(Some("subject"),
                JsonUtil.toJson(work).get,

--- a/id_minter/src/test/scala/uk/ac/wellcome/platform/idminter/utils/IdMinterTestUtils.scala
+++ b/id_minter/src/test/scala/uk/ac/wellcome/platform/idminter/utils/IdMinterTestUtils.scala
@@ -37,7 +37,7 @@ trait IdMinterTestUtils
 
   def generateSqsMessage(MiroID: String): SQSMessage = {
     val work = Work(identifiers =
-                      List(SourceIdentifier("Miro", "MiroID", MiroID)),
+                      List(SourceIdentifier("test-miro-image-number", MiroID)),
                     title = "A query about a queue of quails")
     SQSMessage(Some("subject"),
                JsonUtil.toJson(work).get,

--- a/ingestor/src/test/scala/uk/ac/wellcome/platform/ingestor/IngestorFeatureTest.scala
+++ b/ingestor/src/test/scala/uk/ac/wellcome/platform/ingestor/IngestorFeatureTest.scala
@@ -5,6 +5,7 @@ import com.twitter.finatra.http.EmbeddedHttpServer
 import com.twitter.inject.server.FeatureTestMixin
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.{FunSpec, Matchers}
+import uk.ac.wellcome.finatra.modules.IdentifierSchemes
 import uk.ac.wellcome.models.aws.SQSMessage
 import uk.ac.wellcome.models.{IdentifiedWork, SourceIdentifier, Work}
 import uk.ac.wellcome.utils.GlobalExecutionContext.context
@@ -32,7 +33,7 @@ class IngestorFeatureTest
         IdentifiedWork(
           canonicalId = "1234",
           work = Work(identifiers =
-                        List(SourceIdentifier("test-miro-image-number", "5678")),
+                        List(SourceIdentifier(IdentifierSchemes.miroImageNumber, "5678")),
                       title = "A type of a tame turtle")))
       .get
 

--- a/ingestor/src/test/scala/uk/ac/wellcome/platform/ingestor/IngestorFeatureTest.scala
+++ b/ingestor/src/test/scala/uk/ac/wellcome/platform/ingestor/IngestorFeatureTest.scala
@@ -32,7 +32,7 @@ class IngestorFeatureTest
         IdentifiedWork(
           canonicalId = "1234",
           work = Work(identifiers =
-                        List(SourceIdentifier("Miro", "MiroID", "5678")),
+                        List(SourceIdentifier("test-miro-image-number", "5678")),
                       title = "A type of a tame turtle")))
       .get
 

--- a/ingestor/src/test/scala/uk/ac/wellcome/platform/ingestor/services/IdentifiedWorkIndexerTest.scala
+++ b/ingestor/src/test/scala/uk/ac/wellcome/platform/ingestor/services/IdentifiedWorkIndexerTest.scala
@@ -38,7 +38,7 @@ class IdentifiedWorkIndexerTest
         IdentifiedWork(
           canonicalId = canonicalId,
           work = Work(identifiers =
-                        List(SourceIdentifier("Miro", "MiroID", sourceId)),
+                        List(SourceIdentifier("test-miro-image-number", sourceId)),
                       title = title)))
       .get
   }

--- a/ingestor/src/test/scala/uk/ac/wellcome/platform/ingestor/services/IdentifiedWorkIndexerTest.scala
+++ b/ingestor/src/test/scala/uk/ac/wellcome/platform/ingestor/services/IdentifiedWorkIndexerTest.scala
@@ -6,6 +6,7 @@ import com.sksamuel.elastic4s.http.ElasticDsl._
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.mockito.MockitoSugar
 import org.scalatest.{FunSpec, Matchers}
+import uk.ac.wellcome.finatra.modules.IdentifierSchemes
 import uk.ac.wellcome.metrics.MetricsSender
 import uk.ac.wellcome.models.{IdentifiedWork, SourceIdentifier, Work}
 import uk.ac.wellcome.test.utils.IndexedElasticSearchLocal
@@ -38,7 +39,7 @@ class IdentifiedWorkIndexerTest
         IdentifiedWork(
           canonicalId = canonicalId,
           work = Work(identifiers =
-                        List(SourceIdentifier("test-miro-image-number", sourceId)),
+                        List(SourceIdentifier(IdentifierSchemes.miroImageNumber, sourceId)),
                       title = title)))
       .get
   }

--- a/transformer/src/test/scala/uk/ac/wellcome/transformer/CalmTransformerFeatureTest.scala
+++ b/transformer/src/test/scala/uk/ac/wellcome/transformer/CalmTransformerFeatureTest.scala
@@ -7,7 +7,7 @@ import uk.ac.wellcome.test.utils.MessageInfo
 import uk.ac.wellcome.transformer.utils.TransformerFeatureTest
 import uk.ac.wellcome.utils.JsonUtil
 
-class  CalmTransformerFeatureTest
+class CalmTransformerFeatureTest
     extends FunSpec
     with TransformerFeatureTest
     with Matchers {
@@ -71,7 +71,7 @@ class  CalmTransformerFeatureTest
     snsMessage.message shouldBe JsonUtil
       .toJson(
         Work(
-          identifiers = List(SourceIdentifier("source", "key", "value")),
+          identifiers = List(SourceIdentifier("calm-placeholder-scheme", "value")),
           title = "placeholder title for a Calm record"
         ))
       .get

--- a/transformer/src/test/scala/uk/ac/wellcome/transformer/receive/SQSMessageReceiverTest.scala
+++ b/transformer/src/test/scala/uk/ac/wellcome/transformer/receive/SQSMessageReceiverTest.scala
@@ -47,7 +47,7 @@ class SQSMessageReceiverTest
     createValidMiroSQSMessage("""{}""")
 
   val work = Work(identifiers =
-                    List(SourceIdentifier("source", "key", "value")),
+                    List(SourceIdentifier("calm-placeholder-scheme", "value")),
                   title = "placeholder title for a Calm record")
 
   val metricsSender: MetricsSender = new MetricsSender(


### PR DESCRIPTION
### What is this PR trying to achieve?

Move our identifiers to use the model defined in the latest examples:

```json
{
    "type": "Identifier",
    "identifierScheme": "miro-image-number",
    "value": "V0000001"
}
```

I went with `miro-image-number` as the string, because I couldn’t think of anything better.

We need to be careful about promoting this to prod – it might break the Collection site’s image lookup (although I think they just use the `value` field, so maybe not?).

Fixes #334, fixes #338.

### Who is this change for?

A Platform team who want an up-to-date API.

### Have the following been considered/are they needed?

- [x] Reviewed by @jtweed
- [x] Updated the JSON-LD context – not required
- [ ] Deployed new versions