### PR TITLE
[WIP] Reduce boilerplate in the MiroTransformable tests

### DIFF
--- a/common/src/test/scala/uk/ac/wellcome/models/MiroTransformableTest.scala
+++ b/common/src/test/scala/uk/ac/wellcome/models/MiroTransformableTest.scala
@@ -3,6 +3,7 @@ package uk.ac.wellcome.models
 import org.scalatest.{FunSpec, Matchers}
 
 import uk.ac.wellcome.finatra.modules.IdentifierSchemes
+import uk.ac.wellcome.test.utils.MiroTransformableWrapper
 
 
 /** Tests that the Miro transformer extracts the "title" field correctly.
@@ -10,7 +11,10 @@ import uk.ac.wellcome.finatra.modules.IdentifierSchemes
  *  The rules around this heuristic are somewhat fiddly, and we need to be
  *  careful that we're extracting the right fields from the Miro metadata.
  */
-class MiroTransformableTitleTest extends FunSpec with Matchers {
+class MiroTransformableTitleTest
+    extends FunSpec
+    with Matchers
+    with MiroTransformableWrapper {
 
   it("should use the image_title field on non-V records") {
     val title = "A picture of a parrot"
@@ -157,24 +161,22 @@ class MiroTransformableTitleTest extends FunSpec with Matchers {
     expectedDescription: Option[String] = None,
     miroCollection: String = "TestCollection"
   ) = {
-    val miroTransformable = MiroTransformable(
-      MiroID = "M0000001",
+    val transformedWork = transformWork(
       MiroCollection = miroCollection,
-      data = s"""{
-        "image_cleared": "Y",
-        "image_copyright_cleared": "Y",
-        $data
-      }"""
+      data = data
     )
 
-    miroTransformable.transform.isSuccess shouldBe true
-    miroTransformable.transform.get.title shouldBe expectedTitle
-    miroTransformable.transform.get.description shouldBe expectedDescription
+    transformedWork.isSuccess shouldBe true
+    transformedWork.get.title shouldBe expectedTitle
+    transformedWork.get.description shouldBe expectedDescription
   }
 }
 
 
-class MiroTransformableTest extends FunSpec with Matchers {
+class MiroTransformableTest
+    extends FunSpec
+    with Matchers
+    with MiroTransformableWrapper {
 
   it("should throw an error if there isn't a title field") {
     assertTransformMiroRecordFails(data = """{
@@ -190,33 +192,25 @@ class MiroTransformableTest extends FunSpec with Matchers {
   }
 
   it("should have an empty list if no image_creator field is present") {
-    val work = transformMiroRecord(data = s"""{
-      "image_title": "A guide to giraffes",
-      "image_cleared": "Y",
-      "image_copyright_cleared": "Y"
-    }""")
+    val work = transformMiroRecord(data = s""""image_title": "A guide to giraffes"""")
     work.creators shouldBe List[Agent]()
   }
 
   it("should have an empty list if the image_creator field is empty") {
-    val work = transformMiroRecord(data = s"""{
+    val work = transformMiroRecord(data = s"""
       "image_title": "A box of beavers",
-      "image_creator": [],
-      "image_cleared": "Y",
-      "image_copyright_cleared": "Y"
-    }""")
+      "image_creator": []
+    """)
     work.creators shouldBe List[Agent]()
   }
 
   it("should pass through a single value in the image_creator field") {
     val creator = "Researcher Rosie"
     val work = transformMiroRecord(
-      data = s"""{
+      data = s"""
         "image_title": "A radio for a racoon",
-        "image_creator": ["$creator"],
-        "image_cleared": "Y",
-        "image_copyright_cleared": "Y"
-      }"""
+        "image_creator": ["$creator"]
+      """
     )
     work.creators shouldBe List(Agent(creator))
   }
@@ -226,12 +220,10 @@ class MiroTransformableTest extends FunSpec with Matchers {
     val creator2 = "Cat-wrangler Carol"
     val creator3 = "Dog-owner Derek"
     val work = transformMiroRecord(
-      data = s"""{
+      data = s"""
         "image_title": "A book about badgers",
-        "image_creator": ["$creator1", "$creator2", "$creator3"],
-        "image_cleared": "Y",
-        "image_copyright_cleared": "Y"
-      }"""
+        "image_creator": ["$creator1", "$creator2", "$creator3"]
+      """
     )
     work.creators shouldBe List(Agent(creator1),
                                 Agent(creator2),
@@ -239,23 +231,17 @@ class MiroTransformableTest extends FunSpec with Matchers {
   }
 
   it("should have no description if no image_image_desc field is present") {
-    val work = transformMiroRecord(data = s"""{
-      "image_title": "A line of lions",
-      "image_cleared": "Y",
-      "image_copyright_cleared": "Y"
-    }""")
+    val work = transformMiroRecord(data = s""""image_title": "A line of lions"""")
     work.description shouldBe None
   }
 
   it("should pass through the value of the description field") {
     val description = "A new novel about northern narwhals in November"
     val work = transformMiroRecord(
-      data = s"""{
+      data = s"""
         "image_title": "A note on narwhals",
-        "image_image_desc": "$description",
-        "image_cleared": "Y",
-        "image_copyright_cleared": "Y"
-      }"""
+        "image_image_desc": "$description"
+      """
     )
     work.description shouldBe Some(description)
   }
@@ -263,13 +249,11 @@ class MiroTransformableTest extends FunSpec with Matchers {
   it("should pass through the value of the creation date on V records") {
     val date = "1820-1848"
     val work = transformMiroRecord(
-      data = s"""{
+      data = s"""
         "image_title": "A description of a dalmation",
         "image_image_desc": "A description of a dalmation with dots",
-        "image_artwork_date": "$date",
-        "image_cleared": "Y",
-        "image_copyright_cleared": "Y"
-      }""",
+        "image_artwork_date": "$date"
+      """,
       miroCollection = "Images-V"
     )
     work.createdDate shouldBe Some(Period(date))
@@ -278,12 +262,10 @@ class MiroTransformableTest extends FunSpec with Matchers {
   it("should not pass through the value of the creation date on non-V records") {
     val date = "1820-1848"
     val work = transformMiroRecord(
-      data = s"""{
+      data = s"""
         "image_title": "A diary about a dodo",
-        "image_artwork_date": "$date",
-        "image_cleared": "Y",
-        "image_copyright_cleared": "Y"
-      }""",
+        "image_artwork_date": "$date"
+      """,
       miroCollection = "Images-A"
     )
     work.createdDate shouldBe None
@@ -293,12 +275,10 @@ class MiroTransformableTest extends FunSpec with Matchers {
     "should use the image_creator_secondary field if image_creator is not present") {
     val secondaryCreator = "Scientist Sarah"
     val work = transformMiroRecord(
-      data = s"""{
+      data = s"""
         "image_title": "Samples of a shark",
-        "image_secondary_creator": ["$secondaryCreator"],
-        "image_cleared": "Y",
-        "image_copyright_cleared": "Y"
-      }"""
+        "image_secondary_creator": ["$secondaryCreator"]
+      """
     )
     work.creators shouldBe List(Agent(secondaryCreator))
   }
@@ -308,12 +288,10 @@ class MiroTransformableTest extends FunSpec with Matchers {
     val secondaryCreator1 = "Gamekeeper Gordon"
     val secondaryCreator2 = "Herpetologist Harriet"
     val work = transformMiroRecord(
-      data = s"""{
+      data = s"""
         "image_title": "Verdant and vivid",
-        "image_secondary_creator": ["$secondaryCreator1", "$secondaryCreator2"],
-        "image_cleared": "Y",
-        "image_copyright_cleared": "Y"
-      }"""
+        "image_secondary_creator": ["$secondaryCreator1", "$secondaryCreator2"]
+      """
     )
     work.creators shouldBe List(Agent(secondaryCreator1),
                                 Agent(secondaryCreator2))
@@ -324,13 +302,11 @@ class MiroTransformableTest extends FunSpec with Matchers {
     val creator = "Mycologist Morgan"
     val secondaryCreator = "Manufacturer Mel"
     val work = transformMiroRecord(
-      data = s"""{
+      data = s"""
         "image_title": "Musings on mice",
         "image_creator": ["$creator"],
-        "image_secondary_creator": ["$secondaryCreator"],
-        "image_cleared": "Y",
-        "image_copyright_cleared": "Y"
-      }"""
+        "image_secondary_creator": ["$secondaryCreator"]
+      """
     )
     work.creators shouldBe List(Agent(creator), Agent(secondaryCreator))
   }
@@ -338,12 +314,10 @@ class MiroTransformableTest extends FunSpec with Matchers {
   it(
     "should correct HTML-encoded entities in the input JSON") {
     val work = transformMiroRecord(
-      data = s"""{
+      data = s"""
         "image_title": "A caf&#233; for cats",
-        "image_creator": ["Gyokush&#333;, a c&#228;t &#212;wn&#234;r"],
-        "image_cleared": "Y",
-        "image_copyright_cleared": "Y"
-      }"""
+        "image_creator": ["Gyokush&#333;, a c&#228;t &#212;wn&#234;r"]
+      """
     )
 
     work.title shouldBe "A café for cats"
@@ -409,22 +383,18 @@ class MiroTransformableTest extends FunSpec with Matchers {
   }
 
   private def transformMiroRecord(
+    data: String = "",
     miroID: String = "M0000001",
-    miroCollection: String = "TestCollection",
-    data: String = """{
-      "image_title": "A test tome telling tales about a tapir",
-      "image_cleared": "Y",
-      "image_copyright_cleared": "Y"
-    }"""
+    miroCollection: String = "TestCollection"
   ): Work = {
-    val miroTransformable = MiroTransformable(
+    val transformedWork = transformWork(
       MiroID = miroID,
       MiroCollection = miroCollection,
       data = data
     )
 
-    miroTransformable.transform.isSuccess shouldBe true
-    miroTransformable.transform.get
+    transformedWork.isSuccess shouldBe true
+    transformedWork.get
   }
 }
 
@@ -436,7 +406,10 @@ class MiroTransformableTest extends FunSpec with Matchers {
  *  from Miro will need cleaning before it's presented in the API (casing,
  *  names, etc.) -- these tests will become more complicated.
  */
-class MiroTransformableSubjectsTest extends FunSpec with Matchers {
+class MiroTransformableSubjectsTest
+    extends FunSpec
+    with Matchers
+    with MiroTransformableWrapper {
 
   it("should have an empty subject list on records without keywords") {
     transformRecordAndCheckSubjects(
@@ -486,24 +459,19 @@ class MiroTransformableSubjectsTest extends FunSpec with Matchers {
     data: String,
     expectedSubjects: List[Concept] = List()
   ) = {
-    val miroTransformable = MiroTransformable(
-      MiroID = "M0000001",
-      MiroCollection = "Images-V",
-      data = s"""{
-        "image_cleared": "Y",
-        "image_copyright_cleared": "Y",
-        $data
-      }"""
-    )
+    val transformedWork = transformWork(data = data)
 
-    miroTransformable.transform.isSuccess shouldBe true
-    miroTransformable.transform.get.subjects shouldBe expectedSubjects
+    transformedWork.isSuccess shouldBe true
+    transformedWork.get.subjects shouldBe expectedSubjects
   }
 }
 
 
 
-class MiroTransformableGenresTest extends FunSpec with Matchers {
+class MiroTransformableGenresTest
+    extends FunSpec
+    with Matchers
+    with MiroTransformableWrapper {
 
   it("should have an empty genre list on records without keywords") {
     transformRecordAndCheckGenres(
@@ -553,17 +521,9 @@ class MiroTransformableGenresTest extends FunSpec with Matchers {
     data: String,
     expectedGenres: List[Concept] = List()
   ) = {
-    val miroTransformable = MiroTransformable(
-      MiroID = "M0000001",
-      MiroCollection = "Images-V",
-      data = s"""{
-        "image_cleared": "Y",
-        "image_copyright_cleared": "Y",
-        $data
-      }"""
-    )
+    val transformedWork = transformWork(data = data)
 
-    miroTransformable.transform.isSuccess shouldBe true
-    miroTransformable.transform.get.genres shouldBe expectedGenres
+    transformedWork.isSuccess shouldBe true
+    transformedWork.get.genres shouldBe expectedGenres
   }
 }

--- a/common/src/test/scala/uk/ac/wellcome/models/MiroTransformableTest.scala
+++ b/common/src/test/scala/uk/ac/wellcome/models/MiroTransformableTest.scala
@@ -185,12 +185,12 @@ class MiroTransformableTest
   }
 
   it("should pass through the Miro identifier") {
-    val miroID = "M0000005_test"
+    val MiroID = "M0000005_test"
     val work = transformWork(
       data = """"image_title": "A picture of a passing porpoise"""",
-      miroID = miroID
+      MiroID = MiroID
     )
-    work.identifiers shouldBe List(SourceIdentifier(IdentifierSchemes.miroImageNumber, miroID))
+    work.identifiers shouldBe List(SourceIdentifier(IdentifierSchemes.miroImageNumber, MiroID))
   }
 
   it("should have an empty list if no image_creator field is present") {
@@ -256,7 +256,7 @@ class MiroTransformableTest
         "image_image_desc": "A description of a dalmation with dots",
         "image_artwork_date": "$date"
       """,
-      miroCollection = "Images-V"
+      MiroCollection = "Images-V"
     )
     work.createdDate shouldBe Some(Period(date))
   }
@@ -268,7 +268,7 @@ class MiroTransformableTest
         "image_title": "A diary about a dodo",
         "image_artwork_date": "$date"
       """,
-      miroCollection = "Images-A"
+      MiroCollection = "Images-A"
     )
     work.createdDate shouldBe None
   }

--- a/common/src/test/scala/uk/ac/wellcome/models/MiroTransformableTest.scala
+++ b/common/src/test/scala/uk/ac/wellcome/models/MiroTransformableTest.scala
@@ -166,9 +166,8 @@ class MiroTransformableTitleTest
       data = data
     )
 
-    transformedWork.isSuccess shouldBe true
-    transformedWork.get.title shouldBe expectedTitle
-    transformedWork.get.description shouldBe expectedDescription
+    transformedWork.title shouldBe expectedTitle
+    transformedWork.description shouldBe expectedDescription
   }
 }
 
@@ -187,7 +186,7 @@ class MiroTransformableTest
 
   it("should pass through the Miro identifier") {
     val miroID = "M0000005_test"
-    val work = transformMiroRecord(
+    val work = transformWork(
       data = """"image_title": "A picture of a passing porpoise"""",
       miroID = miroID
     )
@@ -195,12 +194,12 @@ class MiroTransformableTest
   }
 
   it("should have an empty list if no image_creator field is present") {
-    val work = transformMiroRecord(data = s""""image_title": "A guide to giraffes"""")
+    val work = transformWork(data = s""""image_title": "A guide to giraffes"""")
     work.creators shouldBe List[Agent]()
   }
 
   it("should have an empty list if the image_creator field is empty") {
-    val work = transformMiroRecord(data = s"""
+    val work = transformWork(data = s"""
       "image_title": "A box of beavers",
       "image_creator": []
     """)
@@ -209,7 +208,7 @@ class MiroTransformableTest
 
   it("should pass through a single value in the image_creator field") {
     val creator = "Researcher Rosie"
-    val work = transformMiroRecord(
+    val work = transformWork(
       data = s"""
         "image_title": "A radio for a racoon",
         "image_creator": ["$creator"]
@@ -222,7 +221,7 @@ class MiroTransformableTest
     val creator1 = "Beekeeper Brian"
     val creator2 = "Cat-wrangler Carol"
     val creator3 = "Dog-owner Derek"
-    val work = transformMiroRecord(
+    val work = transformWork(
       data = s"""
         "image_title": "A book about badgers",
         "image_creator": ["$creator1", "$creator2", "$creator3"]
@@ -234,13 +233,13 @@ class MiroTransformableTest
   }
 
   it("should have no description if no image_image_desc field is present") {
-    val work = transformMiroRecord(data = s""""image_title": "A line of lions"""")
+    val work = transformWork(data = s""""image_title": "A line of lions"""")
     work.description shouldBe None
   }
 
   it("should pass through the value of the description field") {
     val description = "A new novel about northern narwhals in November"
-    val work = transformMiroRecord(
+    val work = transformWork(
       data = s"""
         "image_title": "A note on narwhals",
         "image_image_desc": "$description"
@@ -251,7 +250,7 @@ class MiroTransformableTest
 
   it("should pass through the value of the creation date on V records") {
     val date = "1820-1848"
-    val work = transformMiroRecord(
+    val work = transformWork(
       data = s"""
         "image_title": "A description of a dalmation",
         "image_image_desc": "A description of a dalmation with dots",
@@ -264,7 +263,7 @@ class MiroTransformableTest
 
   it("should not pass through the value of the creation date on non-V records") {
     val date = "1820-1848"
-    val work = transformMiroRecord(
+    val work = transformWork(
       data = s"""
         "image_title": "A diary about a dodo",
         "image_artwork_date": "$date"
@@ -277,7 +276,7 @@ class MiroTransformableTest
   it(
     "should use the image_creator_secondary field if image_creator is not present") {
     val secondaryCreator = "Scientist Sarah"
-    val work = transformMiroRecord(
+    val work = transformWork(
       data = s"""
         "image_title": "Samples of a shark",
         "image_secondary_creator": ["$secondaryCreator"]
@@ -290,7 +289,7 @@ class MiroTransformableTest
     "should use all the values in the image_creator_secondary field if image_creator is not present") {
     val secondaryCreator1 = "Gamekeeper Gordon"
     val secondaryCreator2 = "Herpetologist Harriet"
-    val work = transformMiroRecord(
+    val work = transformWork(
       data = s"""
         "image_title": "Verdant and vivid",
         "image_secondary_creator": ["$secondaryCreator1", "$secondaryCreator2"]
@@ -304,7 +303,7 @@ class MiroTransformableTest
     "should combine the values in the image_creator and image_secondary_creator fields if both present") {
     val creator = "Mycologist Morgan"
     val secondaryCreator = "Manufacturer Mel"
-    val work = transformMiroRecord(
+    val work = transformWork(
       data = s"""
         "image_title": "Musings on mice",
         "image_creator": ["$creator"],
@@ -316,7 +315,7 @@ class MiroTransformableTest
 
   it(
     "should correct HTML-encoded entities in the input JSON") {
-    val work = transformMiroRecord(
+    val work = transformWork(
       data = s"""
         "image_title": "A caf&#233; for cats",
         "image_creator": ["Gyokush&#333;, a c&#228;t &#212;wn&#234;r"]
@@ -372,9 +371,9 @@ class MiroTransformableTest
   }
 
   private def assertTransformMiroRecordFails(
+    data: String = """{"image_title": "A failed fumble in the fire"}""",
     miroID: String = "M0000001",
-    miroCollection: String = "TestCollection",
-    data: String = """{"image_title": "A failed fumble in the fire"}"""
+    miroCollection: String = "TestCollection"
   ) = {
     val miroTransformable = MiroTransformable(
       MiroID = miroID,
@@ -383,21 +382,6 @@ class MiroTransformableTest
     )
 
     miroTransformable.transform.isSuccess shouldBe false
-  }
-
-  private def transformMiroRecord(
-    data: String = "",
-    miroID: String = "M0000001",
-    miroCollection: String = "TestCollection"
-  ): Work = {
-    val transformedWork = transformWork(
-      MiroID = miroID,
-      MiroCollection = miroCollection,
-      data = data
-    )
-
-    transformedWork.isSuccess shouldBe true
-    transformedWork.get
   }
 }
 
@@ -463,9 +447,7 @@ class MiroTransformableSubjectsTest
     expectedSubjects: List[Concept] = List()
   ) = {
     val transformedWork = transformWork(data = data)
-
-    transformedWork.isSuccess shouldBe true
-    transformedWork.get.subjects shouldBe expectedSubjects
+    transformedWork.subjects shouldBe expectedSubjects
   }
 }
 
@@ -525,8 +507,6 @@ class MiroTransformableGenresTest
     expectedGenres: List[Concept] = List()
   ) = {
     val transformedWork = transformWork(data = data)
-
-    transformedWork.isSuccess shouldBe true
-    transformedWork.get.genres shouldBe expectedGenres
+    transformedWork.genres shouldBe expectedGenres
   }
 }

--- a/common/src/test/scala/uk/ac/wellcome/models/MiroTransformableTest.scala
+++ b/common/src/test/scala/uk/ac/wellcome/models/MiroTransformableTest.scala
@@ -187,7 +187,10 @@ class MiroTransformableTest
 
   it("should pass through the Miro identifier") {
     val miroID = "M0000005_test"
-    val work = transformMiroRecord(miroID = miroID)
+    val work = transformMiroRecord(
+      data = """"image_title": "A picture of a passing porpoise"""",
+      miroID = miroID
+    )
     work.identifiers shouldBe List(SourceIdentifier(IdentifierSchemes.miroImageNumber, miroID))
   }
 

--- a/common/src/test/scala/uk/ac/wellcome/test/utils/MiroTransformableWrapper.scala
+++ b/common/src/test/scala/uk/ac/wellcome/test/utils/MiroTransformableWrapper.scala
@@ -1,5 +1,8 @@
 package uk.ac.wellcome.test.utils
 
+import org.scalatest.Suite
+import scala.util.Try
+
 import uk.ac.wellcome.models.{MiroTransformable, Work}
 
 /** MiroTransformable looks for several fields in the source JSON -- if they're
@@ -11,7 +14,7 @@ import uk.ac.wellcome.models.{MiroTransformable, Work}
  */
 trait MiroTransformableWrapper { this: Suite =>
 
-  def transformRecord(
+  def transformWork(
     data: String,
     MiroID: String = "M0000001",
     MiroCollection: String = "TestCollection"

--- a/common/src/test/scala/uk/ac/wellcome/test/utils/MiroTransformableWrapper.scala
+++ b/common/src/test/scala/uk/ac/wellcome/test/utils/MiroTransformableWrapper.scala
@@ -1,0 +1,30 @@
+package uk.ac.wellcome.test.utils
+
+import uk.ac.wellcome.models.{MiroTransformable, Work}
+
+/** MiroTransformable looks for several fields in the source JSON -- if they're
+ *  missing or have the wrong values, it rejects the record.
+ *
+ *  This trait provides a single method `transform()` which adds the necessary
+ *  fields before transformation, allowing tests to focus on only the fields
+ *  that are interesting for that test.
+ */
+trait MiroTransformableWrapper { this: Suite =>
+
+  def transformRecord(
+    data: String,
+    MiroID: String = "M0000001",
+    MiroCollection: String = "TestCollection"
+  ): Try[Work] = {
+    val miroTransformable = MiroTransformable(
+      MiroID = MiroID,
+      MiroCollection = MiroCollection,
+      data = s"""{
+        "image_cleared": "Y",
+        "image_copyright_cleared": "Y",
+        $data
+      }"""
+    )
+    miroTransformable.transform
+  }
+}

--- a/common/src/test/scala/uk/ac/wellcome/test/utils/MiroTransformableWrapper.scala
+++ b/common/src/test/scala/uk/ac/wellcome/test/utils/MiroTransformableWrapper.scala
@@ -1,6 +1,6 @@
 package uk.ac.wellcome.test.utils
 
-import org.scalatest.Suite
+import org.scalatest.{Matchers, Suite}
 import scala.util.Try
 
 import uk.ac.wellcome.models.{MiroTransformable, Work}
@@ -12,13 +12,13 @@ import uk.ac.wellcome.models.{MiroTransformable, Work}
  *  fields before transformation, allowing tests to focus on only the fields
  *  that are interesting for that test.
  */
-trait MiroTransformableWrapper { this: Suite =>
+trait MiroTransformableWrapper extends Matchers { this: Suite =>
 
   def transformWork(
     data: String,
     MiroID: String = "M0000001",
     MiroCollection: String = "TestCollection"
-  ): Try[Work] = {
+  ): Work = {
     val miroTransformable = MiroTransformable(
       MiroID = MiroID,
       MiroCollection = MiroCollection,
@@ -28,6 +28,7 @@ trait MiroTransformableWrapper { this: Suite =>
         $data
       }"""
     )
-    miroTransformable.transform
+    miroTransformable.transform.isSuccess shouldBe true
+    miroTransformable.transform.get
   }
 }


### PR DESCRIPTION
### What is this PR trying to achieve?

When transforming a Miro record, we need a bunch of fields to be in place of the transform fails (e.g. image_copyright_cleared). Having to put those on every test is tedious and boring – so don’t. Instead define a wrapper method that adds those fields for us.

Extracted from work on #759.

### Who is this change for?

Developers who don’t want to write boilerplate.