### PR TITLE
Adds Item to ES mapping

### DIFF
--- a/common/src/main/scala/uk/ac/wellcome/elasticsearch/mappings/WorksIndex.scala
+++ b/common/src/main/scala/uk/ac/wellcome/elasticsearch/mappings/WorksIndex.scala
@@ -1,14 +1,13 @@
 package uk.ac.wellcome.elasticsearch.mappings
 
 import com.google.inject.Inject
+import com.sksamuel.elastic4s.analyzers._
 import com.sksamuel.elastic4s.http.ElasticDsl._
 import com.sksamuel.elastic4s.http.HttpClient
-import com.sksamuel.elastic4s.analyzers._
 import com.sksamuel.elastic4s.mappings.dynamictemplate.DynamicMapping
 import com.twitter.inject.Logging
 import com.twitter.inject.annotations.Flag
 import org.elasticsearch.ResourceAlreadyExistsException
-import org.elasticsearch.action.admin.indices.mapping.put.PutMappingResponse
 import org.elasticsearch.transport.RemoteTransportException
 import uk.ac.wellcome.utils.GlobalExecutionContext.context
 
@@ -19,48 +18,60 @@ class WorksIndex @Inject()(client: HttpClient,
                            @Flag("es.type") itemType: String)
     extends Logging {
 
+  val license = objectField("license").fields(
+    keywordField("type"),
+    keywordField("licenseType"),
+    textField("label"),
+    textField("url")
+  )
+
+  val identifiers = objectField("identifiers").fields(
+    keywordField("identifierScheme"),
+    keywordField("value"),
+    keywordField("type"))
+
+  def location(fieldName: String = "locations") =
+    objectField(fieldName).fields(
+      keywordField("type"),
+      keywordField("locationType"),
+      textField("url"),
+      license
+    )
+
+  def date(fieldName: String) = objectField(fieldName).fields(
+    textField("label"),
+    keywordField("type")
+  )
+
+  def labelledTextField(fieldName: String) = objectField(fieldName).fields(
+    textField("label"),
+    keywordField("type")
+  )
+
+  val items = objectField("items").fields(
+    identifiers,
+    location()
+  )
+
   val mappingDefinition = putMapping(indexName / itemType)
     .dynamic(DynamicMapping.Strict)
     .as(
       keywordField("canonicalId"),
       objectField("work").fields(
         keywordField("type"),
-        objectField("identifiers").fields(keywordField("identifierScheme"),
-                                          keywordField("value"),
-                                          keywordField("type")),
+        identifiers,
         textField("title").fields(
           textField("english").analyzer(EnglishLanguageAnalyzer)),
         textField("description").fields(
           textField("english").analyzer(EnglishLanguageAnalyzer)),
         textField("lettering").fields(
           textField("english").analyzer(EnglishLanguageAnalyzer)),
-        objectField("createdDate").fields(
-          textField("label"),
-          keywordField("type")
-        ),
-        objectField("creators").fields(
-          textField("label"),
-          keywordField("type")
-        ),
-        objectField("subjects").fields(
-          textField("label"),
-          keywordField("type")
-        ),
-        objectField("genres").fields(
-          textField("label"),
-          keywordField("type")
-        ),
-        objectField("thumbnail").fields(
-          keywordField("type"),
-          keywordField("locationType"),
-          textField("url"),
-          objectField("license").fields(
-            keywordField("type"),
-            keywordField("licenseType"),
-            textField("label"),
-            textField("url")
-          )
-        )
+        date("createdDate"),
+        labelledTextField("creators"),
+        labelledTextField("subjects"),
+        labelledTextField("genres"),
+        items,
+        location("thumbnail")
       )
     )
 


### PR DESCRIPTION
### What is this PR trying to achieve?

Moving towards ingesting items into the API this adds an ES mapping to make it possible to store the items as per the ontology.

This PR also refactors the mappings a little to reduce code duplication.

### Who is this change for?

💻  & 📚 

### Have the following been considered/are they needed?

- [ ] Deployed new versions
