### PR TITLE
Add thumbnails and licenses to our models and Swagger

### DIFF
--- a/api/src/main/scala/uk/ac/wellcome/platform/api/models/DisplayLicense.scala
+++ b/api/src/main/scala/uk/ac/wellcome/platform/api/models/DisplayLicense.scala
@@ -1,0 +1,26 @@
+package uk.ac.wellcome.platform.api.models
+
+import com.fasterxml.jackson.annotation.JsonProperty
+import io.swagger.annotations.{ApiModel, ApiModelProperty}
+
+@ApiModel(
+  value = "License",
+  description =
+    "The specific license under which the work in question is released to the public - for example, one of the forms of Creative Commons - if it is a precise license to which a link can be made."
+)
+case class DisplayLicense(
+  @ApiModelProperty(
+    value =
+      "A type of license under which the work in question is released to the public.",
+    allowableValues = "CC-BY, CC-BY-NC"
+  ) licenseType: String,
+  @ApiModelProperty(
+    value = "The title or other short name of a license"
+  ) label: String,
+  @ApiModelProperty(
+    value = "URL to the full text of a license"
+  ) url: String
+) {
+  @ApiModelProperty(readOnly = true, value = "A type of thing")
+  @JsonProperty("type") val ontologyType: String = "License"
+}

--- a/api/src/main/scala/uk/ac/wellcome/platform/api/models/DisplayLocation.scala
+++ b/api/src/main/scala/uk/ac/wellcome/platform/api/models/DisplayLocation.scala
@@ -1,0 +1,25 @@
+package uk.ac.wellcome.platform.api.models
+
+import com.fasterxml.jackson.annotation.JsonProperty
+import io.swagger.annotations.{ApiModel, ApiModelProperty}
+
+@ApiModel(
+  value = "Location",
+  description = "A location that provides access to an item"
+)
+case class DisplayLocation(
+  @ApiModelProperty(
+    value = "The type of location that an item is accessible from.",
+    allowableValues = "thumbnail-image"
+  ) locationType: String,
+  @ApiModelProperty(
+    value = "The title or other short name of a license"
+  ) url: Option[String] = None,
+  @ApiModelProperty(
+    value =
+      "The specific license under which the work in question is released to the public - for example, one of the forms of Creative Commons - if it is a precise license to which a link can be made."
+  ) license: DisplayLicense
+) {
+  @ApiModelProperty(readOnly = true, value = "A type of thing")
+  @JsonProperty("type") val ontologyType: String = "Location"
+}

--- a/api/src/main/scala/uk/ac/wellcome/platform/api/models/DisplayWork.scala
+++ b/api/src/main/scala/uk/ac/wellcome/platform/api/models/DisplayWork.scala
@@ -44,7 +44,13 @@ case class DisplayWork(
     Concept] = List(),
   @ApiModelProperty(value =
     "Relates a work to the genre that describes the work's content.") genres: List[
-    Concept] = List()) {
+    Concept] = List(),
+  @ApiModelProperty(
+    dataType = "uk.ac.wellcome.platform.api.models.DisplayLocation",
+    value =
+      "Relates any thing to the location of a representative thumbnail image"
+  ) thumbnail: Option[Location] = None
+) {
   @ApiModelProperty(readOnly = true, value = "A type of thing")
   @JsonProperty("type") val ontologyType: String = "Work"
 }

--- a/api/src/test/scala/uk/ac/wellcome/platform/api/ApiSwaggerTest.scala
+++ b/api/src/test/scala/uk/ac/wellcome/platform/api/ApiSwaggerTest.scala
@@ -1,6 +1,6 @@
 package uk.ac.wellcome.platform.api
 
-import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.databind.{JsonNode, ObjectMapper}
 import com.twitter.finagle.http.{Response, Status}
 import com.twitter.finatra.http.EmbeddedHttpServer
 import com.twitter.inject.server.FeatureTestMixin
