### PR TITLE
Add an ontologyType column to the ID minter database

### DIFF
--- a/id_minter/src/main/resources/db/migration/V2__different_ontologytype.sql
+++ b/id_minter/src/main/resources/db/migration/V2__different_ontologytype.sql
@@ -1,0 +1,26 @@
+-- This patch is preliminary work for supporting items in the ID minter.
+--
+-- Because a single MIRO record becomes both a work and an item, we:
+--
+--   * Add an ontologyType field so we can distinguish between an ID minted
+--     for a work and an item.  Everything in the ID minter database when
+--     we made this migration was a "Work", so we backfill existing rows,
+--     then set it to NULL for future rows.
+
+USE ${database};
+
+ALTER TABLE ${tableName}
+ADD COLUMN ontologyType varchar(255) DEFAULT 'Work' AFTER CanonicalID;
+
+ALTER TABLE ${tableName}
+ALTER COLUMN ontologyType SET DEFAULT null;
+
+--   * Drop the uniqueness constraint on (MiroID), and add a new uniqueness
+--     constraint for (ontologyType, MiroID).  This allows us to put the same
+--     MiroID on multiple rows: once for the work, once for the item.
+
+ALTER TABLE ${tableName}
+DROP INDEX MiroID;
+
+ALTER TABLE ${tableName}
+ADD UNIQUE (ontologyType, MiroID);

--- a/id_minter/src/main/resources/db/migration/V2__different_ontologytype.sql
+++ b/id_minter/src/main/resources/db/migration/V2__different_ontologytype.sql
@@ -10,10 +10,10 @@
 USE ${database};
 
 ALTER TABLE ${tableName}
-ADD COLUMN ontologyType varchar(255) DEFAULT 'Work' AFTER CanonicalID;
+ADD COLUMN ontologyType varchar(255) NOT NULL DEFAULT 'Work' AFTER CanonicalID;
 
 ALTER TABLE ${tableName}
-ALTER COLUMN ontologyType SET DEFAULT null;
+ALTER COLUMN ontologyType DROP DEFAULT;
 
 --   * Drop the uniqueness constraint on (MiroID), and add a new uniqueness
 --     constraint for (ontologyType, MiroID).  This allows us to put the same

--- a/id_minter/src/main/scala/uk/ac/wellcome/platform/idminter/database/IdentifiersDao.scala
+++ b/id_minter/src/main/scala/uk/ac/wellcome/platform/idminter/database/IdentifiersDao.scala
@@ -16,13 +16,19 @@ class IdentifiersDao @Inject()(db: DB, identifiers: IdentifiersTable)
 
   implicit val session = AutoSession(db.settingsProvider)
 
-  def lookupMiroID(miroID: String): Future[Option[Identifier]] =
+  def lookupMiroID(miroID: String,
+                   ontologyType: String = "Work"): Future[Option[Identifier]] =
     Future {
       blocking {
         info(s"About to search for MiroID $miroID in Identifiers")
         val i = identifiers.i
         withSQL {
-          select.from(identifiers as i).where.eq(i.MiroID, miroID)
+          select
+            .from(identifiers as i)
+            .where
+            .eq(i.ontologyType, ontologyType)
+            .and
+            .eq(i.MiroID, miroID)
         }.map(Identifier(i)).single.apply()
       }
     } recover {
@@ -40,7 +46,9 @@ class IdentifiersDao @Inject()(db: DB, identifiers: IdentifiersTable)
             .into(identifiers)
             .namedValues(
               identifiers.column.CanonicalID -> identifier.CanonicalID,
-              identifiers.column.MiroID -> identifier.MiroID)
+              identifiers.column.ontologyType -> identifier.ontologyType,
+              identifiers.column.MiroID -> identifier.MiroID
+            )
         }.update().apply()
       }
     }

--- a/id_minter/src/main/scala/uk/ac/wellcome/platform/idminter/model/IdentifiersTable.scala
+++ b/id_minter/src/main/scala/uk/ac/wellcome/platform/idminter/model/IdentifiersTable.scala
@@ -5,12 +5,19 @@ import com.twitter.inject.annotations.Flag
 import scalikejdbc._
 
 /** Represents a set of identifiers as stored in MySQL */
