### PR TITLE
Improve the 🚨 ALARMS 🚨 that appear in Slack

### DIFF
--- a/lambdas/post_to_slack/post_to_slack.py
+++ b/lambdas/post_to_slack/post_to_slack.py
@@ -13,6 +13,22 @@ from urllib.parse import quote
 from botocore.vendored import requests
 
 
+# Alarm reasons are sometimes of the form:
+#
+#     Threshold Crossed: 1 datapoint [1.0 (11/08/18 10:55:00)] was
+#     greater than or equal to the threshold (1.0).
+#
+# This regex is meant to match the datapoint in square brackets.
+DATAPOINT_RE = re.compile(r'''
+    \[
+      (?P<value>[0-9.]+)\s
+      \(
+        (?P<timestamp>[0-9]{2}/[0-9]{2}/[0-9]{2}\s[0-9]{2}:[0-9]{2}:[0-9]{2})
+      \)
+    \]
+''', flags=re.VERBOSE)
+
+
 class Alarm:
     def __init__(self, json_message):
         self.message = json.loads(json_message)
@@ -41,22 +57,39 @@ class Alarm:
     def state_change_time(self):
         return self.message['StateChangeTime']
 
+    def human_reason(self):
+        """
+        Try to return a more human-readable explanation for the alarm.
+        """
+        match = DATAPOINT_RE.search(self.state_reason)
+        if match is None:
+            return
+
+        value = int(float(match.group('value')))
+
+        timestamp = match.group('timestamp')
+        time = dt.datetime.strptime(timestamp, '%d/%m/%y %H:%M:%S')
+        display_time = time.strftime('at %H:%M:%S on %d %b %Y')
+
+        if self.name.endswith('-alb-target-500-errors'):
+            if self.name.startswith('loris'):
+                service = 'Loris'
+            elif self.name.startswith('api_'):
+                service = 'the API'
+            else:
+                return
+
+            if value == 1:
+                return f'The ALB spotted a 500 error in {service} {display_time}.'
+            else:
+                return f'The ALB spotted multiple 500 errors ({value}) in {service} {display_time}.'
+
     def cloudwatch_url(self):
         """
         Sometimes there's enough data in the alarm to make an educated guess
         about useful CloudWatch logs to check.  This method tries to do that.
         """
-        # We can get the time from the datapoint in the reason, which is
-        # typically of the form
-        #
-        #     Threshold Crossed: 1 datapoint [1.0 (11/08/18 10:55:00)] was
-        #     greater than or equal to the threshold (1.0).
-        #
-        # So try to get the timestamp.
-        match = re.search(
-            r'\[(?P<datapoint>[0-9.]+) \((?P<timestamp>[0-9]{2}/[0-9]{2}/[0-9]{2} [0-9]{2}:[0-9]{2}:[0-9]{2})\)\]',
-            self.state_reason
-        )
+        match = DATAPOINT_RE.search(self.state_reason)
         if match is None:
             return
 
@@ -108,7 +141,7 @@ def main(event, _):
                       "fields": [
                           {
                               "title": "Reason",
-                              "value": alarm.state_reason
+                              "value": alarm.human_reason() or alarm.state_reason
                           },
                       ]
                   }]}

--- a/lambdas/post_to_slack/post_to_slack.py
+++ b/lambdas/post_to_slack/post_to_slack.py
@@ -73,6 +73,12 @@ def guess_cloudwatch_url(alarm):
         lambda_name = alarm.name.split('-')[1]
         group = f'/aws/lambda/{lambda_name}'
         search_term = 'Traceback'
+    elif alarm.name == 'api_romulus-alb-target-500-errors':
+        group = 'platform/api_romulus'
+        search_term = 'Unhandled Exception'
+    elif alarm.name == 'api_remus-alb-target-500-errors':
+        group = 'platform/api_remus'
+        search_term = 'Unhandled Exception'
     else:
         return
 

