### PR TITLE
Add an ECS task for taking a complete dump of records from Elasticsearch

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -116,3 +116,4 @@ env:
     - TASK=gatling-build
     - TASK=loris-build
     - TASK=miro_adapter-build
+    - TASK=elasticdump-build

--- a/Makefile
+++ b/Makefile
@@ -57,6 +57,13 @@ miro_adapter-deploy: miro_adapter-build
 	./scripts/deploy_docker_to_aws.py --project=miro_adapter --infra-bucket=$(INFRA_BUCKET)
 
 
+elasticdump-build: install-docker-build-deps
+	./scripts/build_docker_image.py --project=elasticdump
+
+elasticdump-deploy: elasticdump-build
+	./scripts/deploy_docker_to_aws.py --project=elasticdump --infra-bucket=$(INFRA_BUCKET)
+
+
 install-docker-build-deps:
 	pip3 install --upgrade boto3 docopt
 

--- a/docker/elasticdump/Dockerfile
+++ b/docker/elasticdump/Dockerfile
@@ -1,0 +1,9 @@
+FROM alpine
+
+RUN apk update
+RUN apk add nodejs-npm python3
+RUN npm install -g elasticdump
+RUN pip3 install awscli
+
+COPY run_elasticdump.sh /run_elasticdump.sh
+CMD ["/run_elasticdump.sh"]

--- a/docker/elasticdump/README.md
+++ b/docker/elasticdump/README.md
@@ -1,3 +1,32 @@
 # elasticdump
 
-This task can be triggered to get a complete dump of records from an Elasticsearch index, which are then uploaded to an S3 bucket.
+This task can be triggered to get a complete dump of records from an Elasticsearch index, which are uploaded to an S3 bucket.
+
+## Usage
+
+This Docker image is kept as a task definition in ECS, and can be invoked as a one-off task using the RunTask API.
+
+You need to pass the name of the index that you want to dump as an environment variable `INDEX`.
+
+For example:
+
+```
+aws ecs run-task --cluster=services_cluster \
+    --task-definition=elasticdump_task_definition \
+    --overrides='{
+      "containerOverrides": [
+        {
+          "name": "app",
+          "environment": [
+            { "name": "INDEX", "value": "works-with-thumbnails" }
+          ]
+        }
+      ]
+    }'
+```
+
+Assuming the task completes successfully, the dump is written to the `elasticdump` folder in our `platform-infra` bucket.
+
+## Deployment
+
+This task is built and deployed automatically by Travis.

--- a/docker/elasticdump/README.md
+++ b/docker/elasticdump/README.md
@@ -1,0 +1,3 @@
+# elasticdump
+
+This task can be triggered to get a complete dump of records from an Elasticsearch index, which are then uploaded to an S3 bucket.

--- a/docker/elasticdump/run_elasticdump.sh
+++ b/docker/elasticdump/run_elasticdump.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env sh
+
+set -o errexit
+set -o nounset
+
+aws s3 cp s3://platform-infra/config/prod/ingestor.ini ingestor_config.ini
+
+# Create the HTTP auth file required by elasticdump
+username=$(awk -F "=" '/es.username/ {print $2}' ingestor_config.ini)
+password=$(awk -F "=" '/es.password/ {print $2}' ingestor_config.ini)
+echo "user=$username"      > auth.ini
+echo "password=$password" >> auth.ini
+
+# Now run the elasticdump tool and pull it down
+hostname=$(awk -F "=" '/es.host/ {print $2}' ingestor_config.ini)
+outfile="dump_$(date)_$INDEX.txt"
+elasticdump --input="https://$hostname/$INDEX" --output="$outfile" --httpAuthFile=auth.ini
+
+# And copy it back up to S3
+aws s3 cp "$outfile" "s3://platform-infra/esdump/$outfile"

--- a/docker/elasticdump/run_elasticdump.sh
+++ b/docker/elasticdump/run_elasticdump.sh
@@ -3,18 +3,18 @@
 set -o errexit
 set -o nounset
 
