### PR TITLE
Push even more of our build process inside Docker 🐳

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,6 +26,12 @@ clean:
 .docker/image_builder:
 	./scripts/build_ci_docker_image.py --project=image_builder --dir=builds --file=builds/image_builder.Dockerfile
 
+.docker/publish_service_to_aws:
+	./scripts/build_ci_docker_image.py \
+		--project=publish_service_to_aws \
+		--dir=builds \
+		--file=builds/publish_service_to_aws.Dockerfile
+
 .docker/miro_adapter_tests:
 	./scripts/build_ci_docker_image.py --project=miro_adapter_tests --dir=miro_adapter --file=miro_adapter/miro_adapter_tests.Dockerfile
 

--- a/Makefile
+++ b/Makefile
@@ -11,25 +11,23 @@ clean:
 	rm -rf .docker
 
 .docker/jslint_ci:
-	./scripts/build_ci_docker_image.py --project jslint_ci
+	./scripts/build_ci_docker_image.py --project=jslint_ci --dir=docker/jslint_ci
 
 .docker/python3.6_ci:
-	./scripts/build_ci_docker_image.py --project python3.6_ci
+	./scripts/build_ci_docker_image.py --project=python3.6_ci --dir=docker/python3.6_ci
 
 .docker/terraform_ci:
-	./scripts/build_ci_docker_image.py --project terraform_ci
+	./scripts/build_ci_docker_image.py --project=terraform_ci --dir=docker/terraform_ci
 
 .docker/_build_deps:
 	pip3 install --upgrade boto3 docopt
 	mkdir -p .docker && touch .docker/_build_deps
 
 .docker/image_builder:
-	docker build -t image_builder -f builds/image_builder.Dockerfile builds
-	mkdir -p .docker && touch .docker/image_builder
+	./scripts/build_ci_docker_image.py --project=image_builder --dir=builds --file=builds/image_builder.Dockerfile
 
 .docker/miro_adapter_tests:
-	docker build -t miro_adapter_tests -f miro_adapter/miro_adapter_tests.Dockerfile miro_adapter
-	mkdir -p .docker && touch .docker/miro_adapter_tests
+	./scripts/build_ci_docker_image.py --project=miro_adapter_tests --dir=miro_adapter --file=miro_adapter/miro_adapter_tests.Dockerfile
 
 
 ## Build the image for gatling

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-INFRA_BUCKET = platform-infra
+export INFRA_BUCKET = platform-infra
 
 
 # Build the Docker images used for CI tasks.
@@ -47,17 +47,16 @@ gatling-build: .docker/image_builder
 	docker run -v /var/run/docker.sock:/var/run/docker.sock -v $$(pwd):/repo image_builder --project=gatling
 
 ## Deploy the image for gatling
-gatling-deploy: gatling-build
-	./scripts/deploy_docker_to_aws.py --project=gatling --infra-bucket=$(INFRA_BUCKET)
-
+gatling-deploy: gatling-build .docker/publish_service_to_aws
+	PROJECT=gatling ./builds/publish_service.sh
 
 ## Build the image for the cache cleaner
 cache_cleaner-build: .docker/image_builder
 	docker run -v /var/run/docker.sock:/var/run/docker.sock -v $$(pwd):/repo image_builder --project=cache_cleaner
 
 ## Deploy the image for the cache cleaner
-cache_cleaner-deploy: cache_cleaner-build
-	./scripts/deploy_docker_to_aws.py --project=cache_cleaner --infra-bucket=$(INFRA_BUCKET)
+cache_cleaner-deploy: cache_cleaner-build .docker/publish_service_to_aws
+	PROJECT=cache_cleaner ./builds/publish_service.sh
 
 
 ## Build the image for tif-metadata
@@ -65,8 +64,8 @@ tif-metadata-build: .docker/image_builder
 	docker run -v /var/run/docker.sock:/var/run/docker.sock -v $$(pwd):/repo image_builder --project=tif-metadata
 
 ## Deploy the image for tif-metadata