-case class Identifier(CanonicalID: String, MiroID: String)
+case class Identifier(
+  CanonicalID: String,
+  MiroID: String,
+  ontologyType: String = "Work"
+)
 
 object Identifier {
   def apply(p: SyntaxProvider[Identifier])(rs: WrappedResultSet): Identifier =
-    Identifier(rs.string(p.resultName.CanonicalID),
-               rs.string(p.resultName.MiroID))
+    Identifier(
+      CanonicalID = rs.string(p.resultName.CanonicalID),
+      MiroID = rs.string(p.resultName.MiroID),
+      ontologyType = rs.string(p.resultName.ontologyType)
+    )
 }
 
 class IdentifiersTable @Inject()(

--- a/id_minter/src/main/scala/uk/ac/wellcome/platform/idminter/model/IdentifiersTable.scala
+++ b/id_minter/src/main/scala/uk/ac/wellcome/platform/idminter/model/IdentifiersTable.scala
@@ -20,7 +20,7 @@ class IdentifiersTable @Inject()(
   override val schemaName = Some(database)
   override val tableName = table
   override val useSnakeCaseColumnName = false
-  override val columns = Seq("MiroID", "CanonicalID")
+  override val columns = Seq("CanonicalID", "ontologyType", "MiroID")
 
   val i = this.syntax("i")
 }

--- a/id_minter/src/test/scala/uk/ac/wellcome/platform/idminter/database/IdentifiersDaoTest.scala
+++ b/id_minter/src/test/scala/uk/ac/wellcome/platform/idminter/database/IdentifiersDaoTest.scala
@@ -20,8 +20,7 @@ class IdentifiersDaoTest
     it("should return a future of Some[Identifier] if it can find a MiroID in the DB") {
       val identifier = Identifier(
         CanonicalID = "A sand snail",
-        MiroID = "A soft shell",
-        ontologyType = "Work"
+        MiroID = "A soft shell"
       )
       assertInsertingIdentifierSucceeds(identifier)
 
@@ -32,9 +31,23 @@ class IdentifiersDaoTest
     }
 
     it("should return a future of None if looking up a non-existent Miro ID") {
-      whenReady(identifiersDao.lookupMiroID("A missing mouse")) { maybeIdentifier =>
-        maybeIdentifier shouldNot be(defined)
-      }
+      assertLookupMiroIDFindsNothing(
+        miroID = "A missing mouse"
+      )
+    }
+
+    it("should return a future of None if looking up a Miro ID with the wrong ontologyType") {
+      val identifier = Identifier(
+        CanonicalID = "A sprinkling of sage",
+        MiroID = "Seasoning with saffron",
+        ontologyType = "Herbs"
+      )
+      assertInsertingIdentifierSucceeds(identifier)
+
+      assertLookupMiroIDFindsNothing(
+        miroID = identifier.MiroID,
+        ontologyType = "Vegetables"
+      )
     }
   }
 
@@ -66,27 +79,57 @@ class IdentifiersDaoTest
       val identifier = new Identifier(
         CanonicalID = "A failed field of flowers",
         MiroID = "A farm full of fruit",
-        ontologyType = "Work"
+        ontologyType = "Fruits"
       )
       val duplicateIdentifier = new Identifier(
         CanonicalID = identifier.CanonicalID,
         MiroID = "Fuel for a factory",
-        ontologyType = "Work"
+        ontologyType = "Fuels"
       )
 
       assertInsertingDuplicateFails(identifier, duplicateIdentifier)
     }
 
