### PR TITLE
Implement a JSON tree walker in the ID minter

### DIFF
--- a/id_minter/src/main/scala/uk/ac/wellcome/platform/idminter/utils/IdentifiableWalker.scala
+++ b/id_minter/src/main/scala/uk/ac/wellcome/platform/idminter/utils/IdentifiableWalker.scala
@@ -1,0 +1,23 @@
+package uk.ac.wellcome.platform.idminter.utils
+
+import com.fasterxml.jackson.databind.{JsonNode, ObjectMapper}
+
+/* This object takes a JSON string (which is assumed to be a map) and walks
+ * it, looking for objects that conform to the Identifiable trait.
+ * Rather than using first-class Scala types, this does a completely generic
+ * tree-walk -- we're trading some type safety for flexibility.
+ *
+ * In this case, the interesting features of the Identifiable trait are:
+ *
+ *   - a string field called "ontologyType"
+ *   - a list field called "identifiers" which has a non-empty list of
+ *     objects which deserialise as instances of SourceIdentifier
+ */
+object IdentifiableWalker {
+
+  def readTree(jsonString: String): JsonNode = {
+    val mapper = new ObjectMapper()
+    mapper.readTree(jsonString)
+  }
+
+}

--- a/id_minter/src/main/scala/uk/ac/wellcome/platform/idminter/utils/IdentifiableWalker.scala
+++ b/id_minter/src/main/scala/uk/ac/wellcome/platform/idminter/utils/IdentifiableWalker.scala
@@ -65,7 +65,7 @@ case class IdentifiableWalker(
       newNode.set(field.getKey, processValue(field.getValue))
     }
 
