### PR TITLE
Fix paths returned by Loris to account for the proxy

### DIFF
--- a/terraform/services/config/templates/loris.ini.template
+++ b/terraform/services/config/templates/loris.ini.template
@@ -28,6 +28,10 @@ enable_caching = False
 redirect_canonical_image_request = False
 redirect_id_slash_to_info = True
 
+# Because we run Loris behind a proxy, change the paths that appear in the
+# info.json so they reflect the URL of our proxy, not the origin.
+proxy_path = 'https://iiif.wellcomecollection.org/image/'
+
 # Allow arbitrary resizing of images.  This means that when next.wc.org request
 # different sizes of image, if they inadvertently request an image that's too
 # large, Loris doesn't 404.


### PR DESCRIPTION
### What is this PR trying to achieve?

This is really quite undramatic. I thought we’d need a Loris patch, turns out we just need a config option (albeit one that was obscurely documented!). Fixes the paths returned by Loris to reflect our proxy.

Before:

```console
$ curl 'https://iiif-origin.wellcomecollection.org/image/V0000002.jpg/info.json' 2>/dev/null | jq -r '.["@id"]'
http://iiif-origin.wellcomecollection.org/s3%3AV0000000%2FV0000002.jpg
```

After:

```console
$ curl 'https://iiif-origin.wellcomecollection.org/image/V0000002.jpg/info.json' 2>/dev/null | jq -r '.["@id"]'
https://iiif.wellcomecollection.org/image/s3%3AV0000000%2FV0000002.jpg
```

Anything requested from `iiif.wc.org` isn't budging; I suspect the CloudFront cache has got a bit stuck.

Related: #467.

### Who is this change for?

Users of Loris.

### Have the following been considered/are they needed?

- [x] Deployed new versions
- [x] Run `terraform apply`.

I haven’t run `terraform apply` while @kenoir is futzing with the Terraform stacks; I just pushed straight to S3 and watched the config autoloader kick in.