### PR TITLE
Add an Item model

### DIFF
--- a/common/src/main/scala/uk/ac/wellcome/models/Item.scala
+++ b/common/src/main/scala/uk/ac/wellcome/models/Item.scala
@@ -1,0 +1,10 @@
+package uk.ac.wellcome.models
+
+import com.fasterxml.jackson.annotation.JsonProperty
+
+case class Item(
+  identifiers: List[SourceIdentifier],
+  locations: List[Location]
+) {
+  @JsonProperty("type") val ontologyType: String = "Item"
+}

--- a/common/src/main/scala/uk/ac/wellcome/models/Work.scala
+++ b/common/src/main/scala/uk/ac/wellcome/models/Work.scala
@@ -21,7 +21,8 @@ case class Work(
   subjects: List[Concept] = List(),
   creators: List[Agent] = List(),
   genres: List[Concept] = List(),
-  thumbnail: Option[License] = None
+  thumbnail: Option[License] = None,
+  items: List[Item] = List()
 ) {
   @JsonProperty("type") val ontologyType: String = "Work"
 }


### PR DESCRIPTION
### What is this PR trying to achieve?

Adds an item model to move towards representing items from the ontology in the API.

### Who is this change for?

💻  & 📚 

### Have the following been considered/are they needed?

- [ ] Deployed new versions
