### PR TITLE
Add the ability to configure the ReindexShard in the reindexer

### DIFF
--- a/miro_adapter/miro_adapter.py
+++ b/miro_adapter/miro_adapter.py
@@ -40,7 +40,7 @@ def push_to_dynamodb(table_name, collection_name, image_data):
                 Item={
                     'MiroID': image['image_no_calc'],
                     'MiroCollection': collection_name,
-                    'ReindexShard': 'default',
+                    'ReindexShard': collection_name,
                     'ReindexVersion': 1,
                     'data': json.dumps(image, separators=(',', ':'))
                 }

--- a/reindexer/src/main/scala/uk/ac/wellcome/platform/reindexer/modules/ReindexModule.scala
+++ b/reindexer/src/main/scala/uk/ac/wellcome/platform/reindexer/modules/ReindexModule.scala
@@ -24,24 +24,35 @@ object ReindexModule extends TwitterModule with TryBackoff {
   val targetTableName: Flag[String] = flag[String](
     name = "reindex.target.tableName",
     help = "Reindex target table name")
+  val targetReindexShard: Flag[String] = flag[String](
+    name = "reindex.target.reindexShard",
+    help = "Reindex shard to use",
+    default = "default"
+  )
 
   @Singleton
   @Provides
   def providesMiroReindexTargetService(
     dynamoDBClient: AmazonDynamoDB,
     metricsSender: MetricsSender): ReindexTargetService[MiroTransformable] =
-    new MiroReindexTargetService(dynamoDBClient,
-                                 targetTableName(),
-                                 metricsSender)
+    new MiroReindexTargetService(
+      dynamoDBClient = dynamoDBClient,
+      metricsSender = metricsSender,
+      targetTableName = targetTableName(),
+      targetReindexShard = targetReindexShard()
+    )
 
   @Singleton
   @Provides
   def providesCalmReindexTargetService(
     dynamoDBClient: AmazonDynamoDB,
     metricsSender: MetricsSender): ReindexTargetService[CalmTransformable] =
-    new CalmReindexTargetService(dynamoDBClient,
-                                 targetTableName(),
-                                 metricsSender)
+    new CalmReindexTargetService(
+      dynamoDBClient = dynamoDBClient,
+      metricsSender = metricsSender,
+      targetTableName = targetTableName(),
+      targetReindexShard = targetReindexShard()
+    )
 
   override def singletonStartup(injector: Injector) {
     val tableName = targetTableName()

--- a/reindexer/src/main/scala/uk/ac/wellcome/platform/reindexer/services/CalmReindexTargetService.scala
+++ b/reindexer/src/main/scala/uk/ac/wellcome/platform/reindexer/services/CalmReindexTargetService.scala
@@ -11,14 +11,18 @@ import uk.ac.wellcome.utils.ScanamoQueryStream
 
 class CalmReindexTargetService @Inject()(
   dynamoDBClient: AmazonDynamoDB,
-  @Flag("reindex.target.tableName") reindexTargetTableName: String,
+  @Flag("reindex.target.tableName") targetTableName: String,
+  @Flag("reindex.target.reindexShard") targetReindexShard: String = "default",
   metricsSender: MetricsSender)
-    extends ReindexTargetService[CalmTransformable](dynamoDBClient,
-                                                    metricsSender,
-                                                    reindexTargetTableName) {
-
+    extends ReindexTargetService[CalmTransformable](
+      dynamoDBClient = dynamoDBClient,
+      metricsSender = metricsSender,
+      targetTableName = targetTableName,
+      targetReindexShard = targetReindexShard
+    )
+{
   protected val scanamoUpdate: ScanamoUpdate =
-    Scanamo.update[CalmTransformable](dynamoDBClient)(reindexTargetTableName)
+    Scanamo.update[CalmTransformable](dynamoDBClient)(targetTableName)
 
   protected val scanamoQueryStreamFunction: ScanamoQueryStreamFunction =
     ScanamoQueryStream

--- a/reindexer/src/main/scala/uk/ac/wellcome/platform/reindexer/services/MiroReindexTargetService.scala
+++ b/reindexer/src/main/scala/uk/ac/wellcome/platform/reindexer/services/MiroReindexTargetService.scala
@@ -11,14 +11,18 @@ import uk.ac.wellcome.utils.ScanamoQueryStream
 
 class MiroReindexTargetService @Inject()(
   dynamoDBClient: AmazonDynamoDB,
-  @Flag("reindex.target.tableName") reindexTargetTableName: String,
+  @Flag("reindex.target.tableName") targetTableName: String,
+  @Flag("reindex.target.reindexShard") targetReindexShard: String = "default",
   metricsSender: MetricsSender)
-    extends ReindexTargetService[MiroTransformable](dynamoDBClient,
-                                                    metricsSender,
-                                                    reindexTargetTableName) {
-
+    extends ReindexTargetService[MiroTransformable](
+      dynamoDBClient = dynamoDBClient,
+      metricsSender = metricsSender,
+      targetTableName = targetTableName,
+      targetReindexShard = targetReindexShard
+    )
+{
   protected val scanamoUpdate: ScanamoUpdate =
-    Scanamo.update[MiroTransformable](dynamoDBClient)(reindexTargetTableName)
+    Scanamo.update[MiroTransformable](dynamoDBClient)(targetTableName)
 
   protected val scanamoQueryStreamFunction: ScanamoQueryStreamFunction =
     ScanamoQueryStream

--- a/reindexer/src/main/scala/uk/ac/wellcome/platform/reindexer/services/ReindexTargetService.scala
+++ b/reindexer/src/main/scala/uk/ac/wellcome/platform/reindexer/services/ReindexTargetService.scala
@@ -19,7 +19,8 @@ import scala.concurrent.Future
 abstract class ReindexTargetService[T <: Reindexable[String]](
   dynamoDBClient: AmazonDynamoDB,
   metricsSender: MetricsSender,
-  targetTableName: String)
+  targetTableName: String,
+  targetReindexShard: String)
     extends Logging {
 
   type ScanamoQueryResult = Either[DynamoReadError, T]
@@ -72,7 +73,7 @@ abstract class ReindexTargetService[T <: Reindexable[String]](
       Some(gsiName),
       Query(
         AndQueryCondition(
-          KeyEquals('ReindexShard, "default"),
+          KeyEquals('ReindexShard, targetReindexShard),
           KeyIs('ReindexVersion, LT, requestedVersion)
         )),
       ScanamoQueryOptions.default

--- a/reindexer/src/test/scala/uk/ac/wellcome/platform/reindexer/ReindexerFeatureTest.scala
+++ b/reindexer/src/test/scala/uk/ac/wellcome/platform/reindexer/ReindexerFeatureTest.scala
@@ -23,7 +23,8 @@ class ReindexerFeatureTest
       flags = Map(
         "aws.dynamo.reindexTracker.tableName" -> "ReindexTracker",
         "aws.dynamo.calmData.tableName" -> "MiroData",
-        "reindex.target.tableName" -> "MiroData"
+        "reindex.target.tableName" -> "MiroData",
+        "reindex.target.reindexShard" -> "default"
       ) ++ cloudWatchLocalEndpointFlag ++ dynamoDbLocalEndpointFlags
     )
 

--- a/reindexer/src/test/scala/uk/ac/wellcome/platform/reindexer/StartupTest.scala
+++ b/reindexer/src/test/scala/uk/ac/wellcome/platform/reindexer/StartupTest.scala
@@ -21,7 +21,8 @@ class StartupTest
     flags = Map(
       "aws.dynamo.reindexTracker.tableName" -> "ReindexTracker",
       "aws.dynamo.miroData.tableName" -> "MiroData",
-      "reindex.target.tableName" -> "MiroData"
+      "reindex.target.tableName" -> "MiroData",
+      "reindex.target.reindexShard" -> "default"
     ) ++ dynamoDbLocalEndpointFlags ++ cloudWatchLocalEndpointFlag
   )
 

--- a/reindexer/src/test/scala/uk/ac/wellcome/platform/reindexer/services/CalmReindexTargetServiceTest.scala
+++ b/reindexer/src/test/scala/uk/ac/wellcome/platform/reindexer/services/CalmReindexTargetServiceTest.scala
@@ -58,8 +58,11 @@ class CalmReindexTargetServiceTest
     val metricsSender: MetricsSender =
       new MetricsSender(namespace = "reindexer-tests", mock[AmazonCloudWatch])
 
-    val reindexTargetService =
-      new CalmReindexTargetService(dynamoDbClient, "CalmData", metricsSender)
+    val reindexTargetService = new CalmReindexTargetService(
+      dynamoDBClient = dynamoDbClient,
+      targetTableName = "CalmData",
+      metricsSender = metricsSender
+    )
 
     val reindexAttempt = ReindexAttempt(reindex)
     val expectedReindexAttempt = reindexAttempt.copy(

--- a/reindexer/src/test/scala/uk/ac/wellcome/platform/reindexer/services/MiroReindexTargetServiceTest.scala
+++ b/reindexer/src/test/scala/uk/ac/wellcome/platform/reindexer/services/MiroReindexTargetServiceTest.scala
@@ -22,12 +22,81 @@ class MiroReindexTargetServiceTest
   val metricsSender: MetricsSender =
     new MetricsSender(namespace = "reindexer-tests", mock[AmazonCloudWatch])
 
-  val reindexTargetService =
-    new MiroReindexTargetService(
-      dynamoDBClient = dynamoDbClient,
-      targetTableName = "MiroData",
-      metricsSender = metricsSender
+  it("should only update images in the specified ReindexShard") {
+    val currentVersion = 1
+    val requestedVersion = 2
+
+    val inShardMiroTransformables = List(
+      MiroTransformable(
+        MiroID = "Image_A1",
+        MiroCollection = "Images-A",
+        data = s""""{"image_title": "An almanac about armadillos"}""",
+        ReindexShard = "Images-A",
+        ReindexVersion = currentVersion
+      ),
+      MiroTransformable(
+        MiroID = "Image_A2",
+        MiroCollection = "Images-A",
+        data = s""""{"image_title": "Asking after an aardvark"}""",
+        ReindexShard = "Images-A",
+        ReindexVersion = currentVersion
+      )
     )
+
+    val diffShardMiroTransformables = List(
+      MiroTransformable(
+        MiroID = "Image_B1",
+        MiroCollection = "Images-B",
+        data = s""""{"image_title": "Buying books about beavers"}""",
+        ReindexShard = "Images-B",
+        ReindexVersion = currentVersion
+      ),
+      MiroTransformable(
+        MiroID = "Image_C1",
+        MiroCollection = "Images-C",
+        data = s""""{"image_title": "Calling a crafty caterpillar"}""",
+        ReindexShard = "Images-C",
+        ReindexVersion = currentVersion
+      )
+    )
+
+    val miroTransformableList = inShardMiroTransformables ++ diffShardMiroTransformables
+
+    val reindex = Reindex(miroDataTableName, requestedVersion, currentVersion)
+    val reindexAttempt = ReindexAttempt(reindex)
+    val expectedReindexAttempt = reindexAttempt.copy(
+      reindex = reindex,
+      successful = true,
+      attempt = 1
+    )
+
+    miroTransformableList.foreach(
+      Scanamo.put(dynamoDbClient)(miroDataTableName))
+
+    Scanamo.put(dynamoDbClient)(reindexTableName)(reindex)
+
+    val reindexTargetService =
+      new MiroReindexTargetService(
+        dynamoDBClient = dynamoDbClient,
+        targetTableName = "MiroData",
+        targetReindexShard = inShardMiroTransformables.head.ReindexShard,
+        metricsSender = metricsSender
+      )
+
+    whenReady(reindexTargetService.runReindex(reindexAttempt)) {
+      reindexAttempt =>
+        reindexAttempt shouldBe expectedReindexAttempt
+        val reindexVersions = Scanamo
+          .scan[MiroTransformable](dynamoDbClient)(miroDataTableName)
+          .map {
+            case Right(miroTranformable) => miroTranformable.ReindexVersion
+          }
+
+        reindexVersions.filter { _ == currentVersion }.length shouldBe diffShardMiroTransformables.length
+        reindexVersions.filter { _ == requestedVersion }.length shouldBe inShardMiroTransformables.length
+    }
+
+  }
 
   it("should update the correct index to the requested version") {
 
@@ -39,7 +108,7 @@ class MiroReindexTargetServiceTest
         MiroID = "Image1",
         MiroCollection = "Images-A",
         data = s"""{"image_title": "title"}""",
-        ReindexVersion = 1
+        ReindexVersion = currentVersion
       )
     )
 
@@ -67,6 +136,13 @@ class MiroReindexTargetServiceTest
 
     Scanamo.put(dynamoDbClient)(reindexTableName)(reindex)
 
+    val reindexTargetService =
+      new MiroReindexTargetService(
+        dynamoDBClient = dynamoDbClient,
+        targetTableName = "MiroData",
+        metricsSender = metricsSender
+      )
+
     whenReady(reindexTargetService.runReindex(reindexAttempt)) {
       reindexAttempt =>
         reindexAttempt shouldBe expectedReindexAttempt
@@ -76,6 +152,5 @@ class MiroReindexTargetServiceTest
             case Right(miroTranformable) => miroTranformable.ReindexVersion
           } should contain only requestedVersion
     }
-
   }
 }

--- a/reindexer/src/test/scala/uk/ac/wellcome/platform/reindexer/services/MiroReindexTargetServiceTest.scala
+++ b/reindexer/src/test/scala/uk/ac/wellcome/platform/reindexer/services/MiroReindexTargetServiceTest.scala
@@ -19,6 +19,16 @@ class MiroReindexTargetServiceTest
     with MockitoSugar
     with ExtendedPatience {
 
+  val metricsSender: MetricsSender =
+    new MetricsSender(namespace = "reindexer-tests", mock[AmazonCloudWatch])
+
+  val reindexTargetService =
+    new MiroReindexTargetService(
+      dynamoDBClient = dynamoDbClient,
+      targetTableName = "MiroData",
+      metricsSender = metricsSender
+    )
+
   it("should update the correct index to the requested version") {
 
     val currentVersion = 1
@@ -56,12 +66,6 @@ class MiroReindexTargetServiceTest
       Scanamo.put(dynamoDbClient)(miroDataTableName))
 
     Scanamo.put(dynamoDbClient)(reindexTableName)(reindex)
-
-    val metricsSender: MetricsSender =
-      new MetricsSender(namespace = "reindexer-tests", mock[AmazonCloudWatch])
-
-    val reindexTargetService =
-      new MiroReindexTargetService(dynamoDbClient, "MiroData", metricsSender)
 
     whenReady(reindexTargetService.runReindex(reindexAttempt)) {
       reindexAttempt =>

--- a/reindexer/src/test/scala/uk/ac/wellcome/platform/reindexer/services/ReindexServiceTest.scala
+++ b/reindexer/src/test/scala/uk/ac/wellcome/platform/reindexer/services/ReindexServiceTest.scala
@@ -40,7 +40,11 @@ class ReindexServiceTest
         dynamoConfigs,
         "CalmData"
       ),
-      new CalmReindexTargetService(dynamoDbClient, "CalmData", metricsSender),
+      new CalmReindexTargetService(
+        dynamoDBClient = dynamoDbClient,
+        targetTableName = "CalmData",
+        metricsSender = metricsSender
+      ),
       new MetricsSender("reindexer-tests", mock[AmazonCloudWatch])
     )
 


### PR DESCRIPTION
### What is this PR trying to achieve?

Adds a config option to the reindexer that allows us to reindex a specific shard.

### Who is this change for?

Being able to reindex only a subset of the database means that:

* We could (theoretically) run multiple reindexes in parallel, making it go faster
* We can reindex specific collections in Miro

### Have the following been considered/are they needed?

- [ ] Deployed new versions