### PR TITLE
Expose thumbnails in the API

### DIFF
--- a/api/src/main/scala/uk/ac/wellcome/platform/api/models/DisplayLicense.scala
+++ b/api/src/main/scala/uk/ac/wellcome/platform/api/models/DisplayLicense.scala
@@ -2,6 +2,7 @@ package uk.ac.wellcome.platform.api.models
 
 import com.fasterxml.jackson.annotation.JsonProperty
 import io.swagger.annotations.{ApiModel, ApiModelProperty}
+import uk.ac.wellcome.models.LicenseTrait
 
 @ApiModel(
   value = "License",
@@ -23,4 +24,13 @@ case class DisplayLicense(
 ) {
   @ApiModelProperty(readOnly = true, value = "A type of thing")
   @JsonProperty("type") val ontologyType: String = "License"
+}
+
+case object DisplayLicense {
+  def apply(license: LicenseTrait): DisplayLicense =
+    DisplayLicense(
+      licenseType = license.licenseType,
+      label = license.label,
+      url = license.url
+    )
 }

--- a/api/src/main/scala/uk/ac/wellcome/platform/api/models/DisplayLocation.scala
+++ b/api/src/main/scala/uk/ac/wellcome/platform/api/models/DisplayLocation.scala
@@ -2,6 +2,7 @@ package uk.ac.wellcome.platform.api.models
 
 import com.fasterxml.jackson.annotation.JsonProperty
 import io.swagger.annotations.{ApiModel, ApiModelProperty}
+import uk.ac.wellcome.models.Location
 
 @ApiModel(
   value = "Location",
@@ -22,4 +23,13 @@ case class DisplayLocation(
 ) {
   @ApiModelProperty(readOnly = true, value = "A type of thing")
   @JsonProperty("type") val ontologyType: String = "Location"
+}
+
+case object DisplayLocation {
+  def apply(location: Location): DisplayLocation =
+    DisplayLocation(
+      locationType = location.locationType,
+      url = location.url,
+      license = DisplayLicense(location.license)
+    )
 }

--- a/api/src/main/scala/uk/ac/wellcome/platform/api/models/DisplayWork.scala
+++ b/api/src/main/scala/uk/ac/wellcome/platform/api/models/DisplayWork.scala
@@ -49,7 +49,7 @@ case class DisplayWork(
     dataType = "uk.ac.wellcome.platform.api.models.DisplayLocation",
     value =
       "Relates any thing to the location of a representative thumbnail image"
-  ) thumbnail: Option[Location] = None
+  ) thumbnail: Option[DisplayLocation] = None
 ) {
   @ApiModelProperty(readOnly = true, value = "A type of thing")
   @JsonProperty("type") val ontologyType: String = "Work"
@@ -85,7 +85,11 @@ case object DisplayWork {
       identifiers =
         if (includes.identifiers)
           Some(identifiedWork.work.identifiers.map(DisplayIdentifier(_)))
-        else None
+        else None,
+      thumbnail = identifiedWork.work.thumbnail match {
+        case Some(s) => Some(DisplayLocation(s))
+        case None => None
+      }
     )
   }
 }

--- a/api/src/main/scala/uk/ac/wellcome/platform/api/models/DisplayWork.scala
+++ b/api/src/main/scala/uk/ac/wellcome/platform/api/models/DisplayWork.scala
@@ -86,10 +86,12 @@ case object DisplayWork {
         if (includes.identifiers)
           Some(identifiedWork.work.identifiers.map(DisplayIdentifier(_)))
         else None,
-      thumbnail = identifiedWork.work.thumbnail match {
-        case Some(s) => Some(DisplayLocation(s))
-        case None => None
-      }
+      thumbnail =
+        if (includes.thumbnail)
+          identifiedWork.work.thumbnail match {
+          case Some(s) => Some(DisplayLocation(s))
+          case None => None
+        } else None
     )
   }
 }

