### PR TITLE
Pin AWS Terraform provider version

### DIFF
--- a/terraform/provider.tf
+++ b/terraform/provider.tf
@@ -1,6 +1,8 @@
 # Specify the provider and access details
 provider "aws" {
   region = "${var.aws_region}"
+
+  version = "0.1.4"
 }
 
 data "aws_caller_identity" "current" {}


### PR DESCRIPTION
### What is this PR trying to achieve?

Stop the TF AWS provider version advancing automatically and maybe accidentally breaking things.

### Who is this change for?

Developers who wish to stay sane.

### Have the following been considered/are they needed?
- [ ] Run `terraform apply`.