@@ -24,8 +24,17 @@ class ApiSwaggerTest extends FunSpec with FeatureTestMixin {
     )
 
   it("should return a valid JSON response") {
+    val tree = readTree("/test/v99/swagger.json")
+
+    tree.at("/host").toString should be("\"test.host\"")
+    tree.at("/schemes").toString should be("[\"http\"]")
+    tree.at("/info/version").toString should be("\"v99\"")
+    tree.at("/basePath").toString should be("\"/test/v99\"")
+  }
+
+  def readTree(path: String): JsonNode = {
     val response: Response = server.httpGet(
-      path = "/test/v99/swagger.json",
+      path = path,
       andExpect = Status.Ok
     )
 
@@ -33,11 +42,6 @@ class ApiSwaggerTest extends FunSpec with FeatureTestMixin {
 
     noException should be thrownBy { mapper.readTree(response.contentString) }
 
-    val tree = mapper.readTree(response.contentString)
-
-    tree.at("/host").toString should be("\"test.host\"")
-    tree.at("/schemes").toString should be("[\"http\"]")
-    tree.at("/info/version").toString should be("\"v99\"")
-    tree.at("/basePath").toString should be("\"/test/v99\"")
+    mapper.readTree(response.contentString)
   }
 }

--- a/common/src/main/scala/uk/ac/wellcome/models/License.scala
+++ b/common/src/main/scala/uk/ac/wellcome/models/License.scala
@@ -1,0 +1,11 @@
+package uk.ac.wellcome.models
+
+import com.fasterxml.jackson.annotation.JsonProperty
+
+case class License(
+  val licenseType: String,
+  val label: String,
+  val url: String
+) {
+  @JsonProperty("type") val ldType: String = "License"
+}

--- a/common/src/main/scala/uk/ac/wellcome/models/Location.scala
+++ b/common/src/main/scala/uk/ac/wellcome/models/Location.scala
@@ -1,0 +1,11 @@
+package uk.ac.wellcome.models
+
+import com.fasterxml.jackson.annotation.JsonProperty
+
+case class Location(
+  locationType: String,
+  url: Option[String] = None,
+  license: License
+) {
+  @JsonProperty("type") val ldType: String = "Location"
+}

--- a/common/src/main/scala/uk/ac/wellcome/models/Work.scala
+++ b/common/src/main/scala/uk/ac/wellcome/models/Work.scala
@@ -20,7 +20,8 @@ case class Work(
   createdDate: Option[Period] = None,
   subjects: List[Concept] = List(),
   creators: List[Agent] = List(),
-  genres: List[Concept] = List()
+  genres: List[Concept] = List(),
+  thumbnail: Option[License] = None
 ) {
   @JsonProperty("type") val ldType: String = "Work"
 }


### PR DESCRIPTION
### What is this PR trying to achieve?

This lays the groundwork for putting thumbnails and licenses in the API. In particular, our `Work` model now knows about `Location` and `License`, and likewise `DisplayWork` has enough information to show them in the Swagger docs. Actually populating these models is deferred to a separate patch.

The following parameter is added to the `Work` definition:

```json
"thumbnail": {
  "description": "Relates any thing to the location of a representative thumbnail image",
  "$ref": "#/definitions/Location"
}
```

And we add two new definitions:

```json
"License": {
  "type": "object",
  "properties": {
    "licenseType": {
      "type": "string",
      "description": "A type of license under which the work in question is released to the public.",
      "enum": [
        "CC-BY",
        "CC-BY-NC"
      ]
    },
    "label": {
      "type": "string",
      "description": "The title or other short name of a license"
    },
    "url": {
      "type": "string",
      "description": "URL to the full text of a license"
    },
    "type": {
      "type": "string",
      "description": "A type of thing",
      "readOnly": true
    }
  },
  "description": "The specific license under which the work in question is released to the public - for example, one of the forms of Creative Commons - if it is a precise license to which a link can be made."
},
"Location": {
  "type": "object",
    "properties": {
      "locationType": {
        "type": "string",
        "description": "The type of location that an item is accessible from.",
        "enum": [
          "thumbnail-image"
        ]
      },
    "url": {
      "type": "string",
      "description": "The title or other short name of a license"
    },
    "license": {
      "description": "The specific license under which the work in question is released to the public - for example, one of the forms of Creative Commons - if it is a precise license to which a link can be made.",
      "$ref": "#/definitions/License"
    },
    "type": {
      "type": "string",
      "description": "A type of thing",
      "readOnly": true
    }
  },
  "description": "A location that provides access to an item"
}
```

Plus a little bit of refactoring in the Swagger tests so we can add more if it gets more complicated.

Related: #792.

### Who is this change for?

Users of the Catalogue API who want to know what they’re receiving.

### Have the following been considered/are they needed?

- [ ] Reviewed by @jtweed
- [x] Updated the Swagger documentation
- [ ] Deployed new versions
