### PR TITLE
Populate the thumbnail field on a MIRO work

### DIFF
--- a/common/src/main/scala/uk/ac/wellcome/models/Location.scala
+++ b/common/src/main/scala/uk/ac/wellcome/models/Location.scala
@@ -5,7 +5,7 @@ import com.fasterxml.jackson.annotation.JsonProperty
 case class Location(
   locationType: String,
   url: Option[String] = None,
-  license: License
+  license: LicenseTrait
 ) {
   @JsonProperty("type") val ontologyType: String = "Location"
 }

--- a/common/src/main/scala/uk/ac/wellcome/models/MiroTransformable.scala
+++ b/common/src/main/scala/uk/ac/wellcome/models/MiroTransformable.scala
@@ -214,7 +214,7 @@ case class MiroTransformable(MiroID: String,
       }
       val thumbnail = Location(
         locationType = "thumbnail-image",
-        url = s"https://iiif.wellcomecollection.org/image/$MiroID.jpg/full/300,/0/default.jpg",
+        url = Some(s"https://iiif.wellcomecollection.org/image/$MiroID.jpg/full/300,/0/default.jpg"),
         license = chooseLicense(useRestrictions=useRestrictions)
       )
 
@@ -226,7 +226,7 @@ case class MiroTransformable(MiroID: String,
         creators = creators ++ secondaryCreators,
         subjects = subjects,
         genres = genres,
-        thumbnail = thumbnail
+        thumbnail = Some(thumbnail)
       )
     }
   }

--- a/common/src/main/scala/uk/ac/wellcome/models/MiroTransformable.scala
+++ b/common/src/main/scala/uk/ac/wellcome/models/MiroTransformable.scala
@@ -245,7 +245,7 @@ case class MiroTransformable(MiroID: String,
    *  TODO: Update these mappings based on the final version of Christy's
    *        document.
    */
-  def chooseLicense(useRestrictions: String): License =
+  def chooseLicense(useRestrictions: String): LicenseTrait =
     useRestrictions match {
 
       // Certain strings map directly onto license types

--- a/common/src/main/scala/uk/ac/wellcome/models/MiroTransformable.scala
+++ b/common/src/main/scala/uk/ac/wellcome/models/MiroTransformable.scala
@@ -245,7 +245,7 @@ case class MiroTransformable(MiroID: String,
       // Any images with this label are explicitly withheld from the API.
       case "See Related Images Tab for Higher Res Available" => {
         throw new ShouldNotTransformException(
-          s"image_use_restrictions=\"$useRestrictions\" mean we should exclude this from the API"
+          s"image_use_restrictions='${useRestrictions}' mean we should exclude this from the API"
         )
       }
 
@@ -256,12 +256,12 @@ case class MiroTransformable(MiroID: String,
             "See Copyright Information" |
             "Suppressed from WI site") => {
         throw new ShouldNotTransformException(
-          s"image_use_restrictions=\"$useRestrictions\" needs more investigation before we can assign a license"
+          s"image_use_restrictions='$useRestrictions' needs more investigation before we can assign a license"
         )
       }
 
       case _ => throw new MiroDataException(
-        s"image_use_restrictions=\"$useRestrictions\" is unrecognised"
+        s"image_use_restrictions='${useRestrictions}' is unrecognised"
       )
     }
 }

--- a/common/src/main/scala/uk/ac/wellcome/models/MiroTransformable.scala
+++ b/common/src/main/scala/uk/ac/wellcome/models/MiroTransformable.scala
@@ -23,9 +23,19 @@ case class MiroTransformableData(
   @JsonProperty("image_keywords_unauth") keywordsUnauth: Option[List[String]],
   @JsonProperty("image_phys_format") physFormat: Option[String],
   @JsonProperty("image_lc_genre") lcGenre: Option[String],
-  @JsonProperty("image_tech_file_size") techFileSize: Option[List[String]]
+  @JsonProperty("image_tech_file_size") techFileSize: Option[List[String]],
+  @JsonProperty("image_use_restrictions") useRestrictions: Option[String]
 )
 
+/** Thrown for errors in the data which need further investigation or indicate
+ *  a transformer bug.
+ */
+case class MiroDataException(message: String)
+    extends Exception(message)
+
+/** Thrown when we know we have a known reason for not transforming
+ *  this record.
+ */
 case class ShouldNotTransformException(message: String)
     extends Exception(message)
 
@@ -205,4 +215,53 @@ case class MiroTransformable(MiroID: String,
       )
     }
   }
+
+  /** If the image has a non-empty image_use_restrictions field, choose which
+   *  license (if any) we're going to assign to the thumbnail for this work.
+   *
+   *  The mappings in this function are based on a document provided by
+   *  Christy Henshaw (MIRO drop-downs.docx).  There are still some gaps in
+   *  that, we'll have to come back and update this code later.
+   *
+   *  For now, this mapping only covers use restrictions seen in the
+   *  V collection.  We'll need to extend this for other licenses later.
+   *
+   *  TODO: Expand this mapping to cover all of MIRO.
+   *  TODO: Update these mappings based on the final version of Christy's
+   *        document.
+   */
+  def chooseLicense(useRestrictions: String): License =
+    useRestrictions match {
+
+      // Certain strings map directly onto license types
+      case "CC-0"        => License_CC0
+      case "CC-BY"       => License_CCBY
+      case "CC-BY-NC"    => License_CCBYNC
+      case "CC-BY-NC-ND" => License_CCBYNCND
+
+      // These mappings are defined in Christy's document
+      case "Academics"   => License_CCBYNC
+
+      // Any images with this label are explicitly withheld from the API.
+      case "See Related Images Tab for Higher Res Available" => {
+        throw new ShouldNotTransformException(
+          s"image_use_restrictions=\"$useRestrictions\" mean we should exclude this from the API"
+        )
+      }
+
+      // These fields are labelled "[Investigate further]" in Christy's
+      // document, so for now we exclude them.
+      case ("Do not use" |
+            "Not for external use" |
+            "See Copyright Information" |
+            "Suppressed from WI site") => {
+        throw new ShouldNotTransformException(
+          s"image_use_restrictions=\"$useRestrictions\" needs more investigation before we can assign a license"
+        )
+      }
+
+      case _ => throw new MiroDataException(
+        s"image_use_restrictions=\"$useRestrictions\" is unrecognised"
+      )
+    }
 }

--- a/common/src/main/scala/uk/ac/wellcome/models/MiroTransformable.scala
+++ b/common/src/main/scala/uk/ac/wellcome/models/MiroTransformable.scala
@@ -204,6 +204,20 @@ case class MiroTransformable(MiroID: String,
         case _ => None
       }
 
+      // Add a thumbnail.  For now the URL is hard coded.
+      // TODO: Less magic strings here.
+      val useRestrictions = miroData.useRestrictions match {
+        case Some(s) => s
+        case None => throw new MiroDataException(
+          "No value provided for image_use_restrictions?"
+        )
+      }
+      val thumbnail = Location(
+        locationType = "thumbnail-image",
+        url = s"https://iiif.wellcomecollection.org/image/$MiroID.jpg/full/300,/0/default.jpg",
+        license = chooseLicense(useRestrictions=useRestrictions)
+      )
+
       Work(
         identifiers = identifiers,
         title = title,
@@ -211,7 +225,8 @@ case class MiroTransformable(MiroID: String,
         createdDate = createdDate,
         creators = creators ++ secondaryCreators,
         subjects = subjects,
-        genres = genres
+        genres = genres,
+        thumbnail = thumbnail
       )
     }
   }

--- a/common/src/test/scala/uk/ac/wellcome/models/MiroTransformableTest.scala
+++ b/common/src/test/scala/uk/ac/wellcome/models/MiroTransformableTest.scala
@@ -508,3 +508,58 @@ class MiroTransformableGenresTest
     transformedWork.genres shouldBe expectedGenres
   }
 }
+
+
+
+class MiroTransformableThumbnailTest
+    extends FunSpec
+    with Matchers
+    with MiroTransformableWrapper {
+
+  it("should reject records that don't have usage data") {
+    assertTransformWorkFails(
+      data = """{
+        "image_cleared": "Y",
+        "image_copyright_cleared": "Y",
+        "image_tech_file_size": ["1000000"],
+        "image_title": "Understand that using this umbrella is unauthorised"
+      }"""
+    )
+  }
+
+  it("should reject records with unrecognised usage data") {
+    assertTransformWorkFails(
+      data = """{
+        "image_cleared": "Y",
+        "image_copyright_cleared": "Y",
+        "image_tech_file_size": ["1000000"],
+        "image_use_restrictions": "Poetic license, normally reserved for authors and not suitable in the real world",
+        "image_title": "Plagiarised poetry by a penguin"
+      }"""
+    )
+  }
+
+  it("should create a thumbnail if the license is present") {
+    transformRecordAndCheckThumbnail(
+      data = s"""
+        "image_use_restrictions": "CC-BY-NC",
+        "image_title": "A thumb-sized tarantula"
+      """,
+      MiroID = "MT0001234",
+      expectedThumbnail = Location(
+        locationType = "thumbnail-image",
+        url = Some("https://iiif.wellcomecollection.org/image/MT0001234.jpg/full/300,/0/default.jpg"),
+        license = License_CCBYNC
+      )
+    )
+  }
+
+  private def transformRecordAndCheckThumbnail(
+    data: String,
+    MiroID: String,
+    expectedThumbnail: Location
+  ) = {
+    val transformedWork = transformWork(data = data, MiroID = MiroID)
+    transformedWork.thumbnail.get shouldBe expectedThumbnail
+  }
+}

--- a/common/src/test/scala/uk/ac/wellcome/test/utils/MiroTransformableWrapper.scala
+++ b/common/src/test/scala/uk/ac/wellcome/test/utils/MiroTransformableWrapper.scala
@@ -26,6 +26,7 @@ trait MiroTransformableWrapper extends Matchers { this: Suite =>
         "image_cleared": "Y",
         "image_copyright_cleared": "Y",
         "image_tech_file_size": ["1000000"],
+        "image_use_restrictions": "CC-BY",
         $data
       }"""
     )


### PR DESCRIPTION
### What is this PR trying to achieve?

Now we have models for Location and License, and some License objects (how they appear in the world tbc), let's start putting some data in them!

This patch only covers the transformer changes – changes to display logic in the API will be a separate patch. Merging is blocked on us deciding how to define Licenses, but stands as a standalone patch.

Related: #792.

### Who is this change for?

The Experience team, who are planning to use thumbnails as a proxy for licenses on items.

### Have the following been considered/are they needed?

- [ ] Deployed new versions