### PR TITLE
What if we tried more memory?

### DIFF
--- a/terraform/services.tf
+++ b/terraform/services.tf
@@ -181,7 +181,7 @@ module "api_romulus" {
   enable_alb_alarm = "${var.production_api == "romulus" ? 1 : 0}"
 
   cpu    = 1792
-  memory = 1840
+  memory = 2048
 
   desired_count = "${var.production_api == "romulus" ? var.api_task_count : var.api_task_count_stage}"
 
@@ -232,7 +232,7 @@ module "api_remus" {
   enable_alb_alarm = "${var.production_api == "remus" ? 1 : 0}"
 
   cpu    = 1792
-  memory = 1840
+  memory = 2048
 
   desired_count = "${var.production_api == "remus" ? var.api_task_count : var.api_task_count_stage}"
 
@@ -274,7 +274,7 @@ module "loris" {
   host_name          = "iiif-origin.wellcomecollection.org"
 
   cpu    = 1792
-  memory = 1840
+  memory = 4096
 
   desired_count = 4
 


### PR DESCRIPTION
![memory](https://user-images.githubusercontent.com/301220/29671056-72e6040a-88e0-11e7-94d0-6a1c1fd2d898.png)

We've been seeing a _lot_ of 500s from Loris recently, as well as spontaneous container reboots -- most of which don't come with an explanatory log.  Looking at memory graphs for the ECS service, it's high then drops low around when we have restarts, which seems like a smoking gun.

Since our t2.xlarge cluster has plenty of spare memory, take advantage of it.  Memory for everybody!

### What is this PR trying to achieve?

Hopefully make Loris be less broken. Whether it works is tbc.

### Who is this change for?

Loris users.

### Have the following been considered/are they needed?

- [x] Run `terraform apply`.