--- a/api/src/main/scala/uk/ac/wellcome/platform/api/models/WorksIncludes.scala
+++ b/api/src/main/scala/uk/ac/wellcome/platform/api/models/WorksIncludes.scala
@@ -8,14 +8,17 @@ import com.fasterxml.jackson.databind.{
   JsonMappingException
 }
 
-case class WorksIncludes(identifiers: Boolean = false)
+case class WorksIncludes(
+  identifiers: Boolean = false,
+  thumbnail: Boolean = false
+)
 
 class WorksIncludesParsingException(msg: String)
     extends JsonMappingException(msg: String)
 
 case object WorksIncludes {
 
-  val recognisedIncludes = List("identifiers")
+  val recognisedIncludes = List("identifiers", "thumbnail")
 
   /// Parse an ?includes query-parameter string.
   ///
@@ -27,7 +30,8 @@ case object WorksIncludes {
       .filterNot(recognisedIncludes.contains)
     if (unrecognisedIncludes.length == 0) {
       WorksIncludes(
-        identifiers = includesList.contains("identifiers")
+        identifiers = includesList.contains("identifiers"),
+        thumbnail = includesList.contains("thumbnail")
       )
     } else {
       val errorMessage = if (unrecognisedIncludes.length == 1) {

--- a/api/src/test/scala/uk/ac/wellcome/platform/api/ApiWorksTest.scala
+++ b/api/src/test/scala/uk/ac/wellcome/platform/api/ApiWorksTest.scala
@@ -819,7 +819,7 @@ class ApiWorksTest
 
     eventually {
       server.httpGet(
-        path = s"/$apiPrefix/works?query=igloo&_index=alt_records",
+        path = s"/$apiPrefix/works",
         andExpect = Status.Ok,
         withJsonBody = s"""
                           |{
@@ -839,7 +839,7 @@ class ApiWorksTest
                           |     "thumbnail": {
                           |       "type": "Location",
                           |       "locationType": "${thumbnail.locationType}",
-                          |       "url": "${thumbnail.url}",
+                          |       "url": "${thumbnail.url.get}",
                           |       "license": {
                           |         "type": "License",
                           |         "licenseType": "${license.licenseType}",

--- a/api/src/test/scala/uk/ac/wellcome/platform/api/ApiWorksTest.scala
+++ b/api/src/test/scala/uk/ac/wellcome/platform/api/ApiWorksTest.scala
@@ -798,7 +798,7 @@ class ApiWorksTest
     }
   }
 
-  it("should include the thumbnail field if available") {
+  it("should include the thumbnail field if available and we use the thumbnail include") {
     val work = identifiedWorkWith(
       canonicalId = "1234",
       title = "A thorn in the thumb tells a traumatic tale",
@@ -819,7 +819,7 @@ class ApiWorksTest
 
     eventually {
       server.httpGet(
-        path = s"/$apiPrefix/works",
+        path = s"/$apiPrefix/works?includes=thumbnail",
         andExpect = Status.Ok,
         withJsonBody = s"""
                           |{
@@ -854,4 +854,48 @@ class ApiWorksTest
       )
     }
   }
+
+  it("should not include the thumbnail if we omit the thumbnail include") {
+    val work = identifiedWorkWith(
+      canonicalId = "1234",
+      title = "A thorn in the thumb tells a traumatic tale",
+      thumbnail = Location(
+        locationType = "thumbnail-image",
+        url = Some("https://iiif.example.org/1234/default.jpg"),
+        license = License(
+          licenseType = "CC-test",
+          label = "A fictional license for testing",
+          url = "http://creativecommons.org/licenses/test/-1.0/"
+        )
+      )
+    )
+    insertIntoElasticSearch(work)
+
+    eventually {
+      server.httpGet(
+        path = s"/$apiPrefix/works",
+        andExpect = Status.Ok,
+        withJsonBody = s"""
+                          |{
+                          |  "@context": "https://localhost:8888/$apiPrefix/context.json",
+                          |  "type": "ResultList",
+                          |  "pageSize": 10,
+                          |  "totalPages": 1,
+                          |  "totalResults": 1,
+                          |  "results": [
+                          |   {
+                          |     "type": "Work",
+                          |     "id": "${work.canonicalId}",
+                          |     "title": "${work.work.title}",
+                          |     "creators": [ ],
+                          |     "subjects": [ ],
+                          |     "genres": [ ]
+                          |   }
+                          |  ]
+                          |}
+          """.stripMargin
+      )
+    }
+  }
+
 }

--- a/api/src/test/scala/uk/ac/wellcome/platform/api/ApiWorksTest.scala
+++ b/api/src/test/scala/uk/ac/wellcome/platform/api/ApiWorksTest.scala
@@ -797,4 +797,61 @@ class ApiWorksTest
       )
     }
   }