-    it("should fail to insert a record with a duplicate MiroID") {
+    it("should allow saving two records with the same MiroID but different ontologyType") {
       val identifier = new Identifier(
-        CanonicalID = "A picking of parsley",
-        MiroID = "A packet of peppermints",
-        ontologyType = "Work"
+        CanonicalID = "A mountain of muesli",
+        MiroID = "A maize made of maze",
+        ontologyType = "Cereals"
+      )
+      val secondIdentifier = new Identifier(
+        CanonicalID = "A mere mango",
+        MiroID = identifier.MiroID,
+        ontologyType = "Fruits"
+      )
+      assertInsertingIdentifierSucceeds(identifier)
+      assertInsertingIdentifierSucceeds(secondIdentifier)
+    }
+
+    it("should allow saving two records with different MiroID but the same ontologyType") {
+      val identifier = new Identifier(
+        CanonicalID = "Overflowing with okra",
+        MiroID = "Olive oil in an orchard",
+        ontologyType = "Crops"
+      )
+      val secondIdentifier = new Identifier(
+        CanonicalID = "An order of onions",
+        MiroID = "Only orange orbs",
+        ontologyType = identifier.ontologyType
+      )
+      assertInsertingIdentifierSucceeds(identifier)
+      assertInsertingIdentifierSucceeds(secondIdentifier)
+    }
+
+    it("should reject inserting two records with the same MiroID and ontologyType") {
+      val identifier = new Identifier(
+        CanonicalID = "A surplus of strawberries",
+        MiroID = "Sunflower seeds in a sack",
+        ontologyType = "Cropssss"
       )
       val duplicateIdentifier = new Identifier(
-        CanonicalID = "A portion of potatoes",
+        CanonicalID = "Sweeteners and sugar cane",
         MiroID = identifier.MiroID,
-        ontologyType = "Work"
+        ontologyType = identifier.ontologyType
       )
 
       assertInsertingDuplicateFails(identifier, duplicateIdentifier)
@@ -111,4 +154,15 @@ class IdentifiersDaoTest
     whenReady(identifiersDao.saveIdentifier(identifier)) { result =>
       result shouldBe 1
     }
+
+  /** Helper method.  Do a Miro ID lookup and check that it fails. */
+  private def assertLookupMiroIDFindsNothing(miroID: String, ontologyType: String = "Work") = {
+    val lookupFuture = identifiersDao.lookupMiroID(
+      miroID = miroID,
+      ontologyType = ontologyType
+    )
+    whenReady(lookupFuture) { maybeIdentifier =>
+      maybeIdentifier shouldNot be(defined)
+    }
+  }
 }

--- a/id_minter/src/test/scala/uk/ac/wellcome/platform/idminter/database/IdentifiersDaoTest.scala
+++ b/id_minter/src/test/scala/uk/ac/wellcome/platform/idminter/database/IdentifiersDaoTest.scala
@@ -20,7 +20,8 @@ class IdentifiersDaoTest
     it("should return a future of Some[Identifier] if it can find a MiroID in the DB") {
       val identifier = Identifier(
         CanonicalID = "A sand snail",
-        MiroID = "A soft shell"
+        MiroID = "A soft shell",
+        ontologyType = "Work"
       )
       insertIdentifier(identifier)
 
@@ -41,7 +42,8 @@ class IdentifiersDaoTest
     it("should insert the provided identifier into the database") {
       val identifier = Identifier(
         CanonicalID = "A provision of porpoises",
-        MiroID = "A picture of pangolins"
+        MiroID = "A picture of pangolins",
+        ontologyType = "Work"
       )
       val future = identifiersDao.saveIdentifier(identifier)
 
@@ -63,11 +65,13 @@ class IdentifiersDaoTest
     it("should fail to insert a record with a duplicate CanonicalID") {
       val identifier = new Identifier(
         CanonicalID = "A failed field of flowers",
-        MiroID = "A farm full of fruit"
+        MiroID = "A farm full of fruit",
+        ontologyType = "Work"
       )
       val duplicateIdentifier = new Identifier(
         CanonicalID = identifier.CanonicalID,
-        MiroID = "Fuel for a factory"
+        MiroID = "Fuel for a factory",
+        ontologyType = "Work"
       )
 
       assertInsertingDuplicateFails(identifier, duplicateIdentifier)
@@ -76,11 +80,13 @@ class IdentifiersDaoTest
     it("should fail to insert a record with a duplicate MiroID") {
       val identifier = new Identifier(
         CanonicalID = "A picking of parsley",
-        MiroID = "A packet of peppermints"
+        MiroID = "A packet of peppermints",
+        ontologyType = "Work"
       )
       val duplicateIdentifier = new Identifier(
         CanonicalID = "A portion of potatoes",
-        MiroID = identifier.MiroID
+        MiroID = identifier.MiroID,
+        ontologyType = "Work"
       )
 
       assertInsertingDuplicateFails(identifier, duplicateIdentifier)

--- a/id_minter/src/test/scala/uk/ac/wellcome/platform/idminter/database/IdentifiersDaoTest.scala
+++ b/id_minter/src/test/scala/uk/ac/wellcome/platform/idminter/database/IdentifiersDaoTest.scala
@@ -23,7 +23,7 @@ class IdentifiersDaoTest
         MiroID = "A soft shell",
         ontologyType = "Work"
       )
-      insertIdentifier(identifier)
+      assertInsertingIdentifierSucceeds(identifier)
 
       whenReady(identifiersDao.lookupMiroID(identifier.MiroID)) { maybeIdentifier =>
         maybeIdentifier shouldBe defined
@@ -98,7 +98,7 @@ class IdentifiersDaoTest
     */
   private def assertInsertingDuplicateFails(identifier: Identifier,
                                             duplicateIdentifier: Identifier) = {
-    insertIdentifier(identifier)
+    assertInsertingIdentifierSucceeds(identifier)
 
     val duplicateFuture = identifiersDao.saveIdentifier(duplicateIdentifier)
     whenReady(duplicateFuture.failed) { exception =>
@@ -107,7 +107,7 @@ class IdentifiersDaoTest
   }
 
   /** Helper method.  Insert a record and check that it succeeds. */
-  private def insertIdentifier(identifier: Identifier) =
+  private def assertInsertingIdentifierSucceeds(identifier: Identifier) =
     whenReady(identifiersDao.saveIdentifier(identifier)) { result =>
       result shouldBe 1
     }

--- a/id_minter/src/test/scala/uk/ac/wellcome/platform/idminter/database/TableProvisionerTest.scala
+++ b/id_minter/src/test/scala/uk/ac/wellcome/platform/idminter/database/TableProvisionerTest.scala
@@ -48,10 +48,14 @@ class TableProvisionerTest
                          dataType = "varchar(255)",
                          nullable = "NO",
                          key = "PRI"),
+        FieldDescription(field = "ontologyType",
+                         dataType = "varchar(255)",
+                         nullable = "YES",
+                         key = "MUL"),
         FieldDescription(field = "MiroID",
                          dataType = "varchar(255)",
                          nullable = "YES",
-                         key = "UNI")
+                         key = "")
       )
     }
   }

--- a/id_minter/src/test/scala/uk/ac/wellcome/platform/idminter/database/TableProvisionerTest.scala
+++ b/id_minter/src/test/scala/uk/ac/wellcome/platform/idminter/database/TableProvisionerTest.scala
@@ -50,7 +50,7 @@ class TableProvisionerTest
                          key = "PRI"),
         FieldDescription(field = "ontologyType",
                          dataType = "varchar(255)",
-                         nullable = "YES",
+                         nullable = "NO",
                          key = "MUL"),
         FieldDescription(field = "MiroID",
                          dataType = "varchar(255)",

--- a/id_minter/src/test/scala/uk/ac/wellcome/platform/idminter/steps/IdentifierGeneratorTest.scala
+++ b/id_minter/src/test/scala/uk/ac/wellcome/platform/idminter/steps/IdentifierGeneratorTest.scala
@@ -36,7 +36,8 @@ class IdentifierGeneratorTest
       insert
         .into(identifiersTable)
         .namedValues(identifiersTable.column.CanonicalID -> "5678",
-                     identifiersTable.column.MiroID -> "1234")
+                     identifiersTable.column.MiroID -> "1234",
+                     identifiersTable.column.ontologyType -> "Work")
     }.update().apply()
 
     val work =


### PR DESCRIPTION
### What is this PR trying to achieve?

Allow us to record ontologyType in the ID minter database. This allows us to have multiple rows with the same MiroID – recording canonical IDs for the corresponding work and item.

This patch sets up the underlying database field to store the ontologyType, although nothing in the ID minter yet sets it to anything except "Work". That will come in a separate patch.

### Who is this change for?

Folks working on #839.

### Have the following been considered/are they needed?

- [ ] Deployed new versions