### PR TITLE
Give IAM permissions for accessing the right bucket

### DIFF
--- a/terraform/iam_policy_document.tf
+++ b/terraform/iam_policy_document.tf
@@ -178,8 +178,8 @@ data "aws_iam_policy_document" "s3_wellcomecollection_mets_ingest_bucket_read_wr
     ]
 
     resources = [
-      "${aws_s3_bucket.mets-ingest.arn}/*",
-      "${aws_s3_bucket.mets-ingest.arn}",
+      "${aws_s3_bucket.wellcomecollection-mets-ingest.arn}/*",
+      "${aws_s3_bucket.wellcomecollection-mets-ingest.arn}",
     ]
   }
 }


### PR DESCRIPTION
Previously we were giving full access to the same bucket, twice.

This is where we were assigning permissions to this IAM user:

https://github.com/wellcometrust/platform-api/blob/dda195578d53ece3d83a7615b39659ee53e551a1/terraform/iam_users.tf#L46-L62

And the result was that they could only reach the `mets-ingest` bucket, not `wellcomecollection-mets-ingest`.

### What is this PR trying to achieve?

Make the permissions work correctly.

### Who is this change for?

Intranda, who were otherwise unable to access this bucket.

### Have the following been considered/are they needed?

- [x] Run `terraform apply`.