### PR TITLE
Local Make tasks are a bit less chatty

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ terraform.tfvars
 release_ids.tfvars
 terraform.tfstate.backup
 .releases
+.docker
 
 ### Gatling ###
 /gatling/results/*

--- a/Makefile
+++ b/Makefile
@@ -232,8 +232,8 @@ lint-python: .docker/python3.6_ci
 test-lambdas: .docker/python3.6_ci
 	./scripts/run_docker_with_aws_credentials.sh -v $$(pwd)/lambdas:/data -e OP=test python3.6_ci:latest
 
-format-terraform:
-	terraform fmt
+format-terraform: .docker/terraform_ci
+	docker run -v $$(pwd):/data terraform_ci
 
 format-scala:
 	sbt scalafmt

--- a/Makefile
+++ b/Makefile
@@ -210,7 +210,7 @@ sbt-deploy: \
 
 ## Run a plan
 terraform-plan: .docker/terraform_ci .docker/lambda_deps
-	docker run -v $$(pwd):/data -v $$HOME/.aws:/root/.aws -v $$HOME/.ssh:/root/.ssh terraform_ci:latest
+	docker run -v $$(pwd):/data -v $$HOME/.aws:/root/.aws -v $$HOME/.ssh:/root/.ssh -e OP=plan terraform_ci:latest
 
 ## Run an apply
 terraform-apply: .docker/terraform_ci

--- a/Makefile
+++ b/Makefile
@@ -19,9 +19,13 @@ clean:
 .docker/terraform_ci:
 	./scripts/build_ci_docker_image.py --project terraform_ci
 
+.docker/_build_deps:
+	pip3 install --upgrade boto3 docopt
+	mkdir -p .docker && touch .docker/_build_deps
+
 
 ## Build the image for gatling
-gatling-build: install-docker-build-deps
+gatling-build: .docker/_build_deps
 	./scripts/build_docker_image.py --project=gatling
 
 ## Deploy the image for gatling
@@ -30,7 +34,7 @@ gatling-deploy: gatling-build
 
 
 ## Build the image for the cache cleaner
-cache_cleaner-build: install-docker-build-deps
+cache_cleaner-build: .docker/_build_deps
 	./scripts/build_docker_image.py --project=cache_cleaner
 
 ## Deploy the image for the cache cleaner
@@ -39,7 +43,7 @@ cache_cleaner-deploy: cache_cleaner-build
 
 
 ## Build the image for tif-metadata
-tif-metadata-build: install-docker-build-deps
+tif-metadata-build: .docker/_build_deps
 	./scripts/build_docker_image.py --project=tif-metadata
 
 ## Deploy the image for tif-metadata
@@ -48,7 +52,7 @@ tif-metadata-deploy: tif-metadata-build
 
 
 ## Build the image for Loris
-loris-build: install-docker-build-deps
+loris-build: .docker/_build_deps
 	./scripts/build_docker_image.py --project=loris
 
 ## Deploy the image for Loris
@@ -56,33 +60,30 @@ loris-deploy: loris-build
 	./scripts/deploy_docker_to_aws.py --project=loris --infra-bucket=$(INFRA_BUCKET)
 
 
-miro_adapter-build: install-docker-build-deps
+miro_adapter-build: .docker/_build_deps
 	./scripts/build_docker_image.py --project=miro_adapter --file=miro_adapter/Dockerfile
 
 miro_adapter-deploy: miro_adapter-build
 	./scripts/deploy_docker_to_aws.py --project=miro_adapter --infra-bucket=$(INFRA_BUCKET)
 
 
-elasticdump-build: install-docker-build-deps
+elasticdump-build: .docker/_build_deps
 	./scripts/build_docker_image.py --project=elasticdump
 
 elasticdump-deploy: elasticdump-build
 	./scripts/deploy_docker_to_aws.py --project=elasticdump --infra-bucket=$(INFRA_BUCKET)
 
 
-install-docker-build-deps:
-	pip3 install --upgrade boto3 docopt
-
-nginx-build-api: install-docker-build-deps
+nginx-build-api: .docker/_build_deps
 	./scripts/build_docker_image.py --project=nginx --variant=api
 
-nginx-build-loris: install-docker-build-deps
+nginx-build-loris: .docker/_build_deps
 	./scripts/build_docker_image.py --project=nginx --variant=loris
 
-nginx-build-services: install-docker-build-deps
+nginx-build-services: .docker/_build_deps
 	./scripts/build_docker_image.py --project=nginx --variant=services
 
-nginx-build-grafana: install-docker-build-deps
+nginx-build-grafana: .docker/_build_deps
 	./scripts/build_docker_image.py --project=nginx --variant=grafana
 
 ## Build images for all of our nginx proxies
@@ -146,22 +147,22 @@ sbt-test: \
 
 
 
-sbt-build-api: install-docker-build-deps sbt-test-api
+sbt-build-api: .docker/_build_deps sbt-test-api
 	./scripts/build_sbt_image.py --project=api
 
-sbt-build-id_minter: install-docker-build-deps sbt-test-id_minter
+sbt-build-id_minter: .docker/_build_deps sbt-test-id_minter
 	./scripts/build_sbt_image.py --project=id_minter
 
-sbt-build-ingestor: install-docker-build-deps sbt-test-ingestor
+sbt-build-ingestor: .docker/_build_deps sbt-test-ingestor
 	./scripts/build_sbt_image.py --project=ingestor
 
-sbt-build-miro_adapter: install-docker-build-deps sbt-test-miro_adapter
+sbt-build-miro_adapter: .docker/_build_deps sbt-test-miro_adapter
 	./scripts/build_sbt_image.py --project=miro_adapter
 
-sbt-build-reindexer: install-docker-build-deps sbt-test-reindexer
+sbt-build-reindexer: .docker/_build_deps sbt-test-reindexer
 	./scripts/build_sbt_image.py --project=reindexer
 
-sbt-build-transformer: install-docker-build-deps sbt-test-transformer
+sbt-build-transformer: .docker/_build_deps sbt-test-transformer
 	./scripts/build_sbt_image.py --project=transformer
 
 sbt-build: \

--- a/Makefile
+++ b/Makefile
@@ -205,11 +205,11 @@ sbt-deploy: \
 
 # Tasks for running terraform #
 
-install-lambda-deps: .docker/python3.6_ci
+.docker/lambda_deps: .docker/python3.6_ci
 	docker run -v $$(pwd)/lambdas:/data -e OP=install-deps python3.6_ci:latest
 
 ## Run a plan
-terraform-plan: .docker/terraform_ci install-lambda-deps
+terraform-plan: .docker/terraform_ci .docker/lambda_deps
 	docker run -v $$(pwd):/data -v $$HOME/.aws:/root/.aws -v $$HOME/.ssh:/root/.ssh terraform_ci:latest
 
 ## Run an apply

--- a/Makefile
+++ b/Makefile
@@ -233,7 +233,7 @@ test-lambdas: .docker/python3.6_ci
 	./scripts/run_docker_with_aws_credentials.sh -v $$(pwd)/lambdas:/data -e OP=test python3.6_ci:latest
 
 format-terraform: .docker/terraform_ci
-	docker run -v $$(pwd):/data terraform_ci
+	docker run -v $$(pwd):/data -e OP=fmt terraform_ci
 
 format-scala:
 	sbt scalafmt

--- a/docker/terraform_ci/run.sh
+++ b/docker/terraform_ci/run.sh
@@ -31,6 +31,9 @@ then
     echo "terraform.plan not found. Have you run a plan?"
     exit 1
   fi
+elif [[ "$OP" == "fmt" ]]
+then
+  terraform fmt
 else
   echo "Unrecognised operation: $OP! Stopping."
   exit 1

--- a/docker/terraform_ci/run.sh
+++ b/docker/terraform_ci/run.sh
@@ -3,6 +3,8 @@
 set -o errexit
 set -o nounset
 
+export OP="${OP:-plan}"
+
 echo "Running terraform operation: $OP"
 echo "Terraform version: $(terraform version)"
 

--- a/docker/terraform_ci/run.sh
+++ b/docker/terraform_ci/run.sh
@@ -3,8 +3,6 @@
 set -o errexit
 set -o nounset
 
-export OP="${OP:-plan}"
-
 echo "Running terraform operation: $OP"
 echo "Terraform version: $(terraform version)"
 

--- a/scripts/build_ci_docker_image.py
+++ b/scripts/build_ci_docker_image.py
@@ -1,0 +1,38 @@
+#!/usr/bin/env python
+# -*- encoding: utf-8 -*-
+"""
+Builds a Docker image for use in CI or a local Make task.
+
+This script has to work with as few deps installed as possible, so:
+ 1. No third-party Python libraries!
+ 2. Python 2 and Python 3 compatible.
+"""
+
+import argparse
+import os
+import subprocess
+
+from tooling import mkdir_p, ROOT
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(
+        description='Build a Docker image for use in CI or a local Make task.'
+    )
+    parser.add_argument(
+        '--project', required=True,
+        help='Name of the Docker project to build'
+    )
+    return parser.parse_args()
+
+
+if __name__ == '__main__':
+    args = parse_args()
+    project = args.project
+
+    subprocess.check_call(
+        ['docker', 'build', './docker/%s' % project, '--tag', project],
+        cwd=ROOT
+    )
+    mkdir_p(os.path.join(ROOT, '.docker'))
+    open(os.path.join(ROOT, '.docker', project), 'w')

--- a/scripts/tooling.py
+++ b/scripts/tooling.py
@@ -1,5 +1,6 @@
 # -*- encoding: utf-8 -*-
 
+import errno
 import os
 import shlex
 import subprocess
@@ -67,3 +68,15 @@ def write_release_id(project, release_id):
     release_file = os.path.join(releases_dir, project)
     with open(release_file, 'w') as f:
         f.write(release_id)
+
+
+def mkdir_p(path):
+    """Create a directory if it doesn't already exist."""
+    # https://stackoverflow.com/a/600612/1558022
+    try:
+        os.makedirs(path)
+    except OSError as exc:  # Python >2.5
+        if exc.errno == errno.EEXIST and os.path.isdir(path):
+            pass
+        else:
+            raise


### PR DESCRIPTION
We have some Docker images that rarely changed for make tasks, but we were rebuilding them _every time_.  That's fine in CI, but annoying if you're doing it locally -- your console gets spammed with output from `docker build`.

Start to modify the Make tasks so they're a bit less chatty.

All the tasks we invoke directly should be exactly the same, for now. (I’m planning on a few other Make enhancements when I get the time.)

### What is this PR trying to achieve?

Make Make Make less noise.

### Who is this change for?

Platform devs.