+
+  it("should include the thumbnail field if available") {
+    val work = identifiedWorkWith(
+      canonicalId = "1234",
+      title = "A thorn in the thumb tells a traumatic tale",
+      thumbnail = Location(
+        locationType = "thumbnail-image",
+        url = Some("https://iiif.example.org/1234/default.jpg"),
+        license = License(
+          licenseType = "CC-test",
+          label = "A fictional license for testing",
+          url = "http://creativecommons.org/licenses/test/-1.0/"
+        )
+      )
+    )
+    insertIntoElasticSearch(work)
+
+    val thumbnail: Location = work.work.thumbnail.get
+    val license: LicenseTrait = thumbnail.license
+
+    eventually {
+      server.httpGet(
+        path = s"/$apiPrefix/works?query=igloo&_index=alt_records",
+        andExpect = Status.Ok,
+        withJsonBody = s"""
+                          |{
+                          |  "@context": "https://localhost:8888/$apiPrefix/context.json",
+                          |  "type": "ResultList",
+                          |  "pageSize": 10,
+                          |  "totalPages": 1,
+                          |  "totalResults": 1,
+                          |  "results": [
+                          |   {
+                          |     "type": "Work",
+                          |     "id": "${work.canonicalId}",
+                          |     "title": "${work.work.title}",
+                          |     "creators": [ ],
+                          |     "subjects": [ ],
+                          |     "genres": [ ],
+                          |     "thumbnail": {
+                          |       "type": "Location",
+                          |       "locationType": "${thumbnail.locationType}",
+                          |       "url": "${thumbnail.url}",
+                          |       "license": {
+                          |         "type": "License",
+                          |         "licenseType": "${license.licenseType}",
+                          |         "label": "${license.label}",
+                          |         "url": "${license.url}"
+                          |       }
+                          |     }
+                          |   }
+                          |  ]
+                          |}
+          """.stripMargin
+      )
+    }
+  }
 }

