### PR TITLE
Expose lettering in the Miro transformer

### DIFF
--- a/common/src/main/scala/uk/ac/wellcome/models/MiroTransformable.scala
+++ b/common/src/main/scala/uk/ac/wellcome/models/MiroTransformable.scala
@@ -24,7 +24,8 @@ case class MiroTransformableData(
   @JsonProperty("image_phys_format") physFormat: Option[String],
   @JsonProperty("image_lc_genre") lcGenre: Option[String],
   @JsonProperty("image_tech_file_size") techFileSize: Option[List[String]],
-  @JsonProperty("image_use_restrictions") useRestrictions: Option[String]
+  @JsonProperty("image_use_restrictions") useRestrictions: Option[String],
+  @JsonProperty("image_supp_lettering") suppLettering: Option[String]
 )
 
 case class ShouldNotTransformException(field: String,
@@ -230,6 +231,7 @@ case class MiroTransformable(MiroID: String,
         identifiers = identifiers,
         title = title,
         description = trimmedDescription,
+        lettering = miroData.suppLettering,
         createdDate = createdDate,
         creators = creators ++ secondaryCreators,
         subjects = subjects,

--- a/common/src/test/scala/uk/ac/wellcome/models/MiroTransformableTest.scala
+++ b/common/src/test/scala/uk/ac/wellcome/models/MiroTransformableTest.scala
@@ -321,6 +321,7 @@ class MiroTransformableTest
         "image_supp_lettering": "$lettering"
       """
     )
+    work.lettering shouldBe Some(lettering)
   }
 
   it(

--- a/common/src/test/scala/uk/ac/wellcome/models/MiroTransformableTest.scala
+++ b/common/src/test/scala/uk/ac/wellcome/models/MiroTransformableTest.scala
@@ -313,6 +313,16 @@ class MiroTransformableTest
     work.creators shouldBe List(Agent(creator), Agent(secondaryCreator))
   }
 
+  it("should pass through the lettering field if available") {
+    val lettering = "A lifelong lament for lemurs"
+    val work = transformWork(
+      data = s"""
+        "image_title": "Lemurs and lemons",
+        "image_supp_lettering": "$lettering"
+      """
+    )
+  }
+
   it(
     "should correct HTML-encoded entities in the input JSON") {
     val work = transformWork(


### PR DESCRIPTION
### What is this PR trying to achieve?

Most of the work to do this is already there – we have the models, and the display logic in the API, we just haven’t glued the two pieces together.

Resolves #843.

### Who is this change for?

Users of the API, in particular the Experience team – because this field often includes the correct title of an image, this should improve search quality. Plus it’s an accessibility feature.

### Have the following been considered/are they needed?

- [ ] Deployed new versions
