### PR TITLE
Add a couple of extra characters to discard for the L images

### DIFF
--- a/miro_adapter/utils.py
+++ b/miro_adapter/utils.py
@@ -59,7 +59,7 @@ def fix_miro_xml_entities(xml_string):
     TODO: Process these properly (what do they contain in the original Miro?)
     """
     bad_values = {
-        b'\x1b', b'\x7f', b'\x1f', b'\x14',
+        b'\x13', b'\x14', b'\x18', b'\x19', b'\x1b', b'\x1f', b'\x7f'
     }
     for v in bad_values:
         xml_string = xml_string.replace(v, b'_')


### PR DESCRIPTION
Required for #517.

### What is this PR trying to achieve?

Allow the Miro adapter to run cleanly over all image data.

### Who is this change for?

Anybody who wants a working Miro adapter.

### Have the following been considered/are they needed?

- [ ] Deployed new versions