### PR TITLE
Allow building Docker images from outside the docker directory

### DIFF
--- a/scripts/build_docker_image.py
+++ b/scripts/build_docker_image.py
@@ -1,19 +1,19 @@
 #!/usr/bin/env python3
 # -*- encoding: utf-8 -*-
 """
-Builds a docker image for a simple project
+Builds a Docker image for a project.
 
 Usage:
-  build_docker_image.py --project=<name> [--variant=<variant>]
+  build_docker_image.py --project=<PROJECT> [--file=<FILE>] [--variant=<VARIANT>]
   build_docker_image.py -h | --help
 
 Options:
-  -h --help                Show this screen.
-  --project=<project>      Name of the project (e.g. api, loris).  Assumes
-                           there's a folder containing a Dockerfile with the
-                           same name.
-  --variant=<variant>      The optional variant of this project (e.g. nginx).
-                           Relies on the Dockerfile accepting a variant ENV.
+  -h --help                Show this screen
+  --project=<PROJECT>      Name of the Docker image to build
+  --file=<FILE>            Path to the Dockerfile (if not in docker/<PROJECT>)
+  --variant=<VARIANT>      The optional variant of this project (e.g. nginx)
+                           Relies on the Dockerfile accepting a variant ARG
+
 """
 
 import os
@@ -27,8 +27,9 @@ from tooling import write_release_id, CURRENT_COMMIT, ROOT
 if __name__ == '__main__':
     args = docopt.docopt(__doc__)
 
-    variant = args['--variant']
     project = args['--project']
+    variant = args['--variant']
+    dockerfile = os.path.join(ROOT, args['--file']) or os.path.join(ROOT, 'docker', project, 'Dockerfile')
 
     print('*** Building image for %s' % project)
 
@@ -45,14 +46,10 @@ if __name__ == '__main__':
 
     print('*** Building the new image')
 
-    cmd = [
-        'docker', 'build',
-        '--file', os.path.join(ROOT, 'docker', project, 'Dockerfile'),
-        '--tag', tag,
-    ]
+    cmd = ['docker', 'build', '--file', dockerfile, '--tag', tag,]
     if variant is not None:
         cmd.extend(['--build-arg', 'variant=%s' % variant])
-    cmd.append(os.path.join(ROOT, 'docker', project))
+    cmd.append(os.path.dirname(dockerfile))
 
     subprocess.check_call(cmd)
 

--- a/scripts/build_docker_image.py
+++ b/scripts/build_docker_image.py
@@ -29,7 +29,10 @@ if __name__ == '__main__':
 
     project = args['--project']
     variant = args['--variant']
-    dockerfile = os.path.join(ROOT, args['--file']) or os.path.join(ROOT, 'docker', project, 'Dockerfile')
+    if args['--file']:
+        dockerfile = os.path.join(ROOT, args['--file'])
+    else:
+        dockerfile = os.path.join(ROOT, 'docker', project, 'Dockerfile')
 
     print('*** Building image for %s' % project)
 
@@ -46,7 +49,7 @@ if __name__ == '__main__':
 
     print('*** Building the new image')
 
-    cmd = ['docker', 'build', '--file', dockerfile, '--tag', tag,]
+    cmd = ['docker', 'build', '--file', dockerfile, '--tag', tag]
     if variant is not None:
         cmd.extend(['--build-arg', 'variant=%s' % variant])
     cmd.append(os.path.dirname(dockerfile))


### PR DESCRIPTION
### What is this PR trying to achieve?

Allow building images from outside the Docker directory.

### Who is this change for?

Me – I want to build a Docker image in the `miro_adapter` directory.