### PR TITLE
ID is now a mandatory field on DisplayItems in the API

### DIFF
--- a/api/src/main/scala/uk/ac/wellcome/platform/api/models/DisplayItem.scala
+++ b/api/src/main/scala/uk/ac/wellcome/platform/api/models/DisplayItem.scala
@@ -12,7 +12,7 @@ case class DisplayItem(
   @ApiModelProperty(
     dataType = "String",
     readOnly = true,
-    value = "The canonical identifier given to a thing.") id: Option[String],
+    value = "The canonical identifier given to a thing.") id: String,
   @ApiModelProperty(
     dataType = "List[uk.ac.wellcome.platform.api.models.DisplayIdentifier]",
     value =
@@ -30,7 +30,7 @@ case class DisplayItem(
 object DisplayItem {
   def apply(item: Item, includesIdentifiers: Boolean): DisplayItem =
     DisplayItem(
-      id = item.canonicalId,
+      id = item.id,
       identifiers =
         if (includesIdentifiers)
           Some(item.identifiers.map(DisplayIdentifier(_)))

--- a/api/src/test/scala/uk/ac/wellcome/platform/api/ApiWorksTest.scala
+++ b/api/src/test/scala/uk/ac/wellcome/platform/api/ApiWorksTest.scala
@@ -183,55 +183,13 @@ class ApiWorksTest
     }
   }
 
-  it("should be able to render an item with no canonicalId") {
-    val work = workWith(
-      canonicalId = canonicalId,
-      title = title,
-      items = List(
-        itemWith(
-          canonicalId = None,
-          identifier = defaultSourceIdentifier,
-          location = defaultLocation
-        )
-      )
-    )
-
-    insertIntoElasticSearch(work)
-
-    eventually {
-      server.httpGet(
-        path = s"/$apiPrefix/works/${work.canonicalId.get}?includes=items",
-        andExpect = Status.Ok,
-        withJsonBody = s"""
-                          |{
-                          | "@context": "https://localhost:8888/$apiPrefix/context.json",
-                          | "type": "Work",
-                          | "id": "${work.canonicalId.get}",
-                          | "title": "$title",
-                          | "creators": [ ],
-                          | "items": [
-                          |   {
-                          |    "type": "${work.items.head.ontologyType}",
-                          |    "locations": [
-                          |      ${locations(work.items.head.locations)}
-                          |    ]
-                          |   }
-                          | ],
-                          | "subjects": [ ],
-                          | "genres": [ ]
-                          |}
-          """.stripMargin
-      )
-    }
-  }
-
   it("should be able to render an item if the items include is present") {
     val work = workWith(
       canonicalId = "b4heraz7",
       title = "Inside an irate igloo",
       items = List(
         itemWith(
-          canonicalId = Some("c3a599u5"),
+          canonicalId = "c3a599u5",
           identifier = defaultSourceIdentifier,
           location = defaultLocation
         )

--- a/api/src/test/scala/uk/ac/wellcome/platform/api/WorksUtil.scala
+++ b/api/src/test/scala/uk/ac/wellcome/platform/api/WorksUtil.scala
@@ -82,7 +82,7 @@ trait WorksUtil {
 
   def defaultItem: Item = {
     itemWith(
-      Some("item-canonical-id"),
+      "item-canonical-id",
       defaultSourceIdentifier,
       defaultLocation
     )
@@ -98,11 +98,11 @@ trait WorksUtil {
       License_CCBY)
   }
 
-  def itemWith(canonicalId: Option[String],
+  def itemWith(canonicalId: String,
                identifier: SourceIdentifier,
                location: Location): Item = {
     Item(
-      canonicalId = canonicalId,
+      canonicalId = Some(canonicalId),
       List(
         identifier
       ),

--- a/api/src/test/scala/uk/ac/wellcome/platform/api/models/DisplayItemTest.scala
+++ b/api/src/test/scala/uk/ac/wellcome/platform/api/models/DisplayItemTest.scala
@@ -44,7 +44,6 @@ class DisplayItemTest extends FunSpec with Matchers {
   }
 
   it("should read an Item as a DisplayItem correctly") {
-
     val item = Item(
         canonicalId = Some("foo"),
         identifiers = List(identifier),
@@ -56,22 +55,7 @@ class DisplayItemTest extends FunSpec with Matchers {
       includesIdentifiers = true
     )
 
-    displayItem.id shouldBe item.canonicalId
-    displayItem.locations shouldBe List(DisplayLocation(location))
-    displayItem.identifiers shouldBe Some(List(DisplayIdentifier(identifier)))
-    displayItem.ontologyType shouldBe "Item"
-
-  }
-
-  it("should be able to render items with no canonicalId") {
-    val item = Item(canonicalId = None, identifiers = List(identifier),
-      locations = List(location))
-
-    val displayItem = DisplayItem(
-      item = item,
-      includesIdentifiers = true
-    )
-    displayItem.id shouldBe None
+    displayItem.id shouldBe item.id
     displayItem.locations shouldBe List(DisplayLocation(location))
     displayItem.identifiers shouldBe Some(List(DisplayIdentifier(identifier)))
     displayItem.ontologyType shouldBe "Item"


### PR DESCRIPTION
### What is this PR trying to achieve?

Now we've merged the ID minter changes to support putting IDs on items, we can remove this temporary code.  If an unidentified item appears in our Elasticsearch index, it becomes an error.

### Who is this change for?

Platform devs who want a nice clean codebase.

### Have the following been considered/are they needed?

- [ ] Deployed new versions