### PR TITLE
Move DisplayIdentifier into its own file

### DIFF
--- a/api/src/main/scala/uk/ac/wellcome/platform/api/models/DisplayIdentifier.scala
+++ b/api/src/main/scala/uk/ac/wellcome/platform/api/models/DisplayIdentifier.scala
@@ -1,0 +1,24 @@
+package uk.ac.wellcome.platform.api.models
+
+import com.fasterxml.jackson.annotation.JsonProperty
+import io.swagger.annotations.{ApiModel, ApiModelProperty}
+import uk.ac.wellcome.models._
+
+@ApiModel(
+  value = "Identifier",
+  description =
+    "A unique system-generated identifier that governs interaction between systems and is regarded as canonical within the Wellcome data ecosystem."
+)
+case class DisplayIdentifier(
+  @ApiModelProperty(value =
+    "Relates a Identifier to a particular authoritative source identifier scheme: for example, if the identifier is MS.49 this property might indicate that this identifier has its origins in the Wellcome Library's CALM archive management system.") identifierScheme: String,
+  @ApiModelProperty(value = "The value of the thing. e.g. an identifier") value: String) {
+  @ApiModelProperty(readOnly = true, value = "A type of thing")
+  @JsonProperty("type") val ontologyType: String = "Identifier"
+}
+
+object DisplayIdentifier {
+  def apply(sourceIdentifier: SourceIdentifier): DisplayIdentifier =
+    DisplayIdentifier(identifierScheme = sourceIdentifier.identifierScheme,
+                      value = sourceIdentifier.value)
+}

--- a/api/src/main/scala/uk/ac/wellcome/platform/api/models/DisplayWork.scala
+++ b/api/src/main/scala/uk/ac/wellcome/platform/api/models/DisplayWork.scala
@@ -89,22 +89,3 @@ case object DisplayWork {
     )
   }
 }
-
-@ApiModel(
-  value = "Identifier",
-  description =
-    "A unique system-generated identifier that governs interaction between systems and is regarded as canonical within the Wellcome data ecosystem."
-)
-case class DisplayIdentifier(
-  @ApiModelProperty(value =
-    "Relates a Identifier to a particular authoritative source identifier scheme: for example, if the identifier is MS.49 this property might indicate that this identifier has its origins in the Wellcome Library's CALM archive management system.") identifierScheme: String,
-  @ApiModelProperty(value = "The value of the thing. e.g. an identifier") value: String) {
-  @ApiModelProperty(readOnly = true, value = "A type of thing")
-  @JsonProperty("type") val ontologyType: String = "Identifier"
-}
-
-object DisplayIdentifier {
-  def apply(sourceIdentifier: SourceIdentifier): DisplayIdentifier =
-    DisplayIdentifier(identifierScheme = sourceIdentifier.identifierScheme,
-                      value = sourceIdentifier.value)
-}


### PR DESCRIPTION
Extracted from work for #792 – all the other `Display*` classes are in individual files, so move this one out as well.

I’ll wait for tests to pass and then merge this immediately.