### PR TITLE
Add an ECS task for updating our API documentation on Stoplight

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -117,3 +117,4 @@ env:
     - TASK=loris-build
     - TASK=miro_adapter-build
     - TASK=elasticdump-build
+    - TASK=api_docs-build

--- a/Makefile
+++ b/Makefile
@@ -78,6 +78,13 @@ elasticdump-deploy: elasticdump-build
 	./scripts/deploy_docker_to_aws.py --project=elasticdump --infra-bucket=$(INFRA_BUCKET)
 
 
+api_docs-build: .docker/_build_deps
+	docker run -v /var/run/docker.sock:/var/run/docker.sock -v $$(pwd):/repo image_builder --project=update_api_docs
+
+api_docs-deploy: api_docs-build
+	./scripts/deploy_docker_to_aws.py --project=update_api_docs --infra-bucket=$(INFRA_BUCKET)
+
+
 nginx-build-api: .docker/image_builder
 	docker run -v /var/run/docker.sock:/var/run/docker.sock -v $$(pwd):/repo image_builder --project=nginx --variant=api
 

--- a/docker/update_api_docs/Dockerfile
+++ b/docker/update_api_docs/Dockerfile
@@ -1,0 +1,11 @@
+FROM alpine
+
+LABEL maintainer "Alex Chan <a.chan@wellcome.ac.uk>"
+LABEL description "Push a new version of Swagger documentation to Spotlight"
+
+RUN apk update
+RUN apk add curl
+
+COPY update_api_docs.sh /update_api_docs.sh
+
+CMD ["/update_api_docs.sh"]

--- a/docker/update_api_docs/README.md
+++ b/docker/update_api_docs/README.md
@@ -1,0 +1,21 @@
+# update_api_docs
+
+This task publishes a new Swagger definition to our documentation, which is hosted on [Spotlight][spotlight].
+
+It performs an [Import][import] and a [Publish][publish], which requires the documentation to have been published at least once before.
+
+[spotlight]: https://stoplight.io/
+[import]: https://help.stoplight.io/api-v1/versions/import
+[publish]: https://help.stoplight.io/api-v1/versions/publish
+
+## Usage
+
+The task takes three parameters:
+
+*   `VERSION_ID` -- the [version identifier][version] for the docs
+*   `API_SECRET` -- your API secret, as provided by [the Stoplight API][auth].
+*   `SWAGGER_URL` -- the URL of the Swagger file to use.
+    This defaults to <https://api.wellcomecollection.org/catalogue/v0/swagger.json>.
+
+[version]: https://help.stoplight.io/api-v1/versions/working-with-versions
+[auth]: https://help.stoplight.io/api-v1/api-introduction/authentication

--- a/docker/update_api_docs/README.md
+++ b/docker/update_api_docs/README.md
@@ -17,5 +17,24 @@ The task takes three parameters:
 *   `SWAGGER_URL` -- the URL of the Swagger file to use.
     This defaults to <https://api.wellcomecollection.org/catalogue/v0/swagger.json>.
 
+You can invoke the task as follows:
+
+```
+aws ecs run-task --cluster=services_cluster \
+     --task-definition=update_api_docs_task_definition \
+     --overrides="{
+       "containerOverrides": [
+         {
+           \"name\": \"app\",
+           \"environment\": [
+           {\"name\": \"VERSION_ID\", \"value\": \"$VERSION_ID\"},
+           {\"name\": \"API_SECRET\", \"value\": \"$API_SECRET\"},
+           {\"name\": \"SWAGGER_URL\", \"value\": \"$SWAGGER_URL\"}
+         ]
+       }
+     ]
+   }"
+```
+
 [version]: https://help.stoplight.io/api-v1/versions/working-with-versions
 [auth]: https://help.stoplight.io/api-v1/api-introduction/authentication

--- a/docker/update_api_docs/update_api_docs.sh
+++ b/docker/update_api_docs/update_api_docs.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/usr/bin/env sh
 
 set -o errexit
 set -o nounset

--- a/docker/update_api_docs/update_api_docs.sh
+++ b/docker/update_api_docs/update_api_docs.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+
+set -o errexit
+set -o nounset
+
+SWAGGER_URL="${SWAGGER_URL:-https://api.wellcomecollection.org/catalogue/v0/swagger.json}"
+
+echo "*** Making the IMPORT request"
+curl --request PUT \
+  --url "https://api.stoplight.io/v1/versions/$VERSION_ID/import" \
+  --header "authorization: Bearer $API_SECRET" \
+  --header "content-type: application/json" \
+  --data "{
+    \"url\": \"$SWAGGER_URL\",
+    \"options\": {
+      \"removeExtraEndpoints\": true,
+      \"removeExtraModels\": true
+    }
+  }"
+echo
+
+echo "*** Making the PUBLISH request"
+curl --request POST \
+  --url "https://api.stoplight.io/v1/versions/$VERSION_ID/publish" \
+  --header "authorization: Bearer $API_SECRET" \
+  --header "content-type: application/json" \
+  --data "{}"

--- a/terraform/ecr.tf
+++ b/terraform/ecr.tf
@@ -80,3 +80,8 @@ module "ecr_repository_elasticdump" {
   source = "./ecr"
   name   = "elasticdump"
 }
+
+module "ecr_repository_update_api_docs" {
+  source = "./ecr"
+  name   = "update_api_docs"
+}

--- a/terraform/ecs_script_task/variables.tf
+++ b/terraform/ecs_script_task/variables.tf
@@ -33,6 +33,7 @@ variable "container_path" {
 variable "env_vars" {
   description = "Environment variables to pass to the container"
   type        = "list"
+  default     = []
 }
 
 variable "cpu" {

--- a/terraform/iam.tf
+++ b/terraform/iam.tf
@@ -72,3 +72,8 @@ module "ecs_elasticdump_iam" {
   source = "./ecs_iam"
   name   = "elasticdump"
 }
+
+module "ecs_update_api_docs_iam" {
+  source = "./ecs_iam"
+  name   = "update_api_docs"
+}

--- a/terraform/script_tasks.tf
+++ b/terraform/script_tasks.tf
@@ -92,3 +92,13 @@ module "elasticdump" {
     "{\"name\": \"AWS_DEFAULT_REGION\", \"value\": \"${var.aws_region}\"}",
   ]
 }
+
+module "update_api_docs" {
+  source        = "./ecs_script_task"
+  task_name     = "update_api_docs"
+  app_uri       = "${module.ecr_repository_update_api_docs.repository_url}:${var.release_ids["update_api_docs"]}"
+  task_role_arn = "${module.ecs_update_api_docs_iam.task_role_arn}"
+
+  cpu    = 1024
+  memory = 1024
+}


### PR DESCRIPTION
### What is this PR trying to achieve?

Make it easier for us to update our Swagger docs.

### Who is this change for?

The Platform team.

### Have the following been considered/are they needed?

- [x] Deployed new versions
- [x] Run `terraform apply`.