-    if (node.has("identifiers") && node.has("ontologyType")) {
+    if (node.has("identifiers") && node.has("type")) {
 
       // This code may throw an exception if these identifiers don't look
       // correct, which may screw with the TryBackoff mechanism.
@@ -81,7 +81,7 @@ case class IdentifiableWalker(
         }
         .toList
 
-      val ontologyType = node.get("ontologyType").textValue
+      val ontologyType = node.get("type").textValue
 
       val canonicalId = generateCanonicalId(sourceIdentifiers, ontologyType)
       newNode.set("canonicalId", new TextNode(canonicalId))

--- a/id_minter/src/main/scala/uk/ac/wellcome/platform/idminter/utils/IdentifiableWalker.scala
+++ b/id_minter/src/main/scala/uk/ac/wellcome/platform/idminter/utils/IdentifiableWalker.scala
@@ -39,6 +39,11 @@ object IdentifiableWalker {
     for (field <- node.fields) {
       newNode.set(field.getKey, processValue(field.getValue))
     }
+
+    if (node.has("identifiers") && node.has("ontologyType")) {
+      println("It's an identifier!")
+    }
+
     newNode
   }
 

--- a/id_minter/src/main/scala/uk/ac/wellcome/platform/idminter/utils/IdentifiableWalker.scala
+++ b/id_minter/src/main/scala/uk/ac/wellcome/platform/idminter/utils/IdentifiableWalker.scala
@@ -4,7 +4,9 @@ import java.util.Map.Entry
 import scala.collection.JavaConversions._
 
 import com.fasterxml.jackson.databind.{JsonNode, ObjectMapper}
-import com.fasterxml.jackson.databind.node.{ArrayNode, JsonNodeFactory, ObjectNode}
+import com.fasterxml.jackson.databind.node.{
+  ArrayNode, JsonNodeFactory, ObjectNode, TextNode
+}
 
 /* This object takes a JSON string (which is assumed to be a map) and walks
  * it, looking for objects that conform to the Identifiable trait.
@@ -24,6 +26,11 @@ object IdentifiableWalker {
     mapper.readTree(jsonString)
   }
 
+  def identifyDocument(jsonString: String): JsonNode = {
+    val node = readTree(jsonString)
+    rebuildObjectNode(node)
+  }
+
   private def processValue(value: JsonNode) = {
     if (value.isObject) {
       rebuildObjectNode(value)
@@ -41,7 +48,7 @@ object IdentifiableWalker {
     }
 
     if (node.has("identifiers") && node.has("ontologyType")) {
-      println("It's an identifier!")
+      newNode.set("canonicalId", new TextNode("PlaceholderIdentifier"))
     }
 
     newNode

--- a/id_minter/src/main/scala/uk/ac/wellcome/platform/idminter/utils/IdentifiableWalker.scala
+++ b/id_minter/src/main/scala/uk/ac/wellcome/platform/idminter/utils/IdentifiableWalker.scala
@@ -8,6 +8,8 @@ import com.fasterxml.jackson.databind.node.{
   ArrayNode, JsonNodeFactory, ObjectNode, TextNode
 }
 
+import uk.ac.wellcome.utils.JsonUtil
+
 /* This object takes a JSON string (which is assumed to be a map) and walks
  * it, looking for objects that conform to the Identifiable trait.
  * Rather than using first-class Scala types, this does a completely generic
@@ -18,6 +20,11 @@ import com.fasterxml.jackson.databind.node.{
  *   - a string field called "ontologyType"
  *   - a list field called "identifiers" which has a non-empty list of
  *     objects which deserialise as instances of SourceIdentifier
+ *
+ * In a nutshell, this walks the entire JSON document, and whenever it's
+ * on a map/object node, it looks to see if the node is Identifiable.
+ * If so, it adds an identifier to the node.  Otherwise the document is
+ * passed through unmodified.
  */
 object IdentifiableWalker {
 
@@ -26,9 +33,9 @@ object IdentifiableWalker {
     mapper.readTree(jsonString)
   }
 
-  def identifyDocument(jsonString: String): JsonNode = {
+  def identifyDocument(jsonString: String): String = {
     val node = readTree(jsonString)
-    rebuildObjectNode(node)
+    JsonUtil.toJson(rebuildObjectNode(node)).get
   }
 
   private def processValue(value: JsonNode) = {

--- a/id_minter/src/main/scala/uk/ac/wellcome/platform/idminter/utils/IdentifiableWalker.scala
+++ b/id_minter/src/main/scala/uk/ac/wellcome/platform/idminter/utils/IdentifiableWalker.scala
@@ -1,6 +1,10 @@
 package uk.ac.wellcome.platform.idminter.utils
 
+import java.util.Map.Entry
+import scala.collection.JavaConversions._
+
 import com.fasterxml.jackson.databind.{JsonNode, ObjectMapper}
+import com.fasterxml.jackson.databind.node.{ArrayNode, JsonNodeFactory, ObjectNode}
 
 /* This object takes a JSON string (which is assumed to be a map) and walks
  * it, looking for objects that conform to the Identifiable trait.
@@ -20,4 +24,29 @@ object IdentifiableWalker {
     mapper.readTree(jsonString)
   }
 
+  private def processValue(value: JsonNode) = {
+    if (value.isObject) {
+      rebuildObjectNode(value)
+    } else if (value.isArray) {
+      rebuildArrayNode(value)
+    } else {
+      value
+    }
+  }
+
+  private def rebuildObjectNode(node: JsonNode): ObjectNode = {
+    val newNode = new ObjectNode(new JsonNodeFactory(false))
+    for (field <- node.fields) {
+      newNode.set(field.getKey, processValue(field.getValue))
+    }
+    newNode
+  }
+
+  private def rebuildArrayNode(node: JsonNode): ArrayNode = {
+    val newNode = new ArrayNode(new JsonNodeFactory(false))
+    for (elem <- node.elements) {
+      newNode.add(processValue(elem))
+    }
+    newNode
+  }
 }

--- a/id_minter/src/main/scala/uk/ac/wellcome/platform/idminter/utils/IdentifiableWalker.scala
+++ b/id_minter/src/main/scala/uk/ac/wellcome/platform/idminter/utils/IdentifiableWalker.scala
@@ -5,7 +5,10 @@ import scala.collection.JavaConversions._
 
 import com.fasterxml.jackson.databind.{JsonNode, ObjectMapper}
 import com.fasterxml.jackson.databind.node.{
-  ArrayNode, JsonNodeFactory, ObjectNode, TextNode
+  ArrayNode,
+  JsonNodeFactory,
+  ObjectNode,
+  TextNode
 }
 
 import uk.ac.wellcome.models.SourceIdentifier
@@ -71,14 +74,16 @@ object IdentifiableWalker {
       // This code may throw an exception if these identifiers don't look
       // correct, which may screw with the TryBackoff mechanism.
       // TODO: Be less crappy with error handling here.
-      val sourceIdentifiers = node.get("identifiers")
+      val sourceIdentifiers = node
+        .get("identifiers")
         .elements
         .map { elem: JsonNode =>
           SourceIdentifier(
             identifierScheme = elem.get("identifierScheme").textValue,
             elem.get("value").textValue
           )
-        }.toList
+        }
+        .toList
 
       val ontologyType = node.get("ontologyType").textValue
 

--- a/id_minter/src/test/scala/uk/ac/wellcome/platform/idminter/utils/IdentifiableWalkerTest.scala
+++ b/id_minter/src/test/scala/uk/ac/wellcome/platform/idminter/utils/IdentifiableWalkerTest.scala
@@ -1,0 +1,20 @@
+package uk.ac.wellcome.models
+
+import org.scalatest.{FunSpec, Matchers}
+
+import uk.ac.wellcome.platform.idminter.utils.IdentifiableWalker
+
+
+/** Tests that the Miro transformer extracts the "title" field correctly.
+ *
+ *  The rules around this heuristic are somewhat fiddly, and we need to be
+ *  careful that we're extracting the right fields from the Miro metadata.
+ */
+class IdentifiableWalkerTest
+    extends FunSpec
+    with Matchers {
+
+  it("should find nothing for an empty map") {
+    IdentifiableWalker
+  }
+}

--- a/id_minter/src/test/scala/uk/ac/wellcome/platform/idminter/utils/IdentifiableWalkerTest.scala
+++ b/id_minter/src/test/scala/uk/ac/wellcome/platform/idminter/utils/IdentifiableWalkerTest.scala
@@ -73,9 +73,142 @@ class IdentifiableWalkerTest
       .mkString("==")
   }
 
-  private def assertWalkerDoesNothing(jsonString: String) = {
-    assertJsonStringsAreEqual(jsonString, walker.identifyDocument(jsonString))
+  describe("Documents with Identifiable structures should be updated correctly") {
+    it("identify a document that is itself Identifiable") {
+      val sourceIdentifiers = List(SourceIdentifier("australia", "sydney"))
+      val ontologyType = "false capitals"
+
+      assertWalkerAddsCanonicalIdCorrectly(s"""
+      {
+        "canonicalId": "${generateCanonicalId(sourceIdentifiers, ontologyType)}",
+        "identifiers": [{
+          "identifierScheme": "${sourceIdentifiers(0).identifierScheme}",
+          "value": "${sourceIdentifiers(0).value}"
+        }],
+        "type": "${ontologyType}"
+      }
+      """)
+    }
+
+    it("identify a document with a key that is identifiable") {
+      val sourceIdentifiers = List(SourceIdentifier("westeros", "king's landing"))
+      val ontologyType = "fictional cities"
+
+      assertWalkerAddsCanonicalIdCorrectly(s"""
+      {
+        "ke": null,
+        "ki": "kiev",
+        "item": {
+          "canonicalId": "${generateCanonicalId(sourceIdentifiers, ontologyType)}",
+          "identifiers": [{
+            "identifierScheme": "${sourceIdentifiers(0).identifierScheme}",
+            "value": "${sourceIdentifiers(0).value}"
+          }],
+          "type": "${ontologyType}"
+        }
+      }
+      """)
+    }
+
+    it("should pick up all the source identifiers that are available") {
+      val sourceIdentifiersA = List(
+        SourceIdentifier("antarctica", "husvik"),
+        SourceIdentifier("greece", "spinalonga"),
+        SourceIdentifier("ireland", "waterfoot")
+      )
+      val ontologyTypeA = "ghost towns"
+
+      val sourceIdentifiersB = List(
+        SourceIdentifier("ocean", "atlantis"),
+        SourceIdentifier("regal", "camelot")
+      )
+      val ontologyTypeB = "mythological places"
+
+      val sourceIdentifiersC = List(
+        SourceIdentifier("england", "lundenwic"),
+        SourceIdentifier("scotland", "dunedin")
+      )
+      val ontologyTypeC = "cities that were renamed"
+
+      assertWalkerAddsCanonicalIdCorrectly(s"""
+      {
+        "items": [
+          {
+            "canonicalId": "${generateCanonicalId(sourceIdentifiersA, ontologyTypeA)}",
+            "identifiers": [
+              {
+                "identifierScheme": "${sourceIdentifiersA(0).identifierScheme}",
+                "value": "${sourceIdentifiersA(0).value}"
+              },
+              {
+                "identifierScheme": "${sourceIdentifiersA(1).identifierScheme}",
+                "value": "${sourceIdentifiersA(1).value}"
+              },
+              {
+                "identifierScheme": "${sourceIdentifiersA(2).identifierScheme}",
+                "value": "${sourceIdentifiersA(2).value}"
+              }
+            ],
+            "type": "${ontologyTypeA}"
+          },
+          {
+            "canonicalId": "${generateCanonicalId(sourceIdentifiersB, ontologyTypeB)}",
+            "identifiers": [
+              {
+                "identifierScheme": "${sourceIdentifiersB(0).identifierScheme}",
+                "value": "${sourceIdentifiersB(0).value}"
+              },
+              {
+                "identifierScheme": "${sourceIdentifiersB(1).identifierScheme}",
+                "value": "${sourceIdentifiersB(1).value}"
+              }
+            ],
+            "type": "${ontologyTypeB}"
+          }
+        ],
+        "title": "A letter about loss",
+        "lettering": "things we lose have a way of coming back to us in the end, if not always in the way we expect",
+        "subjects": [
+          {
+            "label": "Loss and grief",
+            "type": "Concept"
+          },
+          {
+            "label": "Resurrection and renaming",
+            "canonicalId": "${generateCanonicalId(sourceIdentifiersC, ontologyTypeC)}",
+            "identifiers": [
+              {
+                "identifierScheme": "${sourceIdentifiersC(0).identifierScheme}",
+                "value": "${sourceIdentifiersC(0).value}"
+              },
+              {
+                "identifierScheme": "${sourceIdentifiersC(1).identifierScheme}",
+                "value": "${sourceIdentifiersC(1).value}"
+              }
+            ],
+            "type": "${ontologyTypeC}"
+          }
+        ]
+      }
+      """)
+    }
   }
+
+  // Strip the canonical ID from a JSON string, then run it through the walker
+  // and check it's reinserted correctly.
+  private def assertWalkerAddsCanonicalIdCorrectly(jsonString: String) = {
+    val unidentifiedString = jsonString
+      .lines
+      .filterNot { _.contains("canonicalId") }
+      .mkString("\n")
+    unidentifiedString shouldNot be(jsonString)
+    assertJsonStringsAreEqual(
+      walker.identifyDocument(unidentifiedString),
+      jsonString)
+  }
+
+  private def assertWalkerDoesNothing(jsonString: String) =
+    assertJsonStringsAreEqual(jsonString, walker.identifyDocument(jsonString))
 
   private def assertJsonStringsAreEqual(jsonString1: String, jsonString2: String) = {
     val mapper = new ObjectMapper()

--- a/id_minter/src/test/scala/uk/ac/wellcome/platform/idminter/utils/IdentifiableWalkerTest.scala
+++ b/id_minter/src/test/scala/uk/ac/wellcome/platform/idminter/utils/IdentifiableWalkerTest.scala
@@ -2,19 +2,74 @@ package uk.ac.wellcome.models
 
 import org.scalatest.{FunSpec, Matchers}
 
+import com.fasterxml.jackson.databind.ObjectMapper
+
 import uk.ac.wellcome.platform.idminter.utils.IdentifiableWalker
 
 
-/** Tests that the Miro transformer extracts the "title" field correctly.
- *
- *  The rules around this heuristic are somewhat fiddly, and we need to be
- *  careful that we're extracting the right fields from the Miro metadata.
- */
 class IdentifiableWalkerTest
     extends FunSpec
     with Matchers {
 
-  it("should find nothing for an empty map") {
-    IdentifiableWalker
+  /* Because the IdentifiableWalker works by walking the entire tree and
+   * rebuilding a copy of it, we try some JSON structures that don't contain
+   * anything Identifiable and check it isn't losing information.
+   */
+  describe("JSON strings with no Identifiable objects should pass through unchanged") {
+    it("an empty map") {
+      assertWalkerDoesNothing("""{}""")
+    }
+
+    it("a map with some string keys") {
+      assertWalkerDoesNothing("""{
+        "so": "sofia",
+        "sk": "skopje"
+      }""")
+    }
+
+    it("a map with some list objects") {
+      assertWalkerDoesNothing("""{
+        "te": "tehran",
+        "ta": [
+          "tallinn",
+          "tashkent"
+        ]
+      }""")
+    }
+
+    it("a complex nested structure") {
+      assertWalkerDoesNothing("""{
+        "u": "ulan bator",
+        "v": [
+          "vatican city",
+          {
+            "vic": "victoria",
+            "vie": "vienna",
+            "vil": "vilnius"
+          }
+        ],
+        "w": {
+          "wa": [
+            "warsaw",
+            "washington dc"
+          ],
+          "we": "wellington",
+          "wi": {
+            "win": "windhoek"
+          }
+        }
+      }""")
+    }
+  }
+
+  private def assertWalkerDoesNothing(jsonString: String) = {
+    assertJsonStringsAreEqual(jsonString, IdentifiableWalker.identifyDocument(jsonString))
+  }
+
+  private def assertJsonStringsAreEqual(jsonString1: String, jsonString2: String) = {
+    val mapper = new ObjectMapper()
+    val node1 = mapper.readTree(jsonString1)
+    val node2 = mapper.readTree(jsonString2)
+    node1 shouldBe node2
   }
 }

--- a/id_minter/src/test/scala/uk/ac/wellcome/platform/idminter/utils/IdentifiableWalkerTest.scala
+++ b/id_minter/src/test/scala/uk/ac/wellcome/platform/idminter/utils/IdentifiableWalkerTest.scala
@@ -11,11 +11,10 @@ class IdentifiableWalkerTest
     extends FunSpec
     with Matchers {
 
-  /* Because the IdentifiableWalker works by walking the entire tree and
-   * rebuilding a copy of it, we try some JSON structures that don't contain
-   * anything Identifiable and check it isn't losing information.
-   */
-  describe("JSON strings with no Identifiable objects should pass through unchanged") {
+  // Because the IdentifiableWalker works by walking the entire tree and
+  // rebuilding a copy of it, we try some JSON structures that don't contain
+  // anything Identifiable and check it isn't losing information.
+  describe("Documents with no Identifiable objects should pass through unchanged") {
     it("an empty map") {
       assertWalkerDoesNothing("""{}""")
     }
@@ -62,8 +61,20 @@ class IdentifiableWalkerTest
     }
   }
 
+  val walker = IdentifiableWalker(generateCanonicalId = generateCanonicalId)
+
+  // An in-memory canonical ID generator for use in testing.  This allows us
+  // to write lots of fast tests for the tree-walking logic, and we can have
+  // fewer, slower tests that make database calls.
+  def generateCanonicalId(sourceIdentifiers: List[SourceIdentifier],
+                          ontologyType: String): String = {
+    val sourceIdentifiersStrings = sourceIdentifiers.map { _.toString }
+    List(ontologyType, sourceIdentifiersStrings.mkString(";"))
+      .mkString("==")
+  }
+
   private def assertWalkerDoesNothing(jsonString: String) = {
-    assertJsonStringsAreEqual(jsonString, IdentifiableWalker.identifyDocument(jsonString))
+    assertJsonStringsAreEqual(jsonString, walker.identifyDocument(jsonString))
   }
 
   private def assertJsonStringsAreEqual(jsonString1: String, jsonString2: String) = {


### PR DESCRIPTION
This patch only covers implementing the tree walker itself – actually passing the `ontologyType` and `sourceIdentifiers` off the database is a separate patch. A pure in-memory operation, which hopefully means it’s really easy to test.

Still to do:

* [ ] Proper error handling if we encounter some identifier-looking blocks that don’t match our worldview
* [x] ~Check the type on those blocks as well?~
* [x] I’m not sure `ontologyType` is the string field I want, actually
* [x] Tests that it finds and updates Identifiable blocks accurately
* [x] ~Maybe even cast back to a string and re-parse as a list of `SourceIdentifier` blocks, idk~