### PR TITLE
Looking up IDs in the ID minter is now (more) source identifier agnostic

### DIFF
--- a/common/src/main/scala/uk/ac/wellcome/finatra/modules/IdentifierSchemeModule.scala
+++ b/common/src/main/scala/uk/ac/wellcome/finatra/modules/IdentifierSchemeModule.scala
@@ -11,4 +11,6 @@ object IdentifierSchemes {
   // Placeholder until we ingest real Calm records.
   // TODO: Replace this with something more appropriate
   val calmPlaceholder = "calm-placeholder"
+
+  val calmAltRefNo = "calm-altrefno"
 }

--- a/id_minter/src/main/scala/uk/ac/wellcome/platform/idminter/database/IdentifiersDao.scala
+++ b/id_minter/src/main/scala/uk/ac/wellcome/platform/idminter/database/IdentifiersDao.scala
@@ -12,6 +12,9 @@ import uk.ac.wellcome.utils.GlobalExecutionContext.context
 
 import scala.concurrent.{Future, blocking}
 
+case class UnableToMintIdentifierException(message: String)
+    extends Exception(message)
+
 @Singleton
 class IdentifiersDao @Inject()(db: DB, identifiers: IdentifiersTable)
     extends Logging {
@@ -25,7 +28,10 @@ class IdentifiersDao @Inject()(db: DB, identifiers: IdentifiersTable)
    * source identifiers.
    */
   def lookupID(sourceIdentifiers: List[SourceIdentifier],
-               ontologyType: String): Future[Option[Identifier]] =
+               ontologyType: String): Future[Option[Identifier]] = {
+    if (sourceIdentifiers.isEmpty) {
+      throw new UnableToMintIdentifierException("No source identifiers supplied!")
+    }
     Future {
       blocking {
         info(s"About to search for existing ID matching $identifiers and $ontologyType")
@@ -61,6 +67,7 @@ class IdentifiersDao @Inject()(db: DB, identifiers: IdentifiersTable)
         }.map(Identifier(i)).single.apply()
       }
     }