-aws s3 cp s3://platform-infra/config/prod/ingestor.ini ingestor_config.ini
+aws s3 cp s3://$BUCKET/$CONFIG_KEY config.ini
 
 # Create the HTTP auth file required by elasticdump
-username=$(awk -F "=" '/es.username/ {print $2}' ingestor_config.ini)
-password=$(awk -F "=" '/es.password/ {print $2}' ingestor_config.ini)
+username=$(awk -F "=" '/es.username/ {print $2}' config.ini)
+password=$(awk -F "=" '/es.password/ {print $2}' config.ini)
 echo "user=$username"      > auth.ini
 echo "password=$password" >> auth.ini
 
 # Now run the elasticdump tool and pull it down
-hostname=$(awk -F "=" '/es.host/ {print $2}' ingestor_config.ini)
+hostname=$(awk -F "=" '/es.host/ {print $2}' config.ini)
 outfile="dump_$(date +"%Y-%m-%d_%H-%M-%S")_$INDEX.txt"
 elasticdump --input="https://$hostname/$INDEX" --output="$outfile" --httpAuthFile=auth.ini
 
 # And copy it back up to S3
-aws s3 cp "$outfile" "s3://platform-infra/elasticdump/$outfile"
+aws s3 cp "$outfile" "s3://$BUCKET/elasticdump/$outfile"

--- a/docker/elasticdump/run_elasticdump.sh
+++ b/docker/elasticdump/run_elasticdump.sh
@@ -13,8 +13,8 @@ echo "password=$password" >> auth.ini
 
 # Now run the elasticdump tool and pull it down
 hostname=$(awk -F "=" '/es.host/ {print $2}' ingestor_config.ini)
-outfile="dump_$(date)_$INDEX.txt"
+outfile="dump_$(date +"%Y-%m-%d_%H-%M-%S")_$INDEX.txt"
 elasticdump --input="https://$hostname/$INDEX" --output="$outfile" --httpAuthFile=auth.ini
 
 # And copy it back up to S3
-aws s3 cp "$outfile" "s3://platform-infra/esdump/$outfile"
+aws s3 cp "$outfile" "s3://platform-infra/elasticdump/$outfile"

--- a/miro_adapter/miro_adapter.py
+++ b/miro_adapter/miro_adapter.py
@@ -20,7 +20,6 @@ import json
 import time
 
 import boto3
-from botocore.exceptions import ClientError
 import docopt
 
 from utils import generate_images
