### PR TITLE
Add an ID minter database column for Calm AltRefNo

### DIFF
--- a/id_minter/src/main/resources/db/migration/V3__add_calm_altrefno.sql
+++ b/id_minter/src/main/resources/db/migration/V3__add_calm_altrefno.sql
@@ -1,0 +1,15 @@
+-- This patch is another bit of preliminary work for supporting items in
+-- the ID minter.
+--
+-- In particular, it adds a second column of source identifiers: CalmAltRefNo.
+--
+-- This allows us to develop and test ID minter support for working with
+-- multiple source identifiers.
+
+USE ${database};
+
+ALTER TABLE ${tableName}
+ADD COLUMN CalmAltRefNo varchar(255) AFTER MiroID;
+
+ALTER TABLE ${tableName}
+ADD UNIQUE (ontologyType, CalmAltRefNo);

--- a/id_minter/src/main/scala/uk/ac/wellcome/platform/idminter/model/IdentifiersTable.scala
+++ b/id_minter/src/main/scala/uk/ac/wellcome/platform/idminter/model/IdentifiersTable.scala
@@ -27,7 +27,12 @@ class IdentifiersTable @Inject()(
   override val schemaName = Some(database)
   override val tableName = table
   override val useSnakeCaseColumnName = false
-  override val columns = Seq("CanonicalID", "ontologyType", "MiroID")
+  override val columns = Seq(
+    "CanonicalID",
+    "ontologyType",
+    "MiroID",
+    "CalmAltRefNo"
+  )
 
   val i = this.syntax("i")
 }

--- a/id_minter/src/test/scala/uk/ac/wellcome/platform/idminter/database/TableProvisionerTest.scala
+++ b/id_minter/src/test/scala/uk/ac/wellcome/platform/idminter/database/TableProvisionerTest.scala
@@ -55,6 +55,10 @@ class TableProvisionerTest
         FieldDescription(field = "MiroID",
                          dataType = "varchar(255)",
                          nullable = "YES",
+                         key = ""),
+        FieldDescription(field = "CalmAltRefNo",
+                         dataType = "varchar(255)",
+                         nullable = "YES",
                          key = "")
       )
     }


### PR DESCRIPTION
### What is this PR trying to achieve?

Another small patch on the way to #839.

This isn’t populated yet, but I’m going to want a second source identifier column for some testing on #857 – in particular, scenarios where there’s a partial or total overlap between database entries and what we’re looking up.

### Who is this change for?

Me. I need it for testing.

### Have the following been considered/are they needed?

- [ ] Deployed new versions