+  }
 
   /* For a given source identifier scheme (e.g. "miro-image-number") and a
    * corresponding column in the SQL database (e.g. i.MiroID), add a condition

--- a/id_minter/src/main/scala/uk/ac/wellcome/platform/idminter/database/IdentifiersDao.scala
+++ b/id_minter/src/main/scala/uk/ac/wellcome/platform/idminter/database/IdentifiersDao.scala
@@ -6,6 +6,7 @@ import com.google.inject.Inject
 import com.twitter.inject.Logging
 import scalikejdbc._
 
+import uk.ac.wellcome.finatra.modules.IdentifierSchemes
 import uk.ac.wellcome.models.SourceIdentifier
 import uk.ac.wellcome.platform.idminter.model.{Identifier, IdentifiersTable}
 import uk.ac.wellcome.utils.GlobalExecutionContext.context
@@ -56,7 +57,7 @@ class IdentifiersDao @Inject()(db: DB, identifiers: IdentifiersTable)
                 sql = sql,
                 sourceIdentifiers = sourceIdentifiers,
                 column = i.MiroID,
-                identifierScheme = "miro-image-number"
+                identifierScheme = IdentifierSchemes.miroImageNumber
               )
             }
             .map { sql: ConditionSQLBuilder[String] =>
@@ -64,7 +65,7 @@ class IdentifiersDao @Inject()(db: DB, identifiers: IdentifiersTable)
                 sql = sql,
                 sourceIdentifiers = sourceIdentifiers,
                 column = i.CalmAltRefNo,
-                identifierScheme = "calm-altrefno"
+                identifierScheme = IdentifierSchemes.calmAltRefNo
               )
             }
         }.map(Identifier(i)).single

--- a/id_minter/src/main/scala/uk/ac/wellcome/platform/idminter/database/IdentifiersDao.scala
+++ b/id_minter/src/main/scala/uk/ac/wellcome/platform/idminter/database/IdentifiersDao.scala
@@ -52,24 +52,15 @@ class IdentifiersDao @Inject()(db: DB, identifiers: IdentifiersTable)
 
   def lookupMiroID(miroID: String,
                    ontologyType: String = "Work"): Future[Option[Identifier]] =
-    Future {
-      blocking {
-        info(s"About to search for MiroID $miroID in Identifiers")
-        val i = identifiers.i
-        withSQL {
-          select
-            .from(identifiers as i)
-            .where
-            .eq(i.ontologyType, ontologyType)
-            .and
-            .eq(i.MiroID, miroID)
-        }.map(Identifier(i)).single.apply()
-      }
-    } recover {
-      case e: Throwable =>
-        error(s"Failed getting MiroID $miroID in Identifiers", e)
-        throw e
-    }
+    lookupID(
+      sourceIdentifiers = List(
+        SourceIdentifier(
+          identifierScheme = "miro-image-number",
+          value = miroID
+        )
+      ),
+      ontologyType = ontologyType
+    )
 
   def saveIdentifier(identifier: Identifier): Future[Int] = {
     val insertIntoDbFuture = Future {

--- a/id_minter/src/main/scala/uk/ac/wellcome/platform/idminter/database/IdentifiersDao.scala
+++ b/id_minter/src/main/scala/uk/ac/wellcome/platform/idminter/database/IdentifiersDao.scala
@@ -64,6 +64,18 @@ class IdentifiersDao @Inject()(db: DB, identifiers: IdentifiersTable)
               )
             }
 
+            .map { sql: ConditionSQLBuilder[String] =>
+              println(s"${sql}")
+              sql
+            }
+
+            // TODO: Might be nice to log the SQL query we're making as a
+            // debug statement
+            // .map { sql: ConditionSQLBuilder[String] =>
+            //   info(s"Executing SQL query '${sql.value}'")
+            //   sql
+            // }
+
         }.map(Identifier(i)).single.apply()
       }
     }
@@ -92,7 +104,7 @@ class IdentifiersDao @Inject()(db: DB, identifiers: IdentifiersTable)
     if (sourceID.isEmpty) {
       sql
     } else {
-      sql.and.eq(column, sourceID.head.value).or.isNull(column)
+      sql.and.withRoundBracket( _.eq(column, sourceID.head.value).or.isNull(column) )
     }
   }
 
@@ -118,7 +130,8 @@ class IdentifiersDao @Inject()(db: DB, identifiers: IdentifiersTable)
             .namedValues(
               identifiers.column.CanonicalID -> identifier.CanonicalID,
               identifiers.column.ontologyType -> identifier.ontologyType,
-              identifiers.column.MiroID -> identifier.MiroID
+              identifiers.column.MiroID -> identifier.MiroID,
+              identifiers.column.CalmAltRefNo -> identifier.CalmAltRefNo
             )
         }.update().apply()
       }

--- a/id_minter/src/main/scala/uk/ac/wellcome/platform/idminter/database/IdentifiersDao.scala
+++ b/id_minter/src/main/scala/uk/ac/wellcome/platform/idminter/database/IdentifiersDao.scala
@@ -33,11 +33,13 @@ class IdentifiersDao @Inject()(db: DB, identifiers: IdentifiersTable)
     // TODO: This exception should be handled gracefully, not sent around the
     // TryBackoff ad infinitum.
     if (sourceIdentifiers.isEmpty) {
-      throw new UnableToMintIdentifierException("No source identifiers supplied!")
+      throw new UnableToMintIdentifierException(
+        "No source identifiers supplied!")
     }
     Future {
       blocking {
-        info(s"About to search for existing ID matching $identifiers and $ontologyType")
+        info(
+          s"About to search for existing ID matching $identifiers and $ontologyType")
         val i = identifiers.i
         val query = withSQL {
           select
@@ -57,7 +59,6 @@ class IdentifiersDao @Inject()(db: DB, identifiers: IdentifiersTable)
                 identifierScheme = "miro-image-number"
               )
             }
-
             .map { sql: ConditionSQLBuilder[String] =>
               addConditionForLookingUpID(
                 sql = sql,
@@ -88,15 +89,19 @@ class IdentifiersDao @Inject()(db: DB, identifiers: IdentifiersTable)
    * If we find a Sierra record with (Miro = abcd, Sierra = IVDC), we want
    * to find this record even though it doesn't have a complete match.
    */
-  private def addConditionForLookingUpID(sql: ConditionSQLBuilder[String],
-                                         sourceIdentifiers: List[SourceIdentifier],
-                                         column: SQLSyntax,
-                                         identifierScheme: String): ConditionSQLBuilder[String] = {
-    val sourceID = sourceIdentifiers.filter { _.identifierScheme == identifierScheme }
+  private def addConditionForLookingUpID(
+    sql: ConditionSQLBuilder[String],
+    sourceIdentifiers: List[SourceIdentifier],
+    column: SQLSyntax,
+    identifierScheme: String): ConditionSQLBuilder[String] = {
+    val sourceID = sourceIdentifiers.filter {
+      _.identifierScheme == identifierScheme
+    }
     if (sourceID.isEmpty) {
       sql
     } else {
-      sql.and.withRoundBracket( _.eq(column, sourceID.head.value).or.isNull(column) )
+      sql.and.withRoundBracket(
+        _.eq(column, sourceID.head.value).or.isNull(column))
     }
   }
 

--- a/id_minter/src/main/scala/uk/ac/wellcome/platform/idminter/database/IdentifiersDao.scala
+++ b/id_minter/src/main/scala/uk/ac/wellcome/platform/idminter/database/IdentifiersDao.scala
@@ -5,6 +5,8 @@ import javax.inject.Singleton
 import com.google.inject.Inject
 import com.twitter.inject.Logging
 import scalikejdbc._
+
+import uk.ac.wellcome.models.SourceIdentifier
 import uk.ac.wellcome.platform.idminter.model.{Identifier, IdentifiersTable}
 import uk.ac.wellcome.utils.GlobalExecutionContext.context
 
@@ -15,6 +17,38 @@ class IdentifiersDao @Inject()(db: DB, identifiers: IdentifiersTable)
     extends Logging {
 
   implicit val session = AutoSession(db.settingsProvider)
+
+  def lookupID(sourceIdentifiers: List[SourceIdentifier],
+               ontologyType: String): Future[Option[Identifier]] =
+    Future {
+      blocking {
+        info(s"About to search for existing ID matching $identifiers and $ontologyType")
+        val i = identifiers.i
+        withSQL {
+          select
+            .from(identifiers as i)
+            .where
+
+            // We always want to match the ontology type, and this field
+            // in SQL is never null.
+            .eq(i.ontologyType, ontologyType)
+
+            // This seems awfully repetitive, but I haven't been able to pin
+            // down a type parameter for `sql` that lets me put this in a
+            // function.
+            .map { sql: ConditionSQLBuilder[String] =>
+              val miroID = sourceIdentifiers.filter {
+                _.identifierScheme == "miro-image-number"
+              }
+              if (miroID.isEmpty) {
+                sql
+              } else {
+                sql.and.eq(i.MiroID, miroID.head.value).or.isNull(i.MiroID)
+              }
+            }
+        }.map(Identifier(i)).single.apply()
+      }
+    }
 
   def lookupMiroID(miroID: String,
                    ontologyType: String = "Work"): Future[Option[Identifier]] =

--- a/id_minter/src/main/scala/uk/ac/wellcome/platform/idminter/model/IdentifiersTable.scala
+++ b/id_minter/src/main/scala/uk/ac/wellcome/platform/idminter/model/IdentifiersTable.scala
@@ -9,16 +9,16 @@ case class Identifier(
   ontologyType: String = "Work",
   CanonicalID: String,
   MiroID: String,
-  CalmAltRefNo: String
+  CalmAltRefNo: Option[String] = Some(null)
 )
 
 object Identifier {
   def apply(p: SyntaxProvider[Identifier])(rs: WrappedResultSet): Identifier =
     Identifier(
-      ontologyType = rs.string(p.resultName.ontologyType)
+      ontologyType = rs.string(p.resultName.ontologyType),
       CanonicalID = rs.string(p.resultName.CanonicalID),
       MiroID = rs.string(p.resultName.MiroID),
-      CalmAltRefNo = rs.string(p.resultName.CalmAltRefNo)
+      CalmAltRefNo = Some(rs.string(p.resultName.CalmAltRefNo))
     )
 }
 

--- a/id_minter/src/main/scala/uk/ac/wellcome/platform/idminter/model/IdentifiersTable.scala
+++ b/id_minter/src/main/scala/uk/ac/wellcome/platform/idminter/model/IdentifiersTable.scala
@@ -8,8 +8,8 @@ import scalikejdbc._
 case class Identifier(
   ontologyType: String = "Work",
   CanonicalID: String,
-  MiroID: String,
-  CalmAltRefNo: Option[String] = Some(null)
+  MiroID: String = null,
+  CalmAltRefNo: String = null
 )
 
 object Identifier {
@@ -18,7 +18,7 @@ object Identifier {
       ontologyType = rs.string(p.resultName.ontologyType),
       CanonicalID = rs.string(p.resultName.CanonicalID),
       MiroID = rs.string(p.resultName.MiroID),
-      CalmAltRefNo = Some(rs.string(p.resultName.CalmAltRefNo))
+      CalmAltRefNo = rs.string(p.resultName.CalmAltRefNo)
     )
 }
 

--- a/id_minter/src/main/scala/uk/ac/wellcome/platform/idminter/model/IdentifiersTable.scala
+++ b/id_minter/src/main/scala/uk/ac/wellcome/platform/idminter/model/IdentifiersTable.scala
@@ -6,17 +6,19 @@ import scalikejdbc._
 
 /** Represents a set of identifiers as stored in MySQL */
 case class Identifier(
+  ontologyType: String = "Work",
   CanonicalID: String,
   MiroID: String,
-  ontologyType: String = "Work"
+  CalmAltRefNo: String
 )
 
 object Identifier {
   def apply(p: SyntaxProvider[Identifier])(rs: WrappedResultSet): Identifier =
     Identifier(
+      ontologyType = rs.string(p.resultName.ontologyType)
       CanonicalID = rs.string(p.resultName.CanonicalID),
       MiroID = rs.string(p.resultName.MiroID),
-      ontologyType = rs.string(p.resultName.ontologyType)
+      CalmAltRefNo = rs.string(p.resultName.CalmAltRefNo)
     )
 }
 

--- a/id_minter/src/test/scala/uk/ac/wellcome/platform/idminter/database/IdentifiersDaoTest.scala
+++ b/id_minter/src/test/scala/uk/ac/wellcome/platform/idminter/database/IdentifiersDaoTest.scala
@@ -5,6 +5,7 @@ import java.sql.SQLIntegrityConstraintViolationException
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.{FunSpec, Matchers}
 import scalikejdbc._
+import uk.ac.wellcome.finatra.modules.IdentifierSchemes
 import uk.ac.wellcome.models.SourceIdentifier
 import uk.ac.wellcome.platform.idminter.model.Identifier
 import uk.ac.wellcome.platform.idminter.utils.IdentifiersMysqlLocal
@@ -27,7 +28,7 @@ class IdentifiersDaoTest
       assertInsertingIdentifierSucceeds(identifier)
 
       val sourceIdentifiers = List(SourceIdentifier(
-        identifierScheme = "miro-image-number",
+        identifierScheme = IdentifierSchemes.miroImageNumber,
         value = identifier.MiroID
       ))
 
@@ -43,12 +44,12 @@ class IdentifiersDaoTest
   }
 
   val miroSourceIdentifier = SourceIdentifier(
-    identifierScheme = "miro-image-number",
+    identifierScheme = IdentifierSchemes.miroImageNumber,
     value = "V0023075"
   )
 
   val calmSourceIdentifier = SourceIdentifier(
-    identifierScheme = "calm-altrefno",
+    identifierScheme = IdentifierSchemes.calmAltRefNo,
     value = "MS.290"
   )
 

--- a/id_minter/src/test/scala/uk/ac/wellcome/platform/idminter/steps/IdentifierGeneratorTest.scala
+++ b/id_minter/src/test/scala/uk/ac/wellcome/platform/idminter/steps/IdentifierGeneratorTest.scala
@@ -64,7 +64,7 @@ class IdentifierGeneratorTest
         select.from(identifiersTable as i).where.eq(i.MiroID, "1234")
       }.map(Identifier(i)).single.apply()
       maybeIdentifier shouldBe defined
-      maybeIdentifier.get shouldBe Identifier(id, "1234")
+      maybeIdentifier.get shouldBe Identifier(CanonicalID = id, MiroID = "1234")
     }
   }
 


### PR DESCRIPTION
### What is this PR trying to achieve?

Rather than hard-coding logic for Miro, Calm, Sierra source identifiers – have a single `lookupID()` method that makes one big SQL query for us.

Another piece of #839.

### Who is this change for?

Devs who want generic lookups in the ID minter.

### Have the following been considered/are they needed?

- [ ] Deployed new versions