-tif-metadata-deploy: tif-metadata-build
-	./scripts/deploy_docker_to_aws.py --project=tif-metadata --infra-bucket=$(INFRA_BUCKET)
+tif-metadata-deploy: tif-metadata-build .docker/publish_service_to_aws
+	PROJECT=tif-metadata ./builds/publish_service.sh
 
 
 ## Build the image for Loris
@@ -74,8 +73,8 @@ loris-build: .docker/image_builder
 	docker run -v /var/run/docker.sock:/var/run/docker.sock -v $$(pwd):/repo image_builder --project=loris
 
 ## Deploy the image for Loris
-loris-deploy: loris-build
-	./scripts/deploy_docker_to_aws.py --project=loris --infra-bucket=$(INFRA_BUCKET)
+loris-deploy: loris-build .docker/publish_service_to_aws
+	PROJECT=loris ./builds/publish_service.sh
 
 
 miro_adapter-build: .docker/image_builder
@@ -86,22 +85,22 @@ miro_adapter-test: miro_adapter-build .docker/miro_adapter_tests
 	rm -rf $$(pwd)/miro_adapter/*.pyc
 	docker run -v $$(pwd)/miro_adapter:/miro_adapter miro_adapter_tests
 
-miro_adapter-deploy: miro_adapter-build
-	./scripts/deploy_docker_to_aws.py --project=miro_adapter --infra-bucket=$(INFRA_BUCKET)
+miro_adapter-deploy: miro_adapter-build .docker/publish_service_to_aws
+	PROJECT=miro_adapter ./builds/publish_service.sh
 
 
 elasticdump-build: .docker/image_builder
 	docker run -v /var/run/docker.sock:/var/run/docker.sock -v $$(pwd):/repo image_builder --project=elasticdump
 
-elasticdump-deploy: elasticdump-build
-	./scripts/deploy_docker_to_aws.py --project=elasticdump --infra-bucket=$(INFRA_BUCKET)
+elasticdump-deploy: elasticdump-build .docker/publish_service_to_aws
+	PROJECT=elasticdump ./builds/publish_service.sh
 
 
 api_docs-build: .docker/_build_deps
 	docker run -v /var/run/docker.sock:/var/run/docker.sock -v $$(pwd):/repo image_builder --project=update_api_docs
 
-api_docs-deploy: api_docs-build
-	./scripts/deploy_docker_to_aws.py --project=update_api_docs --infra-bucket=$(INFRA_BUCKET)
+api_docs-deploy: api_docs-build .docker/publish_service_to_aws
+	PROJECT=api_docs ./builds/publish_service.sh
 
 
 nginx-build-api: .docker/image_builder
@@ -125,17 +124,17 @@ nginx-build:	\
 
 
 
-nginx-deploy-api: nginx-build-api
-	./scripts/deploy_docker_to_aws.py --project=nginx_api --infra-bucket=$(INFRA_BUCKET)
+nginx-deploy-api: nginx-build-api .docker/publish_service_to_aws
+	PROJECT=nginx_api ./builds/publish_service.sh
 
-nginx-deploy-loris: nginx-build-loris
-	./scripts/deploy_docker_to_aws.py --project=nginx_loris --infra-bucket=$(INFRA_BUCKET)
+nginx-deploy-loris: nginx-build-loris .docker/publish_service_to_aws
+	PROJECT=nginx_loris ./builds/publish_service.sh
 
-nginx-deploy-services: nginx-build-services
-	./scripts/deploy_docker_to_aws.py --project=nginx_services --infra-bucket=$(INFRA_BUCKET)
+nginx-deploy-services: nginx-build-services .docker/publish_service_to_aws
+	PROJECT=nginx_services ./builds/publish_service.sh
 
-nginx-deploy-grafana: nginx-build-grafana
-	./scripts/deploy_docker_to_aws.py --project=nginx_grafana --infra-bucket=$(INFRA_BUCKET)
+nginx-deploy-grafana: nginx-build-grafana .docker/publish_service_to_aws
+	PROJECT=nginx_grafana ./builds/publish_service.sh
 
 ## Push images for all of our nginx proxies
 nginx-deploy:	\
@@ -205,29 +204,25 @@ sbt-build: \
 
 
 
-sbt-deploy-api: sbt-build-api
-	./scripts/deploy_docker_to_aws.py --project=api --infra-bucket=$(INFRA_BUCKET)
+sbt-deploy-api: sbt-build-api .docker/publish_service_to_aws
+	PROJECT=api ./builds/publish_service.sh
 
-sbt-deploy-id_minter: sbt-build-id_minter
-	./scripts/deploy_docker_to_aws.py --project=id_minter --infra-bucket=$(INFRA_BUCKET)
+sbt-deploy-id_minter: sbt-build-id_minter .docker/publish_service_to_aws
+	PROJECT=id_minter ./builds/publish_service.sh
 
-sbt-deploy-ingestor: sbt-build-ingestor
-	./scripts/deploy_docker_to_aws.py --project=ingestor --infra-bucket=$(INFRA_BUCKET)
+sbt-deploy-ingestor: sbt-build-ingestor .docker/publish_service_to_aws
+	PROJECT=ingestor ./builds/publish_service.sh
 
-sbt-deploy-miro_adapter: sbt-build-miro_adapter
-	./scripts/deploy_docker_to_aws.py --project=miro_adapter --infra-bucket=$(INFRA_BUCKET)
+sbt-deploy-reindexer: sbt-build-reindexer .docker/publish_service_to_aws
+	PROJECT=reindexer ./builds/publish_service.sh
 
-sbt-deploy-reindexer: sbt-build-reindexer
-	./scripts/deploy_docker_to_aws.py --project=reindexer --infra-bucket=$(INFRA_BUCKET)
-
-sbt-deploy-transformer: sbt-build-transformer
-	./scripts/deploy_docker_to_aws.py --project=transformer --infra-bucket=$(INFRA_BUCKET)
+sbt-deploy-transformer: sbt-build-transformer .docker/publish_service_to_aws
+	PROJECT=transformer ./builds/publish_service.sh
 
 sbt-deploy: \
 	sbt-deploy-api	\
 	sbt-deploy-id_minter \
 	sbt-deploy-ingestor   \
-	sbt-deploy-miro_adapter \
 	sbt-deploy-reindexer	\
 	sbt-deploy-transformer
 

--- a/Makefile
+++ b/Makefile
@@ -44,7 +44,7 @@ clean:
 
 ## Build the image for gatling
 gatling-build: .docker/image_builder
-	docker run -v /var/run/docker.sock:/var/run/docker.sock -v $$(pwd):/repo image_builder --project=gatling
+	PROJECT=gatling ./builds/build_image.sh
 
 ## Deploy the image for gatling
 gatling-deploy: gatling-build .docker/publish_service_to_aws
@@ -52,7 +52,7 @@ gatling-deploy: gatling-build .docker/publish_service_to_aws
 
 ## Build the image for the cache cleaner
 cache_cleaner-build: .docker/image_builder
-	docker run -v /var/run/docker.sock:/var/run/docker.sock -v $$(pwd):/repo image_builder --project=cache_cleaner
+	PROJECT=cache_cleaner ./builds/build_image.sh
 
 ## Deploy the image for the cache cleaner
 cache_cleaner-deploy: cache_cleaner-build .docker/publish_service_to_aws
@@ -61,7 +61,7 @@ cache_cleaner-deploy: cache_cleaner-build .docker/publish_service_to_aws
 
 ## Build the image for tif-metadata
 tif-metadata-build: .docker/image_builder
-	docker run -v /var/run/docker.sock:/var/run/docker.sock -v $$(pwd):/repo image_builder --project=tif-metadata
+	PROJECT=tif-metadata ./builds/build_image.sh
 
 ## Deploy the image for tif-metadata
 tif-metadata-deploy: tif-metadata-build .docker/publish_service_to_aws
@@ -70,7 +70,7 @@ tif-metadata-deploy: tif-metadata-build .docker/publish_service_to_aws
 
 ## Build the image for Loris
 loris-build: .docker/image_builder
-	docker run -v /var/run/docker.sock:/var/run/docker.sock -v $$(pwd):/repo image_builder --project=loris
+	PROJECT=loris ./builds/build_image.sh
 
 ## Deploy the image for Loris
 loris-deploy: loris-build .docker/publish_service_to_aws
@@ -78,7 +78,7 @@ loris-deploy: loris-build .docker/publish_service_to_aws
 
 
 miro_adapter-build: .docker/image_builder
-	docker run -v /var/run/docker.sock:/var/run/docker.sock -v $$(pwd):/repo image_builder --project=miro_adapter --file=miro_adapter/Dockerfile
+	PROJECT=miro_adapter FILE=miro_adapter/Dockerfile ./builds/build_image.sh
 
 miro_adapter-test: miro_adapter-build .docker/miro_adapter_tests
 	rm -rf $$(pwd)/miro_adapter/__pycache__
@@ -90,30 +90,30 @@ miro_adapter-deploy: miro_adapter-build .docker/publish_service_to_aws
 
 
 elasticdump-build: .docker/image_builder
-	docker run -v /var/run/docker.sock:/var/run/docker.sock -v $$(pwd):/repo image_builder --project=elasticdump
+	PROJECT=elasticdump ./builds/build_image.sh
 
 elasticdump-deploy: elasticdump-build .docker/publish_service_to_aws
 	PROJECT=elasticdump ./builds/publish_service.sh
 
 
 api_docs-build: .docker/_build_deps
-	docker run -v /var/run/docker.sock:/var/run/docker.sock -v $$(pwd):/repo image_builder --project=update_api_docs
+	PROJECT=update_api_docs ./builds/build_image.sh
 
 api_docs-deploy: api_docs-build .docker/publish_service_to_aws
-	PROJECT=api_docs ./builds/publish_service.sh
+	PROJECT=update_api_docs ./builds/publish_service.sh
 
 
 nginx-build-api: .docker/image_builder
-	docker run -v /var/run/docker.sock:/var/run/docker.sock -v $$(pwd):/repo image_builder --project=nginx --variant=api
+	PROJECT=nginx VARIANT=api ./builds/build_image.sh
 
 nginx-build-loris: .docker/image_builder
-	docker run -v /var/run/docker.sock:/var/run/docker.sock -v $$(pwd):/repo image_builder --project=nginx --variant=loris
+	PROJECT=nginx VARIANT=loris ./builds/build_image.sh
 
 nginx-build-services: .docker/image_builder
-	docker run -v /var/run/docker.sock:/var/run/docker.sock -v $$(pwd):/repo image_builder --project=nginx --variant=services
+	PROJECT=nginx VARIANT=services ./builds/build_image.sh
 
 nginx-build-grafana: .docker/image_builder
-	docker run -v /var/run/docker.sock:/var/run/docker.sock -v $$(pwd):/repo image_builder --project=nginx --variant=grafana
+	PROJECT=nginx VARIANT=grafana ./builds/build_image.sh
 
 ## Build images for all of our nginx proxies
 nginx-build:	\

--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,10 @@ clean:
 	mkdir -p .docker && touch .docker/_build_deps
 
 .docker/image_builder:
-	./scripts/build_ci_docker_image.py --project=image_builder --dir=builds --file=builds/image_builder.Dockerfile
+	./scripts/build_ci_docker_image.py \
+		--project=image_builder \
+		--dir=builds \
+		--file=builds/image_builder.Dockerfile
 
 .docker/publish_service_to_aws:
 	./scripts/build_ci_docker_image.py \
@@ -33,7 +36,10 @@ clean:
 		--file=builds/publish_service_to_aws.Dockerfile
 
 .docker/miro_adapter_tests:
-	./scripts/build_ci_docker_image.py --project=miro_adapter_tests --dir=miro_adapter --file=miro_adapter/miro_adapter_tests.Dockerfile
+	./scripts/build_ci_docker_image.py \
+		--project=miro_adapter_tests \
+		--dir=miro_adapter \
+		--file=miro_adapter/miro_adapter_tests.Dockerfile
 
 
 ## Build the image for gatling

--- a/builds/build_image.sh
+++ b/builds/build_image.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+
+set -o errexit
+set -o nounset
+
+FILE="${FILE-}"
+VARIANT="${VARIANT-}"
+
+if [[ ! -z "$FILE" ]]
+then
+  docker run --tty \
+    --volume /var/run/docker.sock:/var/run/docker.sock \
+    --volume $(pwd):/repo \
+    image_builder --project="$PROJECT" --file="$FILE"
+elif [[ ! -z "$VARIANT" ]]
+then
+  docker run --tty \
+    --volume /var/run/docker.sock:/var/run/docker.sock \
+    --volume $(pwd):/repo \
+    image_builder --project="$PROJECT" --variant="$VARIANT"
+else
+  docker run --tty \
+    --volume /var/run/docker.sock:/var/run/docker.sock \
+    --volume $(pwd):/repo \
+    image_builder --project="$PROJECT"
+fi

--- a/builds/publish_service.sh
+++ b/builds/publish_service.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+
+set -o errexit
+set -o nounset
+
+docker run --tty \
+	--volume /var/run/docker.sock:/var/run/docker.sock \
+	--volume $(pwd):/repo \
+	--volume ~/.aws:/root/.aws \
+	publish_service_to_aws --project="$PROJECT" --infra-bucket="$INFRA_BUCKET"

--- a/builds/publish_service_to_aws.Dockerfile
+++ b/builds/publish_service_to_aws.Dockerfile
@@ -1,0 +1,16 @@
+FROM alpine
+
+LABEL maintainer "Alex Chan <a.chan@wellcome.ac.uk>"
+LABEL description "A Docker image for deploying our Docker images to AWS"
+
+RUN apk update
+RUN apk add docker git python3
+
+RUN pip3 install docopt boto3
+
+COPY . /builds
+
+VOLUME /repo
+WORKDIR /repo
+
+ENTRYPOINT ["python3", "/builds/deploy_docker_image_to_aws.py"]

--- a/builds/publish_service_to_aws.Dockerfile
+++ b/builds/publish_service_to_aws.Dockerfile
@@ -6,11 +6,11 @@ LABEL description "A Docker image for deploying our Docker images to AWS"
 RUN apk update
 RUN apk add docker git python3
 
-RUN pip3 install docopt boto3
+RUN pip3 install awscli docopt boto3
 
 COPY . /builds
 
 VOLUME /repo
 WORKDIR /repo
 
-ENTRYPOINT ["python3", "/builds/deploy_docker_image_to_aws.py"]
+ENTRYPOINT ["python3", "/builds/publish_service_to_aws.py"]

--- a/builds/publish_service_to_aws.py
+++ b/builds/publish_service_to_aws.py
@@ -4,8 +4,8 @@
 Push a Docker image to ECR and upload a release ID to S3.
 
 Usage:
-  deploy_docker_to_aws.py --project=<name> --infra-bucket=<bucket>
-  deploy_docker_to_aws.py -h | --help
+  publish_service_to_aws.py --project=<name> --infra-bucket=<bucket>
+  publish_service_to_aws.py -h | --help
 
 Options:
   -h --help                Show this screen.

--- a/builds/tooling.py
+++ b/builds/tooling.py
@@ -23,3 +23,25 @@ def write_release_id(project, release_id):
     release_file = os.path.join(releases_dir, project)
     with open(release_file, 'w') as f:
         f.write(release_id)
+
+
+def ecr_repo_uri_from_name(ecr_client, name):
+    """
+    Given the name of an ECR repo (e.g. uk.ac.wellcome/api), return the URI
+    for the repo.
+    """
+    resp = ecr_client.describe_repositories(repositoryNames=[name])
+    try:
+        return resp['repositories'][0]['repositoryUri']
+    except (KeyError, IndexError) as e:
+        raise RuntimeError('Unable to look up repo URI for %r: %s' % (name, e))
+
+
+def ecr_login():
+    """
+    Authenticates for pushing to ECR.
+    """
+    command = subprocess.check_output([
+        'aws', 'ecr', 'get-login', '--no-include-email'
+    ]).decode('ascii')
+    subprocess.check_call(shlex.split(command))

--- a/builds/tooling.py
+++ b/builds/tooling.py
@@ -1,6 +1,7 @@
 # -*- encoding: utf-8 -*-
 
 import os
+import shlex
 import subprocess
 
 

--- a/scripts/build_ci_docker_image.py
+++ b/scripts/build_ci_docker_image.py
@@ -6,6 +6,7 @@ Builds a Docker image for use in CI or a local Make task.
 This script has to work with as few deps installed as possible, so:
  1. No third-party Python libraries!
  2. Python 2 and Python 3 compatible.
+
 """
 
 import argparse
@@ -23,16 +24,26 @@ def parse_args():
         '--project', required=True,
         help='Name of the Docker project to build'
     )
+    parser.add_argument(
+        '--dir', required=True,
+        help='Directory containing the Dockerfile'
+    )
+    parser.add_argument(
+        '--file', required=False,
+        help='Path to the Dockerfile'
+    )
     return parser.parse_args()
 
 
 if __name__ == '__main__':
     args = parse_args()
     project = args.project
+    directory = args.dir
 
-    subprocess.check_call(
-        ['docker', 'build', './docker/%s' % project, '--tag', project],
-        cwd=ROOT
-    )
+    command = ['docker', 'build', '--tag', project, directory]
+    if args.file:
+        command.extend(['--file', args.file])
+
+    subprocess.check_call(command, cwd=ROOT)
     mkdir_p(os.path.join(ROOT, '.docker'))
     open(os.path.join(ROOT, '.docker', project), 'w')

--- a/scripts/tooling.py
+++ b/scripts/tooling.py
@@ -2,7 +2,6 @@
 
 import errno
 import os
-import shlex
 import subprocess
 
 

--- a/scripts/tooling.py
+++ b/scripts/tooling.py
@@ -36,28 +36,6 @@ def changed_files(commit_range):
     return files
 
 
-def ecr_repo_uri_from_name(ecr_client, name):
-    """
-    Given the name of an ECR repo (e.g. uk.ac.wellcome/api), return the URI
-    for the repo.
-    """
-    resp = ecr_client.describe_repositories(repositoryNames=[name])
-    try:
-        return resp['repositories'][0]['repositoryUri']
-    except (KeyError, IndexError) as e:
-        raise RuntimeError('Unable to look up repo URI for %r: %s' % (name, e))
-
-
-def ecr_login():
-    """
-    Authenticates for pushing to ECR.
-    """
-    command = subprocess.check_output([
-        'aws', 'ecr', 'get-login', '--no-include-email'
-    ]).decode('ascii')
-    subprocess.check_call(shlex.split(command))
-
-
 def write_release_id(project, release_id):
     """
     Write a release ID to the .releases directory in the root of the repo.


### PR DESCRIPTION
### What is this PR trying to achieve?

Pushing an image to ECR and a release ID to S3 (“publishing a service”) now takes place entirely inside Docker.

### Who is this change for?

Who *isn’t* this for?