### PR TITLE
Actually run the Miro adapter tests in CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -115,6 +115,6 @@ env:
     - TASK=tif-metadata-build
     - TASK=gatling-build
     - TASK=loris-build
-    - TASK=miro_adapter-build
+    - TASK=miro_adapter-test
     - TASK=elasticdump-build
     - TASK=api_docs-build

--- a/Makefile
+++ b/Makefile
@@ -72,7 +72,9 @@ miro_adapter-build: .docker/image_builder
 	docker run -v /var/run/docker.sock:/var/run/docker.sock -v $$(pwd):/repo image_builder --project=miro_adapter --file=miro_adapter/Dockerfile
 
 miro_adapter-test: miro_adapter-build .docker/miro_adapter_tests
-	docker run miro_adapter_tests
+	rm -rf $$(pwd)/miro_adapter/__pycache__
+	rm -rf $$(pwd)/miro_adapter/*.pyc
+	docker run -v $$(pwd)/miro_adapter:/miro_adapter miro_adapter_tests
 
 miro_adapter-deploy: miro_adapter-build
 	./scripts/deploy_docker_to_aws.py --project=miro_adapter --infra-bucket=$(INFRA_BUCKET)

--- a/Makefile
+++ b/Makefile
@@ -27,6 +27,10 @@ clean:
 	docker build -t image_builder -f builds/image_builder.Dockerfile builds
 	mkdir -p .docker && touch .docker/image_builder
 
+.docker/miro_adapter_tests:
+	docker build -t miro_adapter_tests -f miro_adapter/miro_adapter_tests.Dockerfile miro_adapter
+	mkdir -p .docker && touch .docker/miro_adapter_tests
+
 
 ## Build the image for gatling
 gatling-build: .docker/image_builder
@@ -66,6 +70,9 @@ loris-deploy: loris-build
 
 miro_adapter-build: .docker/image_builder
 	docker run -v /var/run/docker.sock:/var/run/docker.sock -v $$(pwd):/repo image_builder --project=miro_adapter --file=miro_adapter/Dockerfile
+
+miro_adapter-test: miro_adapter-build .docker/miro_adapter_tests
+	docker run miro_adapter_tests
 
 miro_adapter-deploy: miro_adapter-build
 	./scripts/deploy_docker_to_aws.py --project=miro_adapter --infra-bucket=$(INFRA_BUCKET)

--- a/builds/build_docker_image.py
+++ b/builds/build_docker_image.py
@@ -39,8 +39,8 @@ if __name__ == '__main__':
     release_id = CURRENT_COMMIT
 
     if variant is not None:
-        tag = '%s_%s:%s' % (project, variant, release_id)
         release_name = '%s_%s' % (project, variant)
+        tag = '%s:%s' % (release_name, release_id)
     else:
         tag = '%s:%s' % (project, release_id)
         release_name = project
@@ -49,12 +49,13 @@ if __name__ == '__main__':
 
     print('*** Building the new image')
 
-    cmd = ['docker', 'build', '--file', dockerfile, '--tag', tag]
+    cmd = ['docker', 'build', '--file', dockerfile, '--tag', release_name]
     if variant is not None:
         cmd.extend(['--build-arg', 'variant=%s' % variant])
     cmd.append(os.path.dirname(dockerfile))
-
     subprocess.check_call(cmd)
+
+    subprocess.check_call(['docker', 'tag', release_name, tag])
 
     print('*** Saving the release ID to .releases')
     write_release_id(project=release_name, release_id=release_id)

--- a/miro_adapter/Dockerfile
+++ b/miro_adapter/Dockerfile
@@ -12,7 +12,5 @@ COPY requirements.txt /requirements.txt
 RUN pip3 install -r requirements.txt
 
 COPY . /miro_adapter
-RUN rm -rf /miro_adapter/__pycache__
-RUN rm -rf /miro_adapter/*.pyc
 
 CMD ["/miro_adapter/run.sh"]

--- a/miro_adapter/Dockerfile
+++ b/miro_adapter/Dockerfile
@@ -12,5 +12,7 @@ COPY requirements.txt /requirements.txt
 RUN pip3 install -r requirements.txt
 
 COPY . /miro_adapter
+RUN rm -rf /miro_adapter/__pycache__
+RUN rm -rf /miro_adapter/*.pyc
 
 CMD ["/miro_adapter/run.sh"]

--- a/miro_adapter/miro_adapter_tests.Dockerfile
+++ b/miro_adapter/miro_adapter_tests.Dockerfile
@@ -1,0 +1,7 @@
+FROM miro_adapter
+LABEL maintainer "Alex Chan <a.chan@wellcome.ac.uk>"
+LABEL description "Docker image for running Miro adapter tests"
+
+RUN pip3 install pytest
+
+CMD ["py.test", "/miro_adapter"]


### PR DESCRIPTION
### What is this PR trying to achieve?

We’re about to put a whole lot more logic in the Miro adapter (probably, see #875). So we should make sure the tests for the Miro adapter are run by Travis!

### Who is this change for?

Developers who want useful CI.