### PR TITLE
Preliminary refactoring of IdentifiersDao in the ID minter

### DIFF
--- a/id_minter/src/main/scala/uk/ac/wellcome/platform/idminter/database/IdentifiersDao.scala
+++ b/id_minter/src/main/scala/uk/ac/wellcome/platform/idminter/database/IdentifiersDao.scala
@@ -46,7 +46,7 @@ class IdentifiersDao @Inject()(db: DB, identifiers: IdentifiersTable)
         throw e
     }
 
-  def saveIdentifier(identifier: Identifier): Future[Unit] = {
+  def saveIdentifier(identifier: Identifier): Future[Int] = {
     val insertIntoDbFuture = Future {
       blocking {
         info(s"putting new identifier $identifier")
@@ -57,7 +57,6 @@ class IdentifiersDao @Inject()(db: DB, identifiers: IdentifiersTable)
               identifiers.column.CanonicalID -> identifier.CanonicalID,
               identifiers.column.MiroID -> identifier.MiroID)
         }.update().apply()
-        ()
       }
     }
     insertIntoDbFuture.onFailure {

--- a/id_minter/src/main/scala/uk/ac/wellcome/platform/idminter/database/IdentifiersDao.scala
+++ b/id_minter/src/main/scala/uk/ac/wellcome/platform/idminter/database/IdentifiersDao.scala
@@ -16,21 +16,6 @@ class IdentifiersDao @Inject()(db: DB, identifiers: IdentifiersTable)
 
   implicit val session = AutoSession(db.settingsProvider)
 
-  def lookupCanonicalID(canonicalID: String): Future[Option[Identifier]] =
-    Future {
-      blocking {
-        info(s"About to search for canonical ID $canonicalID in Identifiers")
-        val i = identifiers.i
-        withSQL {
-          select.from(identifiers as i).where.eq(i.CanonicalID, canonicalID)
-        }.map(Identifier(i)).single.apply()
-      }
-    } recover {
-      case e: Throwable =>
-        error(s"Failed getting canonicalID $canonicalID in Identifiers", e)
-        throw e
-    }
-
   def lookupMiroID(miroID: String): Future[Option[Identifier]] =
     Future {
       blocking {

--- a/id_minter/src/main/scala/uk/ac/wellcome/platform/idminter/database/IdentifiersDao.scala
+++ b/id_minter/src/main/scala/uk/ac/wellcome/platform/idminter/database/IdentifiersDao.scala
@@ -16,6 +16,21 @@ class IdentifiersDao @Inject()(db: DB, identifiers: IdentifiersTable)
 
   implicit val session = AutoSession(db.settingsProvider)
 
+  def lookupCanonicalID(canonicalID: String): Future[Option[Identifier]] =
+    Future {
+      blocking {
+        info(s"About to search for canonical ID $canonicalID in Identifiers")
+        val i = identifiers.i
+        withSQL {
+          select.from(identifiers as i).where.eq(i.CanonicalID, canonicalID)
+        }.map(Identifier(i)).single.apply()
+      }
+    } recover {
+      case e: Throwable =>
+        error(s"Failed getting canonicalID $canonicalID in Identifiers", e)
+        throw e
+    }
+
   def findSourceIdInDb(miroId: String): Future[Option[Identifier]] =
     Future {
       blocking {

--- a/id_minter/src/main/scala/uk/ac/wellcome/platform/idminter/database/IdentifiersDao.scala
+++ b/id_minter/src/main/scala/uk/ac/wellcome/platform/idminter/database/IdentifiersDao.scala
@@ -31,18 +31,18 @@ class IdentifiersDao @Inject()(db: DB, identifiers: IdentifiersTable)
         throw e
     }
 
-  def findSourceIdInDb(miroId: String): Future[Option[Identifier]] =
+  def lookupMiroID(miroID: String): Future[Option[Identifier]] =
     Future {
       blocking {
-        info(s"About to search for MiroID $miroId in Identifiers")
+        info(s"About to search for MiroID $miroID in Identifiers")
         val i = identifiers.i
         withSQL {
-          select.from(identifiers as i).where.eq(i.MiroID, miroId)
+          select.from(identifiers as i).where.eq(i.MiroID, miroID)
         }.map(Identifier(i)).single.apply()
       }
     } recover {
       case e: Throwable =>
-        error(s"Failed getting MiroID $miroId in DynamoDB", e)
+        error(s"Failed getting MiroID $miroID in Identifiers", e)
         throw e
     }
 

--- a/id_minter/src/main/scala/uk/ac/wellcome/platform/idminter/steps/IdentifierGenerator.scala
+++ b/id_minter/src/main/scala/uk/ac/wellcome/platform/idminter/steps/IdentifierGenerator.scala
@@ -33,7 +33,7 @@ class IdentifierGenerator @Inject()(identifiersDao: IdentifiersDao,
 
   private def retrieveOrGenerateCanonicalId(
     identifier: SourceIdentifier): Future[String] =
-    identifiersDao.findSourceIdInDb(identifier.value).flatMap {
+    identifiersDao.lookupMiroID(identifier.value).flatMap {
       case Some(id) => {
         metricsSender.incrementCount("found-old-id")
         Future.successful(id.CanonicalID)

--- a/id_minter/src/test/scala/uk/ac/wellcome/platform/idminter/database/IdentifiersDaoTest.scala
+++ b/id_minter/src/test/scala/uk/ac/wellcome/platform/idminter/database/IdentifiersDaoTest.scala
@@ -16,27 +16,6 @@ class IdentifiersDaoTest
 
   val identifiersDao = new IdentifiersDao(DB.connect(), identifiersTable)
 
-  describe("lookupCanonicalID") {
-    it("should return a future of Some[Identifier] if it can find a Canonical ID in the DB") {
-      val identifier = Identifier(
-        CanonicalID = "A canonical cat",
-        MiroID = "A curious cheetah"
-      )
-      insertIdentifier(identifier)
-
-      whenReady(identifiersDao.lookupCanonicalID(identifier.CanonicalID)) { maybeIdentifier =>
-        maybeIdentifier shouldBe defined
-        maybeIdentifier.get shouldBe identifier
-      }
-    }
-
-    it("should return a future of None if looking up a non-existent Canonical ID") {
-      whenReady(identifiersDao.lookupCanonicalID("A vanishing vulture")) { maybeIdentifier =>
-        maybeIdentifier shouldNot be(defined)
-      }
-    }
-  }
-
   describe("lookupMiroID") {
     it("should return a future of Some[Identifier] if it can find a MiroID in the DB") {
       val identifier = Identifier(

--- a/id_minter/src/test/scala/uk/ac/wellcome/platform/idminter/database/IdentifiersDaoTest.scala
+++ b/id_minter/src/test/scala/uk/ac/wellcome/platform/idminter/database/IdentifiersDaoTest.scala
@@ -17,7 +17,7 @@ class IdentifiersDaoTest
   val identifiersDao = new IdentifiersDao(DB.connect(), identifiersTable)
 
   describe("lookupCanonicalID") {
-    it("should return a future of Some[Identifier] able to find a Canonical ID in the DB") {
+    it("should return a future of Some[Identifier] if it can find a Canonical ID in the DB") {
       val identifier = Identifier(
         CanonicalID = "A canonical cat",
         MiroID = "A curious cheetah"
@@ -38,8 +38,7 @@ class IdentifiersDaoTest
   }
 
   describe("findSourceIdInDb") {
-    it(
-      "should return a future of some if the requested miroId is in the database") {
+    it("should return a future of Some[Identifier] if it can find a MiroID in the DB") {
       val identifier = Identifier(
         CanonicalID = "A sand snail",
         MiroID = "A soft shell"
@@ -52,9 +51,8 @@ class IdentifiersDaoTest
       }
     }
 
-    it(
-      "should return a future of none if the requested miroId is not in the database") {
-      whenReady(identifiersDao.findSourceIdInDb("abcdef")) { maybeIdentifier =>
+    it("should return a future of None if looking up a non-existent Miro ID") {
+      whenReady(identifiersDao.findSourceIdInDb("A missing mouse")) { maybeIdentifier =>
         maybeIdentifier shouldNot be(defined)
       }
     }

--- a/id_minter/src/test/scala/uk/ac/wellcome/platform/idminter/database/IdentifiersDaoTest.scala
+++ b/id_minter/src/test/scala/uk/ac/wellcome/platform/idminter/database/IdentifiersDaoTest.scala
@@ -108,6 +108,9 @@ class IdentifiersDaoTest
     }
   }
 
+  /** Helper method.  Given two records, try to insert them both, and check
+    * that integrity checks in the database reject the second record.
+    */
   private def assertInsertingDuplicateFails(identifier: Identifier,
                                             duplicateIdentifier: Identifier) = {
     insertIdentifier(identifier)
@@ -118,6 +121,7 @@ class IdentifiersDaoTest
     }
   }
 
+  /** Helper method.  Insert a record and check that it succeeds. */
   private def insertIdentifier(identifier: Identifier) =
     whenReady(identifiersDao.saveIdentifier(identifier)) { result =>
       result shouldBe 1

--- a/id_minter/src/test/scala/uk/ac/wellcome/platform/idminter/database/IdentifiersDaoTest.scala
+++ b/id_minter/src/test/scala/uk/ac/wellcome/platform/idminter/database/IdentifiersDaoTest.scala
@@ -37,7 +37,7 @@ class IdentifiersDaoTest
     }
   }
 
-  describe("findSourceIdInDb") {
+  describe("lookupMiroID") {
     it("should return a future of Some[Identifier] if it can find a MiroID in the DB") {
       val identifier = Identifier(
         CanonicalID = "A sand snail",
@@ -45,14 +45,14 @@ class IdentifiersDaoTest
       )
       insertIdentifier(identifier)
 
-      whenReady(identifiersDao.findSourceIdInDb(identifier.MiroID)) { maybeIdentifier =>
+      whenReady(identifiersDao.lookupMiroID(identifier.MiroID)) { maybeIdentifier =>
         maybeIdentifier shouldBe defined
         maybeIdentifier.get shouldBe identifier
       }
     }
 
     it("should return a future of None if looking up a non-existent Miro ID") {
-      whenReady(identifiersDao.findSourceIdInDb("A missing mouse")) { maybeIdentifier =>
+      whenReady(identifiersDao.lookupMiroID("A missing mouse")) { maybeIdentifier =>
         maybeIdentifier shouldNot be(defined)
       }
     }

--- a/id_minter/src/test/scala/uk/ac/wellcome/platform/idminter/database/IdentifiersDaoTest.scala
+++ b/id_minter/src/test/scala/uk/ac/wellcome/platform/idminter/database/IdentifiersDaoTest.scala
@@ -84,13 +84,7 @@ class IdentifiersDaoTest
     it(
       "should fail inserting a record if there is already a record for the same miroId") {
       val identifier = new Identifier(CanonicalID = "5678", MiroID = "1234")
-      withSQL {
-        insert
-          .into(identifiersTable)
-          .namedValues(
-            identifiersTable.column.CanonicalID -> identifier.CanonicalID,
-            identifiersTable.column.MiroID -> identifier.MiroID)
-      }.update().apply()
+      insertIdentifier(identifier)
 
       val saveCanonicalId =
         identifiersDao.saveIdentifier(identifier.copy(CanonicalID = "0987"))
@@ -101,12 +95,7 @@ class IdentifiersDaoTest
   }
 
   private def insertIdentifier(identifier: Identifier) =
-    withSQL {
-      insert
-        .into(identifiersTable)
-        .namedValues(
-          identifiersTable.column.CanonicalID -> identifier.CanonicalID,
-          identifiersTable.column.MiroID -> identifier.MiroID
-        )
-    }.update().apply()
+    whenReady(identifiersDao.saveIdentifier(identifier)) { result =>
+      result shouldBe 1
+    }
 }

--- a/id_minter/src/test/scala/uk/ac/wellcome/platform/idminter/modules/IdMinterWorkerTest.scala
+++ b/id_minter/src/test/scala/uk/ac/wellcome/platform/idminter/modules/IdMinterWorkerTest.scala
@@ -73,7 +73,7 @@ class IdMinterWorkerTest
   it(
     "should send a function that returns a failed future to sqsReader if inserting an identifier into the database fails") {
     val miroId = "1234"
-    when(identifiersDao.findSourceIdInDb(miroId))
+    when(identifiersDao.lookupMiroID(miroId))
       .thenReturn(Future.successful(None))
     when(identifiersDao.saveIdentifier(any[Identifier]))
       .thenReturn(Future.failed(new Exception("cannot insert")))

--- a/id_minter/src/test/scala/uk/ac/wellcome/platform/idminter/steps/IdentifierGeneratorTest.scala
+++ b/id_minter/src/test/scala/uk/ac/wellcome/platform/idminter/steps/IdentifierGeneratorTest.scala
@@ -89,7 +89,7 @@ class IdentifierGeneratorTest
     val identifierGenerator =
       new IdentifierGenerator(identifiersDao, metricsSender)
 
-    when(identifiersDao.findSourceIdInDb(miroId))
+    when(identifiersDao.lookupMiroID(miroId))
       .thenReturn(Future.successful(None))
     val expectedException = new Exception("Noooo")
     when(identifiersDao.saveIdentifier(any[Identifier]()))


### PR DESCRIPTION
Separated from #840 – this is a bit of refactoring in the IdentifiersDao.

Underlying ideas:

* Reduce code repetition
* More whimsy/unique strings (yes I like whimsy, also makes it easier to see which tests are in-flight and debug broken things)
* Prepare for the fact that we’re going to get more complex uniqueness checks, and so making it easy to test “can I do X but not Y” will be helpful