### PR TITLE
Don't put the Lambda zip bundles in the target directory

### DIFF
--- a/docker/terraform_ci/run.sh
+++ b/docker/terraform_ci/run.sh
@@ -22,9 +22,9 @@ then
 
     set +o errexit
 
-    echo "Extracting ouput to $OUTPUT_LOCATION"
+    echo "Extracting output to $OUTPUT_LOCATION"
     terraform output --json > "$OUTPUT_LOCATION"
-    
+
     echo "Sending succesful apply notification."
     /app/notify.sh $TOPIC_ARN "$OUTPUT_LOCATION"
 

--- a/terraform/lambda/lambda_function.tf
+++ b/terraform/lambda/lambda_function.tf
@@ -1,7 +1,7 @@
 data "archive_file" "lambda_zip_file" {
   type        = "zip"
   source_dir  = "${var.source_dir}"
-  output_path = "${var.source_dir}/${var.name}.zip"
+  output_path = "${var.source_dir}/../${var.name}.zip"
 }
 
 resource "aws_lambda_function" "lambda_function" {


### PR DESCRIPTION
We had a chain of nested target directories -- each ZIP bundle was getting mixed into the next invocation of `terraform plan`, thus the Lambdas never stabilised.

The target directories are definitely cleared between runs, but if the ZIP is written _as the directory is being read_, you’d get a snake eating its own tail – as the ZIP is written, so it’s read back into itself.

### What is this PR trying to achieve?

Make our Lambda deploys deterministic.

### Who is this change for?

Devs who want predictable deployments.