### PR TITLE
Upgrade our version of Loris

### DIFF
--- a/docker/loris/install_loris.sh
+++ b/docker/loris/install_loris.sh
@@ -4,7 +4,7 @@
 set -o errexit
 set -o nounset
 
-LORIS_COMMIT="2ba933cbddad7f322c2d1d483b11f1445ba6204c"
+LORIS_COMMIT="400bc3979a7dc3ff938abff84665c2731f750a69"
 
 # Install dependencies.  We don't include Apache because we're running
 # Loris with UWSGI and nginx, not Apache.


### PR DESCRIPTION
### What is this PR trying to achieve?

Bump our version of Loris to include https://github.com/loris-imageserver/loris/pull/342

### Who is this change for?

Folks who don’t want 500 errors from Loris.

### Have the following been considered/are they needed?

- [ ] Deployed new versions