@@ -33,8 +32,6 @@ def push_to_dynamodb(table_name, collection_name, image_data):
     """
     dynamodb = boto3.resource('dynamodb')
     table = dynamodb.Table(table_name)
-
-    wait_time = 1
 
     with table.batch_writer() as batch:
         for i, image in enumerate(image_data, start=1):

--- a/terraform/ecr.tf
+++ b/terraform/ecr.tf
@@ -75,3 +75,8 @@ module "ecr_repository_miro_adapter" {
   source = "./ecr"
   name   = "miro_adapter"
 }
+
+module "ecr_repository_elasticdump" {
+  source = "./ecr"
+  name   = "elasticdump"
+}

--- a/terraform/iam.tf
+++ b/terraform/iam.tf
@@ -67,3 +67,8 @@ module "ecs_miro_adapter_iam" {
   source = "./ecs_iam"
   name   = "miro_adapter"
 }
+
+module "ecs_elasticdump_iam" {
+  source = "./ecs_iam"
+  name   = "elasticdump"
+}

--- a/terraform/iam_policy_document.tf
+++ b/terraform/iam_policy_document.tf
@@ -369,3 +369,27 @@ data "aws_iam_policy_document" "s3_tif_derivative" {
     ]
   }
 }
+
+data "aws_iam_policy_document" "s3_read_ingestor_config" {
+  statement {
+    actions = [
+      "s3:GetObject",
+    ]
+
+    resources = [
+      "arn:aws:s3:::${var.infra_bucket}/${module.ingestor.config_key}",
+    ]
+  }
+}
+
+data "aws_iam_policy_document" "s3_upload_to_to_elasticdump_directory" {
+  statement {
+    actions = [
+      "s3:PutObject",
+    ]
+
+    resources = [
+      "arn:aws:s3:::${var.infra_bucket}/elasticdump/*",
+    ]
+  }
+}

--- a/terraform/iam_role_policy.tf
+++ b/terraform/iam_role_policy.tf
@@ -287,3 +287,15 @@ resource "aws_iam_role_policy" "miro_adapter_dynamodb_access" {
   role   = "${module.ecs_miro_adapter_iam.task_role_name}"
   policy = "${data.aws_iam_policy_document.reindex_target_miro.json}"
 }
+
+# Policies for the Elasticdump task
+
+resource "aws_iam_role_policy" "elasticdump_read_ingestor_config_from_s3" {
+  role   = "${module.ecs_elasticdump_iam.task_role_name}"
+  policy = "${data.aws_iam_policy_document.s3_read_ingestor_config.json}"
+}
+
+resource "aws_iam_role_policy" "elasticdump_upload_files_to_s3" {
+  role   = "${module.ecs_elasticdump_iam.task_role_name}"
+  policy = "${data.aws_iam_policy_document.s3_upload_to_to_elasticdump_directory.json}"
+}

--- a/terraform/s3.tf
+++ b/terraform/s3.tf
@@ -45,6 +45,16 @@ resource "aws_s3_bucket" "infra" {
       days = 30
     }
   }
+
+  lifecycle_rule {
+    id      = "elasticdump"
+    prefix  = "elasticdump/"
+    enabled = true
+
+    expiration {
+      days = 30
+    }
+  }
 }
 
 resource "aws_s3_bucket" "dashboard" {

--- a/terraform/script_tasks.tf
+++ b/terraform/script_tasks.tf
@@ -89,3 +89,18 @@ module "elasticdump" {
     "{\"name\": \"AWS_DEFAULT_REGION\", \"value\": \"${var.aws_region}\"}",
   ]
 }
+
+module "elasticdump" {
+  source        = "./ecs_script_task"
+  task_name     = "elasticdump"
+  app_uri       = "${module.ecr_repository_elasticdump.repository_url}:${var.release_ids["elasticdump"]}"
+  task_role_arn = "${module.ecs_elasticdump_iam.task_role_arn}"
+
+  cpu    = 1024
+  memory = 1024
+
+  env_vars = [
+    "{\"name\": \"BUCKET\", \"value\": \"${var.infra_bucket}\"}",
+    "{\"name\": \"AWS_DEFAULT_REGION\", \"value\": \"${var.aws_region}\"}",
+  ]
+}

--- a/terraform/script_tasks.tf
+++ b/terraform/script_tasks.tf
@@ -101,6 +101,7 @@ module "elasticdump" {
 
   env_vars = [
     "{\"name\": \"BUCKET\", \"value\": \"${var.infra_bucket}\"}",
+    "{\"name\": \"CONFIG_KEY\", \"value\": \"${module.ingestor.config_key}\"}",
     "{\"name\": \"AWS_DEFAULT_REGION\", \"value\": \"${var.aws_region}\"}",
   ]
 }

--- a/terraform/services/outputs.tf
+++ b/terraform/services/outputs.tf
@@ -13,3 +13,7 @@ output "role_name" {
 output "host_name" {
   value = "${var.host_name}"
 }
+
+output "config_key" {
+  value = "${var.config_key}"
+}


### PR DESCRIPTION
### What is this PR trying to achieve?

Give us an easy way to inspect the complete contents of an Elasticsearch index.

This provides an ECS task that can be run on-demand, uploading the complete contents of an ES index in our prod cluster to an S3 bucket.

### Who is this change for?

The Platform team (or at least, me). This was useful in tracking down some issues with the Miro adapter earlier.

### Have the following been considered/are they needed?

- [x] Deployed new versions
- [x] Run `terraform apply`.