--- a/lambdas/post_to_slack/post_to_slack.py
+++ b/lambdas/post_to_slack/post_to_slack.py
@@ -107,10 +107,6 @@ def main(event, _):
                       "title": alarm.name,
                       "fields": [
                           {
-                              "title": "Metric",
-                              "value": f"{alarm.namespace}/{alarm.metric_name}"
-                          },
-                          {
                               "title": "Reason",
                               "value": alarm.state_reason
                           },

--- a/lambdas/post_to_slack/post_to_slack.py
+++ b/lambdas/post_to_slack/post_to_slack.py
@@ -41,59 +41,58 @@ class Alarm:
     def state_change_time(self):
         return self.message['StateChangeTime']
 
+    def cloudwatch_url(self):
+        """
+        Sometimes there's enough data in the alarm to make an educated guess
+        about useful CloudWatch logs to check.  This method tries to do that.
+        """
+        # We can get the time from the datapoint in the reason, which is
+        # typically of the form
+        #
+        #     Threshold Crossed: 1 datapoint [1.0 (11/08/18 10:55:00)] was
+        #     greater than or equal to the threshold (1.0).
+        #
+        # So try to get the timestamp.
+        match = re.search(
+            r'\[(?P<datapoint>[0-9.]+) \((?P<timestamp>[0-9]{2}/[0-9]{2}/[0-9]{2} [0-9]{2}:[0-9]{2}:[0-9]{2})\)\]',
+            self.state_reason
+        )
+        if match is None:
+            return
 
-def guess_cloudwatch_url(alarm):
-    """
-    Sometimes there's enough data in the alarm to make an educated guess
-    about useful CloudWatch logs to check.  This function tries to do that.
-    """
-    # We can get the time from the datapoint in the reason, which is
-    # typically of the form
-    #
-    #     Threshold Crossed: 1 datapoint [1.0 (11/08/18 10:55:00)] was
-    #     greater than or equal to the threshold (1.0).
-    #
-    # So try to get the timestamp.
-    match = re.search(
-        r'\[(?P<datapoint>[0-9.]+) \((?P<timestamp>[0-9]{2}/[0-9]{2}/[0-9]{2} [0-9]{2}:[0-9]{2}:[0-9]{2})\)\]',
-        alarm.state_reason
-    )
-    if match is None:
-        return
+        timestamp = match.group('timestamp')
+        time = dt.datetime.strptime(timestamp, '%d/%m/%y %H:%M:%S')
+        start = time - dt.timedelta(seconds=300)
+        end = time + dt.timedelta(seconds=300)
 
-    timestamp = match.group('timestamp')
-    time = dt.datetime.strptime(timestamp, '%d/%m/%y %H:%M:%S')
-    start = time - dt.timedelta(seconds=300)
-    end = time + dt.timedelta(seconds=300)
+        if self.name == 'loris-alb-target-500-errors':
+            group = 'platform/loris'
+            search_term = '"HTTP/1.0 500"'
+        elif self.name.startswith('lambda'):
+            lambda_name = alarm.name.split('-')[1]
+            group = f'/aws/lambda/{lambda_name}'
+            search_term = 'Traceback'
+        elif self.name == 'api_romulus-alb-target-500-errors':
+            group = 'platform/api_romulus'
+            search_term = 'Unhandled Exception'
+        elif self.name == 'api_remus-alb-target-500-errors':
+            group = 'platform/api_remus'
+            search_term = 'Unhandled Exception'
+        else:
+            return
 
-    if alarm.name == 'loris-alb-target-500-errors':
-        group = 'platform/loris'
-        search_term = '"HTTP/1.0 500"'
-    elif alarm.name.startswith('lambda'):
-        lambda_name = alarm.name.split('-')[1]
-        group = f'/aws/lambda/{lambda_name}'
-        search_term = 'Traceback'
-    elif alarm.name == 'api_romulus-alb-target-500-errors':
-        group = 'platform/api_romulus'
-        search_term = 'Unhandled Exception'
-    elif alarm.name == 'api_remus-alb-target-500-errors':
-        group = 'platform/api_remus'
-        search_term = 'Unhandled Exception'
-    else:
-        return
+        return (
+            'https://eu-west-1.console.aws.amazon.com/cloudwatch/home'
+            '?region=eu-west-1'
+            f'#logEventViewer:group={group};'
 
-    return (
-        'https://eu-west-1.console.aws.amazon.com/cloudwatch/home'
-        '?region=eu-west-1'
-        f'#logEventViewer:group={group};'
+            # Look for strings matching 'HTTP/1.0 500'
+            f'filter={quote(search_term)};'
 
-        # Look for strings matching 'HTTP/1.0 500'
-        f'filter={quote(search_term)};'
-
-        # And add the date parameters to filter to the exact time
-        f'start={start.strftime("%Y-%m-%dT%H:%M:%SZ")};'
-        f'end={end.strftime("%Y-%m-%dT%H:%M:%SZ")};'
-    )
+            # And add the date parameters to filter to the exact time
+            f'start={start.strftime("%Y-%m-%dT%H:%M:%SZ")};'
+            f'end={end.strftime("%Y-%m-%dT%H:%M:%SZ")};'
+        )
 
 
 def main(event, _):
@@ -118,7 +117,7 @@ def main(event, _):
                       ]
                   }]}
 
-    cloudwatch_url = guess_cloudwatch_url(alarm)
+    cloudwatch_url = alarm.cloudwatch_url()
     if cloudwatch_url is not None:
         slack_data['attachments'][0]['fields'].append({
             'title': 'CloudWatch URL',

--- a/lambdas/post_to_slack/post_to_slack.py
+++ b/lambdas/post_to_slack/post_to_slack.py
@@ -100,7 +100,7 @@ def main(event, _):
     alarm = Alarm(event['Records'][0]['Sns']['Message'])
 
     slack_data = {'username': 'cloudwatch-alert',
-                  "icon_emoji": ":slack:",
+                  "icon_emoji": ":rotating_light:",
                   "attachments": [{
                       'color': 'danger',
                       'fallback': alarm.name,

--- a/lambdas/post_to_slack/post_to_slack.py
+++ b/lambdas/post_to_slack/post_to_slack.py
@@ -4,8 +4,11 @@
 Sends slack notifications for alarms events
 """
 
+import datetime as dt
 import json
 import os
+import re
+from urllib.parse import quote
 
 from botocore.vendored import requests
 
@@ -39,6 +42,54 @@ class Alarm:
         return self.message['StateChangeTime']
 
 
+def guess_cloudwatch_url(alarm):
+    """
+    Sometimes there's enough data in the alarm to make an educated guess
+    about useful CloudWatch logs to check.  This function tries to do that.
+    """
+    # We can get the time from the datapoint in the reason, which is
+    # typically of the form
+    #
+    #     Threshold Crossed: 1 datapoint [1.0 (11/08/18 10:55:00)] was
+    #     greater than or equal to the threshold (1.0).
+    #
+    # So try to get the timestamp.
+    match = re.search(
+        r'\[(?P<datapoint>[0-9.]+) \((?P<timestamp>[0-9]{2}/[0-9]{2}/[0-9]{2} [0-9]{2}:[0-9]{2}:[0-9]{2})\)\]',
+        alarm.state_reason
+    )
+    if match is None:
+        return
+
+    timestamp = match.group('timestamp')
+    time = dt.datetime.strptime(timestamp, '%d/%m/%y %H:%M:%S')
+    start = time - dt.timedelta(seconds=300)
+    end = time + dt.timedelta(seconds=300)
+
+    if alarm.name == 'loris-alb-target-500-errors':
+        group = 'platform/loris'
+        search_term = '"HTTP/1.0 500"'
+    elif alarm.name.startswith('lambda'):
+        lambda_name = alarm.name.split('-')[1]
+        group = f'/aws/lambda/{lambda_name}'
+        search_term = 'Traceback'
+    else:
+        return
+
+    return (
+        'https://eu-west-1.console.aws.amazon.com/cloudwatch/home'
+        '?region=eu-west-1'
+        f'#logEventViewer:group={group};'
+
+        # Look for strings matching 'HTTP/1.0 500'
+        f'filter={quote(search_term)};'
+
+        # And add the date parameters to filter to the exact time
+        f'start={start.strftime("%Y-%m-%dT%H:%M:%SZ")};'
+        f'end={end.strftime("%Y-%m-%dT%H:%M:%SZ")};'
+    )
+
+
 def main(event, _):
     print(f'event = {event!r}')
     alarm = Alarm(event['Records'][0]['Sns']['Message'])
@@ -68,6 +119,13 @@ def main(event, _):
                           }
                       ]
                   }]}
+
+    cloudwatch_url = guess_cloudwatch_url(alarm)
+    if cloudwatch_url is not None:
+        slack_data['attachments'][0]['fields'].append({
+            'title': 'CloudWatch URL',
+            'value': cloudwatch_url
+        })
 
     response = requests.post(
         os.environ["SLACK_INCOMING_WEBHOOK"],

--- a/lambdas/post_to_slack/post_to_slack.py
+++ b/lambdas/post_to_slack/post_to_slack.py
@@ -112,17 +112,9 @@ def main(event, _):
                               "value": f"{alarm.namespace}/{alarm.metric_name}"
                           },
                           {
-                              "title": "Dimensions",
-                              "value": repr(alarm.dimensions)
-                          },
-                          {
                               "title": "Reason",
                               "value": alarm.state_reason
                           },
-                          {
-                              "title": "Timestamp",
-                              "value": alarm.state_change_time
-                          }
                       ]
                   }]}
 


### PR DESCRIPTION
### What is this PR trying to achieve?

This makes some improvements to our CloudWatch alerts in Slack to make them more useful and human-friendly.

* Try to write a human-friendly reason in-place of the opaque messages we get from AWS
* Try to suggest a CloudWatch URL for digging into the error
* Drop some fields that I didn’t think were very useful
* Take up less vertical space in Slack
* Use a 🚨 icon for extra ALARMINGNESS

Before:

![screen shot 2017-08-11 at 14 27 17](https://user-images.githubusercontent.com/301220/29215060-72c5c350-7ea1-11e7-9bf4-ca0f52643e98.png)

After:

![screen shot 2017-08-11 at 14 29 05](https://user-images.githubusercontent.com/301220/29215062-764e9f24-7ea1-11e7-9bf5-27f13319eeb4.png)

Resolves #746.

### Who is this change for?

People who want more compact and more helpful error messages.

### Have the following been considered/are they needed?

- [ ] Deployed new versions