--- a/api/src/test/scala/uk/ac/wellcome/platform/api/WorksUtil.scala
+++ b/api/src/test/scala/uk/ac/wellcome/platform/api/WorksUtil.scala
@@ -48,6 +48,15 @@ trait WorksUtil {
 
   def identifiedWorkWith(canonicalId: String,
                          title: String,
+                         thumbnail: Location): IdentifiedWork =
+    IdentifiedWork(canonicalId, Work(
+      identifiers = List(SourceIdentifier(IdentifierSchemes.miroImageNumber, "5678")),
+      title = title,
+      thumbnail = Some(thumbnail)
+    ))
+
+  def identifiedWorkWith(canonicalId: String,
+                         title: String,
                          description: String,
                          lettering: String,
                          createdDate: Period,

--- a/api/src/test/scala/uk/ac/wellcome/platform/api/models/DisplayLicenseTest.scala
+++ b/api/src/test/scala/uk/ac/wellcome/platform/api/models/DisplayLicenseTest.scala
@@ -1,0 +1,24 @@
+package uk.ac.wellcome.platform.api.models
+
+import org.scalatest.{FunSpec, Matchers}
+import uk.ac.wellcome.models._
+
+class DisplayLicenseTest extends FunSpec with Matchers {
+
+  it("should read a License as a DisplayLicense correctly") {
+    val licenseType = "CC-Test"
+    val label = "A fictional license for testing"
+    val url = "http://creativecommons.org/licenses/test/-1.0/"
+
+    val internalLicense = License(
+      licenseType = licenseType,
+      label = label,
+      url = url
+    )
+    val displayLicense = DisplayLicense(internalLicense)
+
+    displayLicense.licenseType shouldBe licenseType
+    displayLicense.label shouldBe label
+    displayLicense.url shouldBe url
+  }
+}

--- a/api/src/test/scala/uk/ac/wellcome/platform/api/models/DisplayLocationTest.scala
+++ b/api/src/test/scala/uk/ac/wellcome/platform/api/models/DisplayLocationTest.scala
@@ -7,12 +7,13 @@ class DisplayLocationTest extends FunSpec with Matchers {
 
   it("should read a Location as a DisplayLocation correctly") {
     val thumbnailUrl = Some("https://iiif.example.org/V0000001/default.jpg")
+    val locationType = "thumbnail-image"
     val licenseType = "CC-Test"
     val licenseLabel = "A fictional license for testing"
     val licenseUrl = "http://creativecommons.org/licenses/test/-1.0/"
 
     val internalLocation = Location(
-      locationType = "thumbnail-image",
+      locationType = locationType,
       url = thumbnailUrl,
       license = License(
         licenseType = licenseType,
@@ -22,6 +23,7 @@ class DisplayLocationTest extends FunSpec with Matchers {
     )
     val displayLocation = DisplayLocation(internalLocation)
 
+    displayLocation.locationType shouldBe locationType
     displayLocation.url shouldBe thumbnailUrl
     displayLocation.license shouldBe DisplayLicense(
       licenseType = licenseType,

--- a/api/src/test/scala/uk/ac/wellcome/platform/api/models/DisplayLocationTest.scala
+++ b/api/src/test/scala/uk/ac/wellcome/platform/api/models/DisplayLocationTest.scala
@@ -1,0 +1,32 @@
+package uk.ac.wellcome.platform.api.models
+
+import org.scalatest.{FunSpec, Matchers}
+import uk.ac.wellcome.models._
+
+class DisplayLocationTest extends FunSpec with Matchers {
+
+  it("should read a Location as a DisplayLocation correctly") {
+    val thumbnailUrl = Some("https://iiif.example.org/V0000001/default.jpg")
+    val licenseType = "CC-Test"
+    val licenseLabel = "A fictional license for testing"
+    val licenseUrl = "http://creativecommons.org/licenses/test/-1.0/"
+
+    val internalLocation = Location(
+      locationType = "thumbnail-image",
+      url = thumbnailUrl,
+      license = License(
+        licenseType = licenseType,
+        label = licenseLabel,
+        url = licenseUrl
+      )
+    )
+    val displayLocation = DisplayLocation(internalLocation)
+
+    displayLocation.url shouldBe thumbnailUrl
+    displayLocation.license shouldBe DisplayLicense(
+      licenseType = licenseType,
+      label = licenseLabel,
+      url = licenseUrl
+    )
+  }
+}

--- a/common/src/main/scala/uk/ac/wellcome/models/License.scala
+++ b/common/src/main/scala/uk/ac/wellcome/models/License.scala
@@ -8,7 +8,9 @@
 package uk.ac.wellcome.models
 
 import com.fasterxml.jackson.annotation.JsonProperty
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize
 
+@JsonDeserialize(as = classOf[License])
 trait LicenseTrait {
   val licenseType: String
   val label: String
@@ -16,7 +18,7 @@ trait LicenseTrait {
   @JsonProperty("type") val ontologyType: String = "License"
 }
 
-case class License (
+case class License(
   val licenseType: String,
   val label: String,
   val url: String


### PR DESCRIPTION
This is the display logic corresponding to #822 – once the ingestor puts information about thumbnails in Elasticsearch, make sure it appears on the other side.

Related: #792.