### PR TITLE
Remove lookupMiroID in favour of lookupID

### DIFF
--- a/id_minter/src/main/scala/uk/ac/wellcome/platform/idminter/database/IdentifiersDao.scala
+++ b/id_minter/src/main/scala/uk/ac/wellcome/platform/idminter/database/IdentifiersDao.scala
@@ -108,18 +108,6 @@ class IdentifiersDao @Inject()(db: DB, identifiers: IdentifiersTable)
     }
   }
 
-  def lookupMiroID(miroID: String,
-                   ontologyType: String = "Work"): Future[Option[Identifier]] =
-    lookupID(
-      sourceIdentifiers = List(
-        SourceIdentifier(
-          identifierScheme = "miro-image-number",
-          value = miroID
-        )
-      ),
-      ontologyType = ontologyType
-    )
-
   def saveIdentifier(identifier: Identifier): Future[Int] = {
     val insertIntoDbFuture = Future {
       blocking {

--- a/id_minter/src/main/scala/uk/ac/wellcome/platform/idminter/steps/IdentifierGenerator.scala
+++ b/id_minter/src/main/scala/uk/ac/wellcome/platform/idminter/steps/IdentifierGenerator.scala
@@ -22,10 +22,11 @@ class IdentifierGenerator @Inject()(identifiersDao: IdentifiersDao,
       "generate-id",
       () =>
         findMiroID(work) match {
-          case Some(identifier) => retrieveOrGenerateCanonicalId(
-            identifier,
-            ontologyType = work.ontologyType
-          )
+          case Some(identifier) =>
+            retrieveOrGenerateCanonicalId(
+              identifier,
+              ontologyType = work.ontologyType
+            )
           case None =>
             error(s"Item $work did not contain a MiroID")
             Future.failed(

--- a/id_minter/src/test/scala/uk/ac/wellcome/platform/idminter/database/IdentifiersDaoTest.scala
+++ b/id_minter/src/test/scala/uk/ac/wellcome/platform/idminter/database/IdentifiersDaoTest.scala
@@ -372,15 +372,4 @@ class IdentifiersDaoTest
     whenReady(identifiersDao.saveIdentifier(identifier)) { result =>
       result shouldBe 1
     }
-
-  /* Helper method.  Do a Miro ID lookup and check that it fails. */
-  private def assertLookupMiroIDFindsNothing(miroID: String, ontologyType: String = "Work") = {
-    val lookupFuture = identifiersDao.lookupMiroID(
-      miroID = miroID,
-      ontologyType = ontologyType
-    )
-    whenReady(lookupFuture) { maybeIdentifier =>
-      maybeIdentifier shouldNot be(defined)
-    }
-  }
 }

--- a/id_minter/src/test/scala/uk/ac/wellcome/platform/idminter/database/IdentifiersDaoTest.scala
+++ b/id_minter/src/test/scala/uk/ac/wellcome/platform/idminter/database/IdentifiersDaoTest.scala
@@ -269,41 +269,6 @@ class IdentifiersDaoTest
     }
   }
 
-  describe("lookupMiroID") {
-    it("should return a future of Some[Identifier] if it can find a MiroID in the DB") {
-      val identifier = Identifier(
-        CanonicalID = "A sand snail",
-        MiroID = "A soft shell"
-      )
-      assertInsertingIdentifierSucceeds(identifier)
-
-      whenReady(identifiersDao.lookupMiroID(identifier.MiroID)) { maybeIdentifier =>
-        maybeIdentifier shouldBe defined
-        maybeIdentifier.get shouldBe identifier
-      }
-    }
-
-    it("should return a future of None if looking up a non-existent Miro ID") {
-      assertLookupMiroIDFindsNothing(
-        miroID = "A missing mouse"
-      )
-    }
-
-    it("should return a future of None if looking up a Miro ID with the wrong ontologyType") {
-      val identifier = Identifier(
-        CanonicalID = "A sprinkling of sage",
-        MiroID = "Seasoning with saffron",
-        ontologyType = "Herbs"
-      )
-      assertInsertingIdentifierSucceeds(identifier)
-
-      assertLookupMiroIDFindsNothing(
-        miroID = identifier.MiroID,
-        ontologyType = "Vegetables"
-      )
-    }
-  }
-
   describe("saveIdentifier") {
     it("should insert the provided identifier into the database") {
       val identifier = Identifier(
@@ -386,36 +351,6 @@ class IdentifiersDaoTest
       )
 
       assertInsertingDuplicateFails(identifier, duplicateIdentifier)
-    }
-  }
-
-  /** Helper method.  Given two records, try to insert them both, and check
-    * that integrity checks in the database reject the second record.
-    */
-  private def assertInsertingDuplicateFails(identifier: Identifier,
-                                            duplicateIdentifier: Identifier) = {
-    assertInsertingIdentifierSucceeds(identifier)
-
-    val duplicateFuture = identifiersDao.saveIdentifier(duplicateIdentifier)
-    whenReady(duplicateFuture.failed) { exception =>
-      exception shouldBe a[SQLIntegrityConstraintViolationException]
-    }
-  }
-
-  /** Helper method.  Insert a record and check that it succeeds. */
-  private def assertInsertingIdentifierSucceeds(identifier: Identifier) =
-    whenReady(identifiersDao.saveIdentifier(identifier)) { result =>
-      result shouldBe 1
-    }
-
-  /** Helper method.  Do a Miro ID lookup and check that it fails. */
-  private def assertLookupMiroIDFindsNothing(miroID: String, ontologyType: String = "Work") = {
-    val lookupFuture = identifiersDao.lookupMiroID(
-      miroID = miroID,
-      ontologyType = ontologyType
-    )
-    whenReady(lookupFuture) { maybeIdentifier =>
-      maybeIdentifier shouldNot be(defined)
     }
   }
 }

--- a/id_minter/src/test/scala/uk/ac/wellcome/platform/idminter/database/IdentifiersDaoTest.scala
+++ b/id_minter/src/test/scala/uk/ac/wellcome/platform/idminter/database/IdentifiersDaoTest.scala
@@ -353,4 +353,34 @@ class IdentifiersDaoTest
       assertInsertingDuplicateFails(identifier, duplicateIdentifier)
     }
   }
+
+  /* Helper method.  Given two records, try to insert them both, and check
+   * that integrity checks in the database reject the second record.
+   */
+  private def assertInsertingDuplicateFails(identifier: Identifier,
+                                            duplicateIdentifier: Identifier) = {
+    assertInsertingIdentifierSucceeds(identifier)
+
+    val duplicateFuture = identifiersDao.saveIdentifier(duplicateIdentifier)
+    whenReady(duplicateFuture.failed) { exception =>
+      exception shouldBe a[SQLIntegrityConstraintViolationException]
+    }
+  }
+
+  /* Helper method.  Insert a record and check that it succeeds. */
+  private def assertInsertingIdentifierSucceeds(identifier: Identifier) =
+    whenReady(identifiersDao.saveIdentifier(identifier)) { result =>
+      result shouldBe 1
+    }
+
+  /* Helper method.  Do a Miro ID lookup and check that it fails. */
+  private def assertLookupMiroIDFindsNothing(miroID: String, ontologyType: String = "Work") = {
+    val lookupFuture = identifiersDao.lookupMiroID(
+      miroID = miroID,
+      ontologyType = ontologyType
+    )
+    whenReady(lookupFuture) { maybeIdentifier =>
+      maybeIdentifier shouldNot be(defined)
+    }
+  }
 }

--- a/id_minter/src/test/scala/uk/ac/wellcome/platform/idminter/steps/IdentifierGeneratorTest.scala
+++ b/id_minter/src/test/scala/uk/ac/wellcome/platform/idminter/steps/IdentifierGeneratorTest.scala
@@ -83,14 +83,25 @@ class IdentifierGeneratorTest
   it(
     "should return a failed future if it fails inserting the identifier in the database") {
     val miroId = "1234"
-    val work =
-      Work(identifiers = List(SourceIdentifier(IdentifierSchemes.miroImageNumber, miroId)),
-           title = "A fear of failing in a fox")
+    val sourceIdentifiers = List(
+      SourceIdentifier(
+        identifierScheme = IdentifierSchemes.miroImageNumber,
+        value = miroId
+      )
+    )
+    val work = Work(
+      identifiers = sourceIdentifiers,
+      title = "A fear of failing in a fox"
+    )
     val identifiersDao = mock[IdentifiersDao]
     val identifierGenerator =
       new IdentifierGenerator(identifiersDao, metricsSender)
 
-    when(identifiersDao.lookupMiroID(miroId))
+    val lookupFuture = identifiersDao.lookupID(
+      sourceIdentifiers = sourceIdentifiers,
+      ontologyType = work.ontologyType
+    )
+    when(lookupFuture)
       .thenReturn(Future.successful(None))
     val expectedException = new Exception("Noooo")
     when(identifiersDao.saveIdentifier(any[Identifier]()))


### PR DESCRIPTION
### What is this PR trying to achieve?

The natural follow-up to #857. This removes some Miro-specific logic from the database lookups.

Yet another patch for #839.