### PR TITLE
[WIP] Use Lenses!

### DIFF
--- a/id_minter/src/main/scala/uk/ac/wellcome/platform/idminter/services/IdMinterWorkerService.scala
+++ b/id_minter/src/main/scala/uk/ac/wellcome/platform/idminter/services/IdMinterWorkerService.scala
@@ -5,23 +5,20 @@ import com.google.inject.Inject
 import uk.ac.wellcome.metrics.MetricsSender
 import uk.ac.wellcome.models.Work
 import uk.ac.wellcome.models.aws.SQSMessage
-import uk.ac.wellcome.platform.idminter.steps.{
-  IdentifierGenerator,
-  WorkExtractor
-}
+import uk.ac.wellcome.platform.idminter.steps.{SomethingSomethin, WorkExtractor}
 import uk.ac.wellcome.sns.SNSWriter
 import uk.ac.wellcome.sqs.{SQSReader, SQSWorker}
+import uk.ac.wellcome.utils.GlobalExecutionContext.context
 import uk.ac.wellcome.utils.JsonUtil
 
 import scala.concurrent.Future
-import uk.ac.wellcome.utils.GlobalExecutionContext.context
 
 class IdMinterWorkerService @Inject()(
-  idGenerator: IdentifierGenerator,
-  writer: SNSWriter,
-  reader: SQSReader,
-  system: ActorSystem,
-  metrics: MetricsSender
+                                       identificator: SomethingSomethin,
+                                       writer: SNSWriter,
+                                       reader: SQSReader,
+                                       system: ActorSystem,
+                                       metrics: MetricsSender
 ) extends SQSWorker(reader, system, metrics) {
 
   val snsSubject = "identified-item"
@@ -33,7 +30,7 @@ class IdMinterWorkerService @Inject()(
   override def processMessage(message: SQSMessage): Future[Unit] =
     for {
       work <- WorkExtractor.toWork(message)
-      canonicalId <- idGenerator.generateId(work)
+      canonicalId <- identificator.generateId(work)
       _ <- writer.writeMessage(toWorkJson(work, canonicalId), Some(snsSubject))
     } yield ()
 

--- a/id_minter/src/test/scala/uk/ac/wellcome/platform/idminter/modules/IdMinterWorkerTest.scala
+++ b/id_minter/src/test/scala/uk/ac/wellcome/platform/idminter/modules/IdMinterWorkerTest.scala
@@ -11,15 +11,13 @@ import scalikejdbc.interpolation.SQLSyntax
 import uk.ac.wellcome.finatra.modules.IdentifierSchemes
 import uk.ac.wellcome.models.aws.SQSMessage
 import uk.ac.wellcome.models.{SourceIdentifier, Work}
-import uk.ac.wellcome.platform.idminter.database.{
-  FieldDescription,
-  IdentifiersDao
-}
+import uk.ac.wellcome.platform.idminter.database.{FieldDescription, IdentifiersDao}
 import uk.ac.wellcome.platform.idminter.model.Identifier
 import uk.ac.wellcome.platform.idminter.utils.IdMinterTestUtils
 import uk.ac.wellcome.utils.JsonUtil
 
 import scala.concurrent.Future
+import scala.util.{Failure, Success}
 
 class IdMinterWorkerTest
     extends FunSpec
@@ -85,15 +83,15 @@ class IdMinterWorkerTest
       title = "Some fresh fruit for a flamingo"
     )
 
-    val lookupFuture = identifiersDao.lookupID(
+    val triedLookup = identifiersDao.lookupID(
       sourceIdentifiers = sourceIdentifiers,
       ontologyType = work.ontologyType
     )
 
-    when(lookupFuture)
-      .thenReturn(Future.successful(None))
+    when(triedLookup)
+      .thenReturn(Success(None))
     when(identifiersDao.saveIdentifier(any[Identifier]))
-      .thenReturn(Future.failed(new Exception("cannot insert")))
+      .thenReturn(Failure(new Exception("cannot insert")))
 
     val message = JsonUtil
       .toJson(

--- a/id_minter/src/test/scala/uk/ac/wellcome/platform/idminter/steps/IdentifierGeneratorTest.scala
+++ b/id_minter/src/test/scala/uk/ac/wellcome/platform/idminter/steps/IdentifierGeneratorTest.scala
@@ -15,6 +15,7 @@ import uk.ac.wellcome.platform.idminter.model.Identifier
 import uk.ac.wellcome.platform.idminter.utils.IdentifiersMysqlLocal
 
 import scala.concurrent.Future
+import scala.util.{Failure, Success}
 
 class IdentifierGeneratorTest
     extends FunSpec
@@ -97,15 +98,15 @@ class IdentifierGeneratorTest
     val identifierGenerator =
       new IdentifierGenerator(identifiersDao, metricsSender)
 
-    val lookupFuture = identifiersDao.lookupID(
+    val triedLookup = identifiersDao.lookupID(
       sourceIdentifiers = sourceIdentifiers,
       ontologyType = work.ontologyType
     )
-    when(lookupFuture)
-      .thenReturn(Future.successful(None))
+    when(triedLookup)
+      .thenReturn(Success(None))
     val expectedException = new Exception("Noooo")
     when(identifiersDao.saveIdentifier(any[Identifier]()))
-      .thenReturn(Future.failed(expectedException))
+      .thenReturn(Failure(expectedException))
 
     whenReady(identifierGenerator.generateId(work).failed) { exception =>
       exception shouldBe expectedException

--- a/id_minter/src/test/scala/uk/ac/wellcome/platform/idminter/steps/IdentifierGeneratorTest.scala
+++ b/id_minter/src/test/scala/uk/ac/wellcome/platform/idminter/steps/IdentifierGeneratorTest.scala
@@ -14,15 +14,28 @@ import uk.ac.wellcome.platform.idminter.database.IdentifiersDao
 import uk.ac.wellcome.platform.idminter.model.Identifier
 import uk.ac.wellcome.platform.idminter.utils.IdentifiersMysqlLocal
 
-import scala.concurrent.Future
 import scala.util.{Failure, Success}
+
+class SomethingSomethinTest
+    extends FunSpec
+    with ScalaFutures
+    with Matchers
+    with BeforeAndAfterEach
+    with MockitoSugar {
+
+  private val metricsSender =
+    new MetricsSender("id_minter_test_metrics", mock[AmazonCloudWatch])
+  val identificator = new SomethingSomethin(
+    metricsSender,
+    mock[IdentifierGenerator]
+  )
+
+}
 
 class IdentifierGeneratorTest
     extends FunSpec
     with IdentifiersMysqlLocal
-    with ScalaFutures
     with Matchers
-    with BeforeAndAfterEach
     with MockitoSugar {
 
   private val metricsSender =
@@ -41,48 +54,43 @@ class IdentifierGeneratorTest
                      identifiersTable.column.ontologyType -> "Work")
     }.update().apply()
 
-    val work =
-      Work(identifiers = List(SourceIdentifier(IdentifierSchemes.miroImageNumber, "1234")),
-           title = "Searching for a sea slug")
-    val futureId = identifierGenerator.generateId(work)
+    val triedId = identifierGenerator.retrieveOrGenerateCanonicalId(
+      SourceIdentifier(IdentifierSchemes.miroImageNumber, "1234"),
+      "Work")
 
-    whenReady(futureId) { id =>
-      id shouldBe "5678"
-    }
+    triedId shouldBe Success("5678")
   }
 
   it(
     "should generate an id and save it in the database if a record doesn't already exist") {
-    val work =
-      Work(identifiers = List(SourceIdentifier(IdentifierSchemes.miroImageNumber, "1234")),
-           title = "A novel name for a nightingale")
-    val futureId = identifierGenerator.generateId(work)
+    val triedId = identifierGenerator.retrieveOrGenerateCanonicalId(
+      SourceIdentifier(IdentifierSchemes.miroImageNumber, "1234"),
+      "Work")
 
-    whenReady(futureId) { id =>
-      id should not be (empty)
-      val i = identifiersTable.i
-      val maybeIdentifier = withSQL {
-        select.from(identifiersTable as i).where.eq(i.MiroID, "1234")
-      }.map(Identifier(i)).single.apply()
-      maybeIdentifier shouldBe defined
-      maybeIdentifier.get shouldBe Identifier(CanonicalID = id, MiroID = "1234")
-    }
-  }
-
-  it("should reject an item with no miroId in the list of Identifiers") {
-    val work =
-      Work(
-        identifiers = List(SourceIdentifier("not-a-miro-image-number", "1234")),
-        title = "The rejection of a robin")
-    val futureId = identifierGenerator.generateId(work)
-
-    whenReady(futureId.failed) { exception =>
-      exception.getMessage shouldBe s"Item $work did not contain a MiroID"
-    }
+    triedId shouldBe a[Success[String]]
+    val id = triedId.get
+    id should not be (empty)
+    val i = identifiersTable.i
+    val maybeIdentifier = withSQL {
+      select.from(identifiersTable as i).where.eq(i.MiroID, "1234")
+    }.map(Identifier(i)).single.apply()
+    maybeIdentifier shouldBe defined
+    maybeIdentifier.get shouldBe Identifier(CanonicalID = id, MiroID = "1234")
   }
 
   it(
-    "should return a failed future if it fails inserting the identifier in the database") {
+    "should fail if the identifier does not contain a known identifierScheme in the list of Identifiers") {
+    val triedGeneratingId = identifierGenerator.retrieveOrGenerateCanonicalId(
+      SourceIdentifier("not-a-miro-image-number", "1234"),
+      "Work")
+
+    triedGeneratingId shouldBe a[Failure[Exception]]
+    val exception = triedGeneratingId.get.asInstanceOf[Exception]
+    exception.getMessage shouldBe s"identifier list did not contain a known identifierScheme"
+  }
+
+  it(
+    "should return a failure if it fails inserting the identifier in the database") {
     val miroId = "1234"
     val sourceIdentifiers = List(
       SourceIdentifier(
@@ -108,9 +116,10 @@ class IdentifierGeneratorTest
     when(identifiersDao.saveIdentifier(any[Identifier]()))
       .thenReturn(Failure(expectedException))
 
-    whenReady(identifierGenerator.generateId(work).failed) { exception =>
-      exception shouldBe expectedException
-    }
-
+    val triedGeneratingId =
+      identifierGenerator.retrieveOrGenerateCanonicalId(sourceIdentifiers.head,
+                                                        "Work")
+    triedGeneratingId shouldBe a[Failure[Exception]]
+    triedGeneratingId.failed.get shouldBe expectedException
   }
 }

--- a/project/Common.scala
+++ b/project/Common.scala
@@ -16,7 +16,8 @@ object Common {
       "-Yinline",
       "-Xverify",
       "-feature",
-      "-language:postfixOps"
+      "-language:postfixOps",
+      "-Yrangepos"
     ),
     parallelExecution in Test := false
   ) ++ Search.settings ++ Swagger.settings ++ Finatra.settings

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -38,6 +38,12 @@ object Dependencies {
     "mysql" % "mysql-connector-java" % "6.0.6",
     "org.flywaydb" % "flyway-core" % "4.2.0"
   )
+
+  val monocleDependencies: Seq[ModuleID] = Seq(
+    "com.github.kenbot" %%  "goggles-dsl"     % "1.0",
+    "com.github.kenbot" %%  "goggles-macros"  % "1.0"
+  )
+
   val esDependencies: Seq[ModuleID] = Seq(
     "com.sksamuel.elastic4s" %% "elastic4s-core" % versions.elastic4s,
     "com.sksamuel.elastic4s" %% "elastic4s-http" % versions.elastic4s,
@@ -80,7 +86,7 @@ object Dependencies {
   val ingestorDependencies: Seq[ModuleID] = commonDependencies
 
   val idminterDependencies
-    : Seq[ModuleID] = commonDependencies ++ mysqlDependencies
+    : Seq[ModuleID] = commonDependencies ++ mysqlDependencies ++ monocleDependencies
 
   val reindexerDependencies: Seq[ModuleID] = commonDependencies
 }


### PR DESCRIPTION
### What is this PR trying to achieve?
Use [Monocle](http://julien-truffaut.github.io/Monocle/) to reduce the size of patches needed to the idMinter to generate identifiers for things other than Work. As discussed with @alexwlchan, the id_minter will not be completely agnostic of the Json structure (as that turned out to be a difficult problem to solve) but this change should make it a one liner to tell the idminter where to add ids
### Who is this change for?
Devs
### Have the following been considered/are they needed?

- [ ] Deployed new versions
