### PR TITLE
Drop images from the API that don’t have technical metadata

### DIFF
--- a/common/src/main/scala/uk/ac/wellcome/models/MiroTransformable.scala
+++ b/common/src/main/scala/uk/ac/wellcome/models/MiroTransformable.scala
@@ -18,7 +18,7 @@ case class MiroTransformableData(
     List[String]],
   @JsonProperty("image_artwork_date") artworkDate: Option[String],
   @JsonProperty("image_cleared") cleared: Option[String],
-  @JsonProperty("image_copyright_cleared") copyright_cleared: Option[String],
+  @JsonProperty("image_copyright_cleared") copyrightCleared: Option[String],
   @JsonProperty("image_keywords") keywords: Option[List[String]],
   @JsonProperty("image_keywords_unauth") keywordsUnauth: Option[List[String]],
   @JsonProperty("image_phys_format") physFormat: Option[String],
@@ -62,7 +62,7 @@ case class MiroTransformable(MiroID: String,
       if (miroData.cleared.getOrElse("N") != "Y") {
         throw new ShouldNotTransformException("image_cleared field is not Y")
       }
-      if (miroData.copyright_cleared.getOrElse("N") != "Y") {
+      if (miroData.copyrightCleared.getOrElse("N") != "Y") {
         throw new ShouldNotTransformException(
           "image_copyright_cleared field is not Y")
       }

--- a/common/src/main/scala/uk/ac/wellcome/models/MiroTransformable.scala
+++ b/common/src/main/scala/uk/ac/wellcome/models/MiroTransformable.scala
@@ -22,7 +22,8 @@ case class MiroTransformableData(
   @JsonProperty("image_keywords") keywords: Option[List[String]],
   @JsonProperty("image_keywords_unauth") keywordsUnauth: Option[List[String]],
   @JsonProperty("image_phys_format") physFormat: Option[String],
-  @JsonProperty("image_lc_genre") lcGenre: Option[String]
+  @JsonProperty("image_lc_genre") lcGenre: Option[String],
+  @JsonProperty("image_tech_file_size") techFileSize: Option[List[String]]
 )
 
 case class ShouldNotTransformException(message: String)
@@ -65,6 +66,20 @@ case class MiroTransformable(MiroID: String,
       if (miroData.copyrightCleared.getOrElse("N") != "Y") {
         throw new ShouldNotTransformException(
           "image_copyright_cleared field is not Y")
+      }
+
+      // There are a bunch of <image_tech_*> fields that refer to the
+      // underlying image file.  If these are empty, there isn't actually a
+      // file to retrieve, which breaks the Collection site.  Sometimes this is
+      // a "glue" record that refers to multiple images.  e.g. V0011212ETL
+      //
+      // Eventually it might be nice to collate these -- have all the images
+      // in the same API result, but for now, we just exclude them from
+      // the API.  They aren't useful for testing image search.
+      if (miroData.techFileSize.getOrElse(List[String]()).isEmpty) {
+        throw new ShouldNotTransformException(
+          "No image_tech_file_size means there is no underlying image"
+        )
       }
 
       // In Miro, the <image_image_desc> and <image_image_title> fields are

--- a/common/src/test/scala/uk/ac/wellcome/models/MiroTransformableTest.scala
+++ b/common/src/test/scala/uk/ac/wellcome/models/MiroTransformableTest.scala
@@ -354,7 +354,7 @@ class MiroTransformableTest
     "should not pass through records with an image_cleared value that isn't 'Y'") {
     assertTransformMiroRecordFails(
       data = """{
-      "image_title": "Confidential colourings of crododiles",
+      "image_title": "Confidential colourings of crocodiles",
       "image_cleared": "N",
       "image_copyright_cleared": "Y"
     }""")
@@ -368,6 +368,18 @@ class MiroTransformableTest
       "image_cleared": "Y",
       "image_copyright_cleared": "N"
     }""")
+  }
+
+  it(
+    "should not pass through records that are missing technical metadata") {
+    assertTransformMiroRecordFails(
+      data = """{
+        "image_title": "Touching a toxic tree is truly tragic",
+        "image_cleared": "Y",
+        "image_copyright_cleared": "Y",
+        "image_tech_file_size": []
+      }"""
+    )
   }
 
   private def assertTransformMiroRecordFails(

--- a/common/src/test/scala/uk/ac/wellcome/test/utils/MiroTransformableWrapper.scala
+++ b/common/src/test/scala/uk/ac/wellcome/test/utils/MiroTransformableWrapper.scala
@@ -25,6 +25,7 @@ trait MiroTransformableWrapper extends Matchers { this: Suite =>
       data = s"""{
         "image_cleared": "Y",
         "image_copyright_cleared": "Y",
+        "image_tech_file_size": ["1000000"],
         $data
       }"""
     )

--- a/transformer/src/test/scala/uk/ac/wellcome/transformer/MiroTransformerFeatureTest.scala
+++ b/transformer/src/test/scala/uk/ac/wellcome/transformer/MiroTransformerFeatureTest.scala
@@ -59,13 +59,15 @@ class MiroTransformerFeatureTest
   def shouldTransformMessage(imageTitle: String) = s"""{
           "image_title": "$imageTitle",
           "image_cleared": "Y",
-          "image_copyright_cleared": "Y"
+          "image_copyright_cleared": "Y",
+          "image_tech_file_size": ["100000"]
         }"""
 
   def shouldNotTransformMessage(imageTitle: String) = s"""{
           "image_title": "$imageTitle",
           "image_cleared": "N",
-          "image_copyright_cleared": "N"
+          "image_copyright_cleared": "N",
+          "image_tech_file_size": ["100000"]
         }"""
 
   private def sendMiroImageToSQS(miroID: String, message: String) = {


### PR DESCRIPTION
### What is this PR trying to achieve?

Discard images from the API that don’t have technical metadata – i.e., no underlying file.

Related: #759.

### Who is this change for?

An Experience team who don’t want broken image links.

### Have the following been considered/are they needed?

- [ ] Deployed new versions
