### PR TITLE
Add an Elasticsearch mapping for thumbnail on works

### DIFF
--- a/common/src/main/scala/uk/ac/wellcome/elasticsearch/mappings/WorksIndex.scala
+++ b/common/src/main/scala/uk/ac/wellcome/elasticsearch/mappings/WorksIndex.scala
@@ -49,6 +49,17 @@ class WorksIndex @Inject()(client: HttpClient,
         objectField("genres").fields(
           textField("label"),
           keywordField("type")
+        ),
+        objectField("thumbnail").fields(
+          keywordField("type"),
+          keywordField("locationType"),
+          textField("url"),
+          objectField("license").fields(
+            keywordField("type"),
+            keywordField("licenseType"),
+            textField("label"),
+            textField("url")
+          )
         )
       )
     )


### PR DESCRIPTION
### What is this PR trying to achieve?

Make sure our Elasticsearch cluster knows how to handle thumbnails.